### PR TITLE
Feature/164 aggregate solution

### DIFF
--- a/graphql_api/data/file_data.py
+++ b/graphql_api/data/file_data.py
@@ -137,6 +137,11 @@ class FileData(BaseDynamoDBData):
             logger.info("from_json migration to InversionSolution of: %s" % str(jsondata))
             clazz = getattr(import_module('graphql_api.schema'), 'InversionSolution')
 
+        ## produced_by_id -> produced_by schema migration
+        produced_by_id = jsondata.pop('produced_by_id', None)
+        if produced_by_id and not jsondata.get('produced_by'):
+            jsondata['produced_by'] = produced_by_id
+
         #table datetime conversions
         if jsondata.get('tables'):
             for tbl in jsondata.get('tables'):

--- a/graphql_api/schema/__init__.py
+++ b/graphql_api/schema/__init__.py
@@ -17,6 +17,7 @@ from graphql_api.schema.table import Table
 from graphql_api.schema.custom.inversion_solution import CreateInversionSolution, InversionSolution
 from graphql_api.schema.custom.automation_task import AutomationTask, CreateAutomationTask, UpdateAutomationTask
 from graphql_api.schema.search_manager import SearchManager
+from graphql_api.schema.custom.aggregate_inversion_solution import CreateAggregateInversionSolution, AggregateInversionSolution
 from graphql_api.schema.custom.scaled_inversion_solution import CreateScaledInversionSolution, ScaledInversionSolution
 from graphql_api.schema.custom.inversion_solution_nrml import CreateInversionSolutionNrml, InversionSolutionNrml
 from graphql_api.schema.custom.openquake_hazard_solution import CreateOpenquakeHazardSolution, OpenquakeHazardSolution

--- a/graphql_api/schema/custom/aggregate_inversion_solution.py
+++ b/graphql_api/schema/custom/aggregate_inversion_solution.py
@@ -17,15 +17,11 @@ from .common import PredecessorsInterface, AggregationFn
 from .helpers import resolve_node
 from .automation_task import AutomationTask
 from .inversion_solution import InversionSolutionInterface
-# , InversionSolution
-# from .scaled_inversion_solution import ScaledInversionSolution
+
 
 db_metrics = ServerlessMetricWriter(lambda_name=STACK_NAME, metric_name="MethodDuration",
     resolution=CW_METRICS_RESOLUTION)
 
-# class SourceSolutionUnion(graphene.Union):
-#     class Meta:
-#         types = (InversionSolution, ScaledInversionSolution)
 
 class AggregateInversionSolution(graphene.ObjectType):
     """
@@ -55,9 +51,6 @@ class AggregateInversionSolution(graphene.ObjectType):
     def resolve_common_rupture_set(root, info, **args):
         return resolve_node(root, info, 'common_rupture_set', 'file')
 
-    # def resolve_produced_by(root, info, **args):
-    #     return resolve_node(root, info, 'produced_by', 'thing')
-
 
 class CreateAggregateInversionSolution(relay.ClientIDMutation):
     """
@@ -75,7 +68,8 @@ class CreateAggregateInversionSolution(relay.ClientIDMutation):
         
         produced_by = graphene.ID()
         created = graphene.DateTime(description="When the solution was created")
-        predecessors = graphene.List('graphql_api.schema.custom.predecessor.PredecessorInput', required=False, description="list of predecessors")
+        predecessors = graphene.List('graphql_api.schema.custom.predecessor.PredecessorInput',
+            required=False, description="list of predecessors")
 
     solution = graphene.Field(AggregateInversionSolution)
     ok = graphene.Boolean()

