### PR TITLE
Making local smoke test run again

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@ Where NSHM experiments and outputs are captured (not so old fashioned, tosh).
 
 ## Getting started
 
+Java is required.
+
 ```
 virtualenv nshm-toshi-api
 npm install --save serverless
-npm install --save serverless-dynamodb-local
+npm install --save serverless-dynamodb
 npm install --save serverless-s3-local
 npm install --save serverless-python-requirements
 npm install --save serverless-wsgi
@@ -17,7 +19,7 @@ poetry install
 
 ## running `sls` (alias for `serverless` )
 
-NB to run the following examples, depending on local NPM configuration, it may be necessary to run `npx serverless` instead of `sls`.
+NB to run the following examples, depending on local NPM configuration, it may be necessary to run `serverless`, or `npx serverless` instead of `sls`.
 
 
 ## Smoketest
@@ -27,6 +29,8 @@ sls dynamodb start --stage local &\
 sls s3 start &\
 SLS_OFFLINE=1 TOSHI_FIX_RANDOM_SEED=1 FIRST_DYNAMO_ID=0 sls wsgi serve
 ```
+If `shell` is not available, in `poetry`, it is possible to use `eval $(poetry env activate)`
+
 Then in another shell,
 ```
 docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:6.8.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Where NSHM experiments and outputs are captured (not so old fashioned, tosh).
 
 Java is required.
 
-```
+```bash
 virtualenv nshm-toshi-api
 npm install --save serverless
 npm install --save serverless-dynamodb
@@ -21,9 +21,16 @@ poetry install
 
 NB to run the following examples, depending on local NPM configuration, it may be necessary to run `serverless`, or `npx serverless` instead of `sls`.
 
+You might have to add this block to your AWS credentials file:
+```config
+[default]
+aws_access_key_id=MockAccessKeyId
+aws_secret_access_key=MockAccessKeyId
+```
+
 
 ## Smoketest
-```
+```bash
 poetry shell
 sls dynamodb start --stage local &\
 sls s3 start &\
@@ -32,18 +39,18 @@ SLS_OFFLINE=1 TOSHI_FIX_RANDOM_SEED=1 FIRST_DYNAMO_ID=0 sls wsgi serve
 If `shell` is not available, in `poetry`, it is possible to use `eval $(poetry env activate)`
 
 Then in another shell,
-```
+```bash
 docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:6.8.0
 ```
 (to just run locally stop here)
 
 Then in another shell,
-```
+```bash
 poetry run python3 graphql_api/tests/smoketests.py
 ```
 
 ## Unit test
-```
+```bash
 SLS_OFFLINE=1 TESTING=1 poetry run pytest
 ```
 

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
   },
   "homepage": "https://github.com/GNS-Science/nshm-toshi-api#readme",
   "devDependencies": {
-    "serverless": "^3.30.1",
-    "serverless-dynamodb-local": "^0.2.40",
+    "serverless": "^3.40.0",
+    "serverless-dynamodb": "^0.2.56",
     "serverless-plugin-warmup": "^8.3.0",
-    "serverless-python-requirements": "^6.1.0",
-    "serverless-s3-local": "^0.8.4",
-    "serverless-wsgi": "^3.0.4"
+    "serverless-python-requirements": "^6.1.2",
+    "serverless-s3-local": "^0.8.5",
+    "serverless-wsgi": "^3.0.5"
   }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -43,7 +43,7 @@ custom:
     host: localhost
     directory: /tmp
   #dynamodb-local settings
-  dynamodb:
+  serverless-dynamodb:
   # If you only want to use DynamoDB Local in some stages, declare them here
     stages:
       - local

--- a/serverless.yml
+++ b/serverless.yml
@@ -4,7 +4,7 @@ plugins:
   - serverless-python-requirements
   - serverless-wsgi
   - serverless-s3-local
-  - serverless-dynamodb-local
+  - serverless-dynamodb
   - serverless-plugin-warmup
 package:
   individually: false


### PR DESCRIPTION
- `serverless-dynamodb-local` is broken and no longer supported. Using a fork drop-in replacement
   - old: https://github.com/99x/serverless-dynamodb-local/issues/294#issuecomment-1619297733
   - new: https://www.npmjs.com/package/serverless-dynamodb
- AWS default credentials required
- `shell` is now a poetry plugin rather than command