--- a/graphql_api/schema/custom/aggregate_inversion_solution.py
+++ b/graphql_api/schema/custom/aggregate_inversion_solution.py
@@ -1,0 +1,88 @@
+#!python3
+"""
+This module contains the schema definition for a AggregateInversionSolution.
+
+"""
+import graphene
+from graphene import relay
+from datetime import datetime as dt
+
+from graphql_relay import from_global_id
+from graphql_api.data import get_data_manager
+from graphql_api.schema.file import FileInterface, CreateFile
+from graphql_api.config import STACK_NAME, CW_METRICS_RESOLUTION
+from graphql_api.cloudwatch import ServerlessMetricWriter
+
+from .common import PredecessorsInterface, AggregationFn
+from .helpers import resolve_node
+from .automation_task import AutomationTask
+from .inversion_solution import InversionSolutionInterface
+# , InversionSolution
+# from .scaled_inversion_solution import ScaledInversionSolution
+
+db_metrics = ServerlessMetricWriter(lambda_name=STACK_NAME, metric_name="MethodDuration",
+    resolution=CW_METRICS_RESOLUTION)
+
+# class SourceSolutionUnion(graphene.Union):
+#     class Meta:
+#         types = (InversionSolution, ScaledInversionSolution)
+
+class AggregateInversionSolution(graphene.ObjectType):
+    """
+    Represents a Aggregate Inversion Solution file produced fby applying the 
+    aggregate_fn to the rates of each source solution. 
+    """
+    class Meta:
+        interfaces = (relay.Node, FileInterface, PredecessorsInterface, InversionSolutionInterface)
+
+    common_rupture_set = graphene.ID(
+        description='aggregations must use solutions based on the saem rupture set.')
+    source_solutions = graphene.List('graphql_api.schema.custom.inversion_solution_nrml.SourceSolutionUnion',
+        description="The solutions used to build the aggregate")
+    aggregation_fn = graphene.Field(AggregationFn, 
+        description="aggregation function on rupture rates.")
+
+    @classmethod
+    def get_node(cls, info, _id):
+        node = get_data_manager().file.get_one(_id, "AggregateInversionSolution")
+        return node
+
+    def resolve_source_solutions(root, info, **args):
+        for ssid in root.source_solutions:
+            _type, nid = from_global_id(ssid)  
+            yield get_data_manager().file.get_one(nid)
+
+    def resolve_common_rupture_set(root, info, **args):
+        return resolve_node(root, info, 'common_rupture_set', 'file')
+
+    # def resolve_produced_by(root, info, **args):
+    #     return resolve_node(root, info, 'produced_by', 'thing')
+
+
+class CreateAggregateInversionSolution(relay.ClientIDMutation):
+    """
+    Create a AggregateInversionSolution file
+    """
+    class Input:
+        common_rupture_set = AggregateInversionSolution.common_rupture_set
+        source_solutions = graphene.List(graphene.ID)
+        aggregation_fn = AggregateInversionSolution.aggregation_fn
+        
+        file_name = FileInterface.file_name
+        md5_digest = FileInterface.md5_digest
+        file_size = FileInterface.file_size
+        meta = CreateFile.Arguments.meta
+        
+        produced_by = graphene.ID()
+        created = graphene.DateTime(description="When the solution was created")
+        predecessors = graphene.List('graphql_api.schema.custom.predecessor.PredecessorInput', required=False, description="list of predecessors")
+
+    solution = graphene.Field(AggregateInversionSolution)
+    ok = graphene.Boolean()
+
+    @classmethod
+    def mutate_and_get_payload(cls, root, info, **kwargs):
+        t0 = dt.utcnow()
+        solution = get_data_manager().file.create('AggregateInversionSolution', **kwargs)
+        db_metrics.put_duration(__name__, 'CreateAggregateInversionSolution.mutate_and_get_payload' , dt.utcnow()-t0)
+        return CreateAggregateInversionSolution(solution=solution, ok=True)

--- a/graphql_api/schema/custom/automation_task.py
+++ b/graphql_api/schema/custom/automation_task.py
@@ -20,7 +20,7 @@ from graphql_api.data import get_data_manager
 
 from .common import KeyValuePair, KeyValuePairInput, TaskSubType, ModelType
 from .automation_task_base import AutomationTaskInterface, AutomationTaskBase, AutomationTaskInput, AutomationTaskUpdateInput
-from .inversion_solution import InversionSolution
+#from .inversion_solution import InversionSolution
 from graphql_api.schema.file_relation import FileRole
 
 from datetime import datetime as dt
@@ -38,7 +38,8 @@ class AutomationTask(graphene.ObjectType, AutomationTaskBase):
 
     model_type = ModelType()
     task_type = TaskSubType()
-    inversion_solution = graphene.Field(InversionSolution, description="the primary result of this task (only for task_type == INVERSION.")
+    inversion_solution = graphene.Field('graphql_api.schema.custom.inversion_solution.InversionSolution', 
+        description="the primary result of this task (only for task_type == INVERSION.")
 
     @staticmethod
     def from_json(jsondata):
@@ -68,7 +69,7 @@ class AutomationTask(graphene.ObjectType, AutomationTaskBase):
                 if not file_relation.role == FileRole.WRITE.value:
                     continue
             file = get_data_manager().file.get_one(file_relation.file_id)
-            if file.__class__ == InversionSolution:
+            if file.__class__.__name__ == 'InversionSolution':
                 res = file
                 break
         db_metrics.put_duration(__name__, 'AutomationTask.resolve_inversion_solution' , dt.utcnow()-t0)

--- a/graphql_api/schema/custom/automation_task_base.py
+++ b/graphql_api/schema/custom/automation_task_base.py
@@ -25,7 +25,6 @@ logger = logging.getLogger(__name__)
 
 class AutomationTaskBase():
 
-
     @classmethod
     def get_node(cls, info, _id):
         return  get_data_manager().thing.get_one(_id)

--- a/graphql_api/schema/custom/common.py
+++ b/graphql_api/schema/custom/common.py
@@ -46,6 +46,7 @@ class TaskSubType(graphene.Enum):
     HAZARD = "hazard"
     REPORT = "report"
     SCALE_SOLUTION = "scale_solution"
+    AGGREGATE_SOLUTION = "aggregate_solution"
     SOLUTION_TO_NRML = "solution_to_nrml"
     OPENQUAKE_HAZARD = "openquake_hazard"
 
@@ -53,6 +54,9 @@ class ModelType(graphene.Enum):
     CRUSTAL = "crustal"
     SUBDUCTION = "subduction"
     COMPOSITE = "composite"
+
+class AggregationFn(graphene.Enum):
+    MEAN = "mean"
 
 class PredecessorsInterface(graphene.Interface):
     """A interface for things having predecessors"""

--- a/graphql_api/schema/custom/common.py
+++ b/graphql_api/schema/custom/common.py
@@ -59,3 +59,4 @@ class PredecessorsInterface(graphene.Interface):
 
     predecessors = graphene.List('graphql_api.schema.custom.predecessor.Predecessor', required=False,
         description="list of predecessor info")
+ 

--- a/graphql_api/schema/custom/helpers.py
+++ b/graphql_api/schema/custom/helpers.py
@@ -26,8 +26,16 @@ def resolve_node(root, info, id_field, dm_type):
 
     logger.debug(f"resolve_node() resolving for type {_type}, id: {nid}, id_field: {id_field}, dm_type: {dm_type}")
 
-    if len(info.field_asts[0].selection_set.selections)==1 and \
-        (info.field_asts[0].selection_set.selections[0].name.value == 'id'):
+    # print(f"DEBUG: {info.field_asts[0].selection_set.selections[0]}")
+    selections = info.field_asts[0].selection_set.selections
+    if len(selections)==1 and getattr(selections[0], "type_condition", None):
+        """We have a sub-selection (e.g `... on Node { ...`, so drill in one more level"""
+        selections = selections[0].selection_set.selections
+
+    # print(f"DEBUG: selections {selections}")
+
+    if len(selections)==1 and \
+        (selections[0].name.value == 'id'):
 
         #create an instance with just the id attribute set
         clazz = getattr(import_module('graphql_api.schema'), _type)

--- a/graphql_api/schema/custom/scaled_inversion_solution.py
+++ b/graphql_api/schema/custom/scaled_inversion_solution.py
@@ -14,7 +14,7 @@ from graphql_api.cloudwatch import ServerlessMetricWriter
 
 from .common import PredecessorsInterface
 from .helpers import resolve_node
-from .automation_task import AutomationTask
+from .inversion_solution import InversionSolutionInterface
 
 db_metrics = ServerlessMetricWriter(lambda_name=STACK_NAME, metric_name="MethodDuration",
     resolution=CW_METRICS_RESOLUTION)
@@ -27,12 +27,10 @@ class ScaledInversionSolution(graphene.ObjectType):
     should be captured as in meta field.
     """
     class Meta:
-        interfaces = (relay.Node, FileInterface, PredecessorsInterface)
+        interfaces = (relay.Node, FileInterface, PredecessorsInterface, InversionSolutionInterface)
 
-    created = graphene.DateTime(description="When the scaled solution file was created" )
     source_solution = graphene.Field('graphql_api.schema.custom.inversion_solution.InversionSolution',
          description="The original soloution as produced by opensha")
-    produced_by = graphene.Field(AutomationTask, description="The task creating this")
 
     @classmethod
     def get_node(cls, info, _id):
@@ -41,9 +39,6 @@ class ScaledInversionSolution(graphene.ObjectType):
 
     def resolve_source_solution(root, info, **args):
         return resolve_node(root, info, 'source_solution', 'file')
-
-    def resolve_produced_by(root, info, **args):
-        return resolve_node(root, info, 'produced_by', 'thing')
 
 
 class CreateScaledInversionSolution(relay.ClientIDMutation):
@@ -57,7 +52,7 @@ class CreateScaledInversionSolution(relay.ClientIDMutation):
         meta = CreateFile.Arguments.meta
         source_solution = graphene.ID()
         produced_by = graphene.ID()
-        created = ScaledInversionSolution.created
+        created =  graphene.DateTime(description="When the solution was created")
         predecessors = graphene.List('graphql_api.schema.custom.predecessor.PredecessorInput', required=False, description="list of predecessors")
 
     solution = graphene.Field(ScaledInversionSolution)

--- a/graphql_api/schema/schema.py
+++ b/graphql_api/schema/schema.py
@@ -32,6 +32,8 @@ from .custom.automation_task import AutomationTask, CreateAutomationTask, Update
 
 from graphql_api.schema.custom.inversion_solution import InversionSolution, CreateInversionSolution, AppendInversionSolutionTables, LabelledTableRelationInput
 from graphql_api.schema.custom.scaled_inversion_solution import ScaledInversionSolution, CreateScaledInversionSolution
+from graphql_api.schema.custom.aggregate_inversion_solution import AggregateInversionSolution, CreateAggregateInversionSolution
+
 from graphql_api.schema.custom.inversion_solution_nrml import CreateInversionSolutionNrml, InversionSolutionNrml
 from graphql_api.schema.custom.openquake_hazard_solution import CreateOpenquakeHazardSolution, OpenquakeHazardSolution
 from graphql_api.schema.custom.openquake_hazard_config import CreateOpenquakeHazardConfig, OpenquakeHazardConfig
@@ -182,6 +184,7 @@ class MutationRoot(graphene.ObjectType):
     update_automation_task = UpdateAutomationTask.Field()
     update_general_task = UpdateGeneralTask.Field()
     update_rupture_generation_task = UpdateRuptureGenerationTask.Field()
+    create_aggregate_inversion_solution = CreateAggregateInversionSolution.Field()
     create_scaled_inversion_solution = CreateScaledInversionSolution.Field()
     create_inversion_solution_nrml = CreateInversionSolutionNrml.Field()
     create_openquake_hazard_solution = CreateOpenquakeHazardSolution.Field()

--- a/graphql_api/tests/hazard/setup_helpers.py
+++ b/graphql_api/tests/hazard/setup_helpers.py
@@ -346,8 +346,9 @@ class SetupHelpersMixin:
               {
                 ok
                 solution { id, file_name, file_size, md5_digest, post_url, 
-                source_solution { id }
-                produced_by { ... on Node{ id } } }
+                    source_solution { ... on Node{id} }
+                    produced_by { ... on Node{ id } }
+                }
               }
             }'''
 

--- a/graphql_api/tests/hazard/setup_helpers.py
+++ b/graphql_api/tests/hazard/setup_helpers.py
@@ -65,6 +65,7 @@ class SetupHelpersMixin:
               }
             }
         '''
+
         result = self.client.execute(CREATE_QRY,
             variable_values=dict(digest="ABC", file_name='MyInversion.zip', file_size=1000, produced_by="PRODUCER_ID"))
 
@@ -326,3 +327,36 @@ class SetupHelpersMixin:
         result = self.client.execute(query, variable_values=variables )
         print(result)
         return result
+
+    def create_scaled_solution(self, upstream_sid, task_id):
+        """test helper"""
+        query = '''
+            mutation ($source_solution: ID!, $produced_by: ID!, $digest: String!, $file_name: String!, $file_size: BigInt!, $created: DateTime!) {
+              create_scaled_inversion_solution(
+                  input: {
+                      source_solution: $source_solution
+                      md5_digest: $digest
+                      file_name: $file_name
+                      file_size: $file_size
+                      created: $created
+                      produced_by: $produced_by
+                  }
+              )
+              {
+                ok
+                solution { id, file_name, file_size, md5_digest, post_url, source_solution { id }, produced_by { id }}
+              }
+            }'''
+
+        # from hashlib import sha256, md5
+        filedata = BytesIO("a line\nor two".encode())
+        digest = "sha256(filedata.read()).hexdigest()"
+        filedata.seek(0) #important!
+        size = len(filedata.read())
+        filedata.seek(0) #important!
+        variables = dict(source_solution=upstream_sid, produced_by=task_id,
+            file=filedata, digest=digest, file_name="alineortwo.txt", file_size=size)
+        variables['created'] = dt.datetime.now(tzutc()).isoformat()
+        result = self.client.execute(query, variable_values=variables )
+        print(result)
+        return result        

--- a/graphql_api/tests/hazard/setup_helpers.py
+++ b/graphql_api/tests/hazard/setup_helpers.py
@@ -142,7 +142,8 @@ class SetupHelpersMixin:
               )
               {
                 ok
-                inversion_solution_nrml { id, file_name, file_size, md5_digest, post_url, source_solution { id }}
+                inversion_solution_nrml { id, file_name, file_size, md5_digest, post_url, 
+                source_solution { ... on Node { id } }}
               }
             }'''
 
@@ -172,7 +173,7 @@ class SetupHelpersMixin:
               {
                 ok
                 inversion_solution_nrml { id, file_name, file_size, md5_digest, post_url,
-                    source_solution { id }
+                    source_solution { ... on Node{ id } }
                     predecessors {
                         id,
                         typename,

--- a/graphql_api/tests/hazard/test_inversion_solution.py
+++ b/graphql_api/tests/hazard/test_inversion_solution.py
@@ -64,7 +64,7 @@ class TestInversionSolution(unittest.TestCase, SetupHelpersMixin):
                   md5_digest: $digest
                   file_name: $file_name
                   file_size: $file_size
-                  produced_by_id: $produced_by
+                  produced_by: $produced_by
                   metrics: [{k: "some_metric", v: "20"}]
                   created: "2021-06-11T02:37:26.009506Z"
                   predecessors: $predecessors

--- a/graphql_api/tests/hazard/test_openquake_hazard_config.py
+++ b/graphql_api/tests/hazard/test_openquake_hazard_config.py
@@ -93,8 +93,10 @@ class TestOpenquakeHazardConfig(unittest.TestCase, SetupHelpersMixin):
               source_models {
                 id
                 source_solution {
-                    id
-                    file_name
+                    ... on Node {id}
+                    ... on FileInterface {
+                        file_name
+                    }
                 }
               }
             }

--- a/graphql_api/tests/hazard/test_openquake_hazard_task.py
+++ b/graphql_api/tests/hazard/test_openquake_hazard_task.py
@@ -91,8 +91,8 @@ class TestOpenquakeHazardTask(unittest.TestCase, SetupHelpersMixin):
                     id
                     file_name
                     source_solution {
-                        id
-                        file_name
+                        ... on Node{ id }
+                        ... on FileInterface { file_name }
                     }
                 }
               }

--- a/graphql_api/tests/hazard/test_openquake_sources_nrml_solution.py
+++ b/graphql_api/tests/hazard/test_openquake_sources_nrml_solution.py
@@ -76,7 +76,22 @@ class TestOpenquakeSourcesNrml(unittest.TestCase, SetupHelpersMixin):
         print(ToshiFileObject.get("100002").object_content)
 
         #object ID is stored internally as an INT
-        self.assertEqual(ToshiFileObject.get("100002").object_content['id'], int(from_global_id(ss['id'])[1]))
+        self.assertEqual(ToshiFileObject.get("100002").object_content['id'], 
+            int(from_global_id(ss['id'])[1]))
+
+
+    def test_create_opensha_nrml_from_scaled_solution(self):
+        at_id = self.create_automation_task("SOLUTION_TO_NRML")
+        st_id = self.create_automation_task("SCALE_SOLUTION")        
+        upstream_sid = self.create_source_solution()
+        scaled_sid = self.create_scaled_solution(upstream_sid, st_id)['data']\
+            ['create_scaled_inversion_solution']['solution']['id']
+
+        result = self.create_inversion_solution_nrml(scaled_sid)
+        ss =  result['data']['create_inversion_solution_nrml']['inversion_solution_nrml']
+        self.assertEqual( from_global_id(scaled_sid)[0], "ScaledInversionSolution")
+        self.assertEqual(ss['source_solution']['id'], scaled_sid)
+
 
     def test_create_opensha_nrml_from_solution_with_predecessors(self):
         at_id = self.create_automation_task("SOLUTION_TO_NRML")

--- a/graphql_api/tests/hazard/test_scaled_inversion_solution.py
+++ b/graphql_api/tests/hazard/test_scaled_inversion_solution.py
@@ -100,7 +100,7 @@ class TestScaling(unittest.TestCase, SetupHelpersMixin):
                 __typename
                 ... on ScaledInversionSolution {
                     created
-                    produced_by { id }
+                    produced_by { ... on Node {id} }
                     source_solution { id }
 
                 }
@@ -132,8 +132,8 @@ class TestScaling(unittest.TestCase, SetupHelpersMixin):
                 __typename
                 ... on ScaledInversionSolution {
                     created
-                    produced_by { id }
-                    source_solution { id }
+                    produced_by { ... on Node {id} }
+                    source_solution { ... on Node {id} }
                 }
                 ... on PredecessorsInterface {
                     predecessors {
@@ -181,8 +181,9 @@ class TestScaling(unittest.TestCase, SetupHelpersMixin):
               )
               {
                 ok
-                solution { id, file_name, file_size, md5_digest, post_url, source_solution { id },
-                produced_by { id }
+                solution {
+                    id, file_name, file_size, md5_digest, post_url, source_solution { id },
+                    produced_by { ... on Node {id} }
                     predecessors {
                         id,
                         typename,

--- a/graphql_api/tests/test_inversion_solution_schema.py
+++ b/graphql_api/tests/test_inversion_solution_schema.py
@@ -34,7 +34,7 @@ READ_MOCK = lambda _self, id: dict(
     md5_digest = "$digest",
     file_name = "$file_name",
     file_size = "$file_size",
-    produced_by_id = "VGFibGU6Tm9uZQ==",
+    produced_by = "VGFibGU6Tm9uZQ==",
     mfd_table_id = "VGFibGU6MA==",
     created = "2021-06-11T02:37:26.009506+00:00",
     meta = [{ "k":"max_jump_distance", "v": "55.5" }],
@@ -69,7 +69,7 @@ class TestBasicInversionSolutionOperations(unittest.TestCase):
                   md5_digest: $digest
                   file_name: $file_name
                   file_size: $file_size
-                  produced_by_id: $produced_by
+                  produced_by: $produced_by
                   mfd_table_id: $mfd_table
                   metrics: [{k: "some_metric", v: "20"}]
                   created: "2021-06-11T02:37:26.009506Z"
@@ -80,7 +80,8 @@ class TestBasicInversionSolutionOperations(unittest.TestCase):
             }
         '''
         result = self.client.execute(CREATE_QRY,
-            variable_values=dict(digest="ABC", file_name='MyInversion.zip', file_size=1000, produced_by="PRODUCER_ID", mfd_table="TABLE_ID"))
+            variable_values=dict(digest="ABC", file_name='MyInversion.zip', file_size=1000, 
+                produced_by="PRODUCER_ID", mfd_table="TABLE_ID"))
         print(result)
         assert result['data']['create_inversion_solution']['inversion_solution']['id'] == 'SW52ZXJzaW9uU29sdXRpb246Tm9uZQ=='
 
@@ -195,9 +196,9 @@ class TestCustomResolvers(unittest.TestCase):
           {
             ... on InversionSolution {
               id
-              produced_by_id
+              #produced_by_id
               produced_by {
-                id
+                ... on Node {id}
               }
               mfd_table_id
               mfd_table {
@@ -219,7 +220,7 @@ class TestCustomResolvers(unittest.TestCase):
         result = self.client.execute(qry, variable_values={})
         print(result)
         assert result['data']['node']['id'] == 'SW52ZXJzaW9uU29sdXRpb246MTU0NC4wdlA4QmQ='
-        assert result['data']['node']['produced_by_id'] == "UnVwdHVyZUdlbmVyYXRpb25UYXNrOjcwOXpnTDg5"
+        # assert result['data']['node']['produced_by_id'] == "UnVwdHVyZUdlbmVyYXRpb25UYXNrOjcwOXpnTDg5"
         assert result['data']['node']['produced_by']['id'] == "UnVwdHVyZUdlbmVyYXRpb25UYXNrOjcwOXpnTDg5"
         assert result['data']['node']['mfd_table_id'] == 'VGFibGU6MG8zZmtm'
         assert result['data']['node']['mfd_table']['id'] == 'VGFibGU6MG8zZmtm'


### PR DESCRIPTION
This PR includes:
 - fix for NRML sourceSolution incorrect ID #162 
 - is adds #164 
 - `produced_by_id` field on solution mutations is now `produced _by`. Typed remains ID!
 - to support **AggregateInversionSolution** + **ScaledInversionSolution** + **InversionSolution** we now have a new **InversionSolutionInterface** class. This makes the API code simpler but it does mean that some client queries will need to use a typed fragment whereas before this was not needed `... on Node { id }`