### PR TITLE
[206] no config for oq hazard task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+
+
+## [0.2.5] - XXX
+### Changed
+ - Deprecated config and modified_config in OpenquakeHazardSolution and OpenquakeHazardTask
+
+
 ## [0.2.4] - 2024-07-10
 ### Added
  - new e2e_workflow test package to reproduce end-user workflows

--- a/graphql_api/schema/custom/openquake_hazard_solution.py
+++ b/graphql_api/schema/custom/openquake_hazard_solution.py
@@ -28,6 +28,7 @@ class OpenquakeHazardSolution(graphene.ObjectType):
     Represents a OpenquakeHazardSolution
 
     This has :
+     - config an OpenquakeHazardConfig (Deprecated)
      - export_archive File a zip archive containing hazard outputs (`oq engine --export ....)
      - hdf5_archive File a zip archive containing the raw hdf5 compressed
 

--- a/graphql_api/schema/custom/openquake_hazard_solution.py
+++ b/graphql_api/schema/custom/openquake_hazard_solution.py
@@ -102,6 +102,8 @@ class CreateOpenquakeHazardSolution(relay.ClientIDMutation):  # graphene.Mutatio
 
     class Input:
         created = OpenquakeHazardSolution.created
+        # we're keeping this in here so that we can create old-fashioned entries for tests to ensure we can still read them
+        config = graphene.Field(graphene.ID, required=False, deprecation_reason="We no longer store this config")
         produced_by = graphene.ID(required=True)
 
         csv_archive = graphene.ID(required=False)

--- a/graphql_api/schema/custom/openquake_hazard_solution.py
+++ b/graphql_api/schema/custom/openquake_hazard_solution.py
@@ -28,7 +28,6 @@ class OpenquakeHazardSolution(graphene.ObjectType):
     Represents a OpenquakeHazardSolution
 
     This has :
-     - config an OpenquakeHazardConfig
      - export_archive File a zip archive containing hazard outputs (`oq engine --export ....)
      - hdf5_archive File a zip archive containing the raw hdf5 compressed
 
@@ -40,7 +39,10 @@ class OpenquakeHazardSolution(graphene.ObjectType):
 
     created = graphene.DateTime(description="When it was created (UTZ)")
     config = graphene.Field(
-        OpenquakeHazardConfig, description="the template configuration used to produce this solution"
+        OpenquakeHazardConfig,
+        description="the template configuration used to produce this solution",
+        required=False,
+        deprecation_reason="We no longer use this field",
     )
     csv_archive = graphene.Field(
         File, description="a zip archive containing hazard csv outputs (`oq engine --export-outputs ....)"
@@ -100,7 +102,6 @@ class CreateOpenquakeHazardSolution(relay.ClientIDMutation):  # graphene.Mutatio
 
     class Input:
         created = OpenquakeHazardSolution.created
-        config = graphene.ID(required=True)
         produced_by = graphene.ID(required=True)
 
         csv_archive = graphene.ID(required=False)

--- a/graphql_api/schema/custom/openquake_hazard_solution.py
+++ b/graphql_api/schema/custom/openquake_hazard_solution.py
@@ -39,17 +39,10 @@ class OpenquakeHazardSolution(graphene.ObjectType):
         interfaces = (relay.Node, Thing, PredecessorsInterface)
 
     created = graphene.DateTime(description="When it was created (UTZ)")
-    config = graphene.Field(
-        OpenquakeHazardConfig,
-        description="the template configuration used to produce this solution",
-        required=False,
-        deprecation_reason="We no longer use this field",
-    )
     csv_archive = graphene.Field(
         File, description="a zip archive containing hazard csv outputs (`oq engine --export-outputs ....)"
     )
     hdf5_archive = graphene.Field(File, description="a zip archive containing containing the raw hdf5")
-    modified_config = graphene.Field(File, description="a zip archive containing modified config files.")
     task_args = graphene.Field(File, description="task arguments json file.")
 
     metrics = graphene.List(KeyValuePair, description="result metrics from the solution, as a list of Key Value pairs.")
@@ -58,6 +51,19 @@ class OpenquakeHazardSolution(graphene.ObjectType):
 
     produced_by = graphene.Field(
         'graphql_api.schema.custom.OpenquakeHazardTask', description="The task that produced this solution"
+    )
+
+    config = graphene.Field(
+        OpenquakeHazardConfig,
+        description="the template configuration used to produce this solution",
+        required=False,
+        deprecation_reason="We no longer use this field",
+    )
+    modified_config = graphene.Field(
+        File, 
+        description="a zip archive containing modified config files.",
+        required=False,
+        deprecation_reason="We no longer use this field",
     )
 
     @classmethod
@@ -103,16 +109,11 @@ class CreateOpenquakeHazardSolution(relay.ClientIDMutation):  # graphene.Mutatio
 
     class Input:
         created = OpenquakeHazardSolution.created
-        # we're keeping this in here so that we can create old-fashioned entries for tests to ensure 
-        # we can still read them
-        config = graphene.Field(graphene.ID, required=False, deprecation_reason="We no longer store this config")
         produced_by = graphene.ID(required=True)
 
         csv_archive = graphene.ID(required=False)
         hdf5_archive = graphene.ID(required=False)
-        modified_config = graphene.ID(required=False)
         task_args = graphene.ID(required=False)
-
         meta = graphene.List(
             KeyValuePairInput, required=False, description="additional file meta data, as a list of Key Value pairs."
         )
@@ -126,6 +127,12 @@ class CreateOpenquakeHazardSolution(relay.ClientIDMutation):  # graphene.Mutatio
         predecessors = graphene.List(
             'graphql_api.schema.custom.predecessor.PredecessorInput', required=False, description="list of predecessors"
         )
+
+        # we're keeping these in here so that we can create old-fashioned entries for tests to ensure 
+        # we can still read them
+        config = graphene.Field(graphene.ID, required=False, deprecation_reason="We no longer store this config")
+        modified_config = graphene.Field(graphene.ID, required=False, deprecation_reason="We no longer store this config")
+
 
     openquake_hazard_solution = graphene.Field(OpenquakeHazardSolution)
     ok = graphene.Boolean()

--- a/graphql_api/schema/custom/openquake_hazard_solution.py
+++ b/graphql_api/schema/custom/openquake_hazard_solution.py
@@ -103,7 +103,8 @@ class CreateOpenquakeHazardSolution(relay.ClientIDMutation):  # graphene.Mutatio
 
     class Input:
         created = OpenquakeHazardSolution.created
-        # we're keeping this in here so that we can create old-fashioned entries for tests to ensure we can still read them
+        # we're keeping this in here so that we can create old-fashioned entries for tests to ensure 
+        # we can still read them
         config = graphene.Field(graphene.ID, required=False, deprecation_reason="We no longer store this config")
         produced_by = graphene.ID(required=True)
 

--- a/graphql_api/schema/custom/openquake_hazard_task.py
+++ b/graphql_api/schema/custom/openquake_hazard_task.py
@@ -83,6 +83,8 @@ class OpenquakeHazardTask(graphene.ObjectType, AutomationTaskBase):
 
 
 class OpenquakeHazardTaskInput(AutomationTaskInput):
+    # we're keeping this in here so that we can create old-fashioned entries for tests to ensure we can still read them
+    config = graphene.Field(graphene.ID, required=False, deprecation_reason="We no longer store this config")
     model_type = ModelType(required=True)
     task_type = OpenquakeTaskType(default_value=OpenquakeTaskType.HAZARD)
 

--- a/graphql_api/tests/hazard/setup_helpers.py
+++ b/graphql_api/tests/hazard/setup_helpers.py
@@ -303,12 +303,13 @@ class SetupHelpersMixin:
 
         return self.create_openquake_hazard_disagg_task()
 
-    def create_openquake_hazard_task(self):
+    def create_openquake_hazard_task(self, config=None):
         """test helper"""
         query = '''
-            mutation ($created: DateTime!) {
+            mutation ($created: DateTime!, $config: ID) {
               create_openquake_hazard_task(
                   input: {
+                    config: $config
                     created: $created
                     model_type: COMPOSITE
                     state: UNDEFINED
@@ -334,11 +335,11 @@ class SetupHelpersMixin:
               )
               {
                 ok
-                openquake_hazard_task { id, created, arguments {k v}}
+                openquake_hazard_task { id, config { id }, created, arguments {k v}}
               }
             }'''
 
-        variables = dict(created=dt.datetime.now(tzutc()).isoformat())
+        variables = dict(config=config, created=dt.datetime.now(tzutc()).isoformat())
         result = self.client.execute(query, variable_values=variables)
         print(result)
         ht_id = result['data']['create_openquake_hazard_task']['openquake_hazard_task']['id']

--- a/graphql_api/tests/hazard/setup_helpers.py
+++ b/graphql_api/tests/hazard/setup_helpers.py
@@ -5,6 +5,7 @@ The TestCase sub class must setup self.client
 
 """
 
+import base64
 import datetime as dt
 from hashlib import sha256
 from io import BytesIO
@@ -297,27 +298,17 @@ class SetupHelpersMixin:
         return result
 
     def build_hazard_task(self, disagg=False):
-        upstream_sid = self.create_source_solution()  # File 100001
-        inversion_solution_nrml = self.create_inversion_solution_nrml(upstream_sid)  # File 100002
-        nrml_id = inversion_solution_nrml['data']['create_inversion_solution_nrml']['inversion_solution_nrml']['id']
-        archive = self.create_file("config_archive.zip")  # File 100003
-        archive_id = archive['data']['create_file']['file_result']['id']
-
-        config = self.create_openquake_config([nrml_id], archive_id)  # Thing 100001
-        config_id = config['data']['create_openquake_hazard_config']['config']['id']
-
         if not disagg:
-            return self.create_openquake_hazard_task(config_id)  # Thing 100002
+            return self.create_openquake_hazard_task()  # Thing 100001
 
-        return self.create_openquake_hazard_disagg_task(config_id)
+        return self.create_openquake_hazard_disagg_task()
 
-    def create_openquake_hazard_task(self, config):
+    def create_openquake_hazard_task(self):
         """test helper"""
         query = '''
-            mutation ($created: DateTime!, $config: ID!) {
+            mutation ($created: DateTime!) {
               create_openquake_hazard_task(
                   input: {
-                    config: $config
                     created: $created
                     model_type: COMPOSITE
                     state: UNDEFINED
@@ -343,22 +334,24 @@ class SetupHelpersMixin:
               )
               {
                 ok
-                openquake_hazard_task { id, config { id }, created, arguments {k v}}
+                openquake_hazard_task { id, created, arguments {k v}}
               }
             }'''
 
-        variables = dict(config=config, created=dt.datetime.now(tzutc()).isoformat())
+        variables = dict(created=dt.datetime.now(tzutc()).isoformat())
         result = self.client.execute(query, variable_values=variables)
         print(result)
+        ht_id = result['data']['create_openquake_hazard_task']['openquake_hazard_task']['id']
+        # this shows the id to be used with ToshiThingObject.get()
+        print(base64.b64decode(ht_id).decode("ascii"))
         return result
 
-    def create_openquake_hazard_disagg_task(self, config):
+    def create_openquake_hazard_disagg_task(self):
         """test helper"""
         query = '''
-            mutation ($created: DateTime!, $config: ID!) {
+            mutation ($created: DateTime!) {
               create_openquake_hazard_task(
                   input: {
-                    config: $config
                     created: $created
                     model_type: COMPOSITE
                     task_type: DISAGG
@@ -385,13 +378,16 @@ class SetupHelpersMixin:
               )
               {
                 ok
-                openquake_hazard_task { id, config { id }, created, arguments {k v}}
+                openquake_hazard_task { id, created, arguments {k v}}
               }
             }'''
 
-        variables = dict(config=config, created=dt.datetime.now(tzutc()).isoformat())
+        variables = dict(created=dt.datetime.now(tzutc()).isoformat())
         result = self.client.execute(query, variable_values=variables)
         print(result)
+        ht_id = result['data']['create_openquake_hazard_task']['openquake_hazard_task']['id']
+        # this shows the id to be used with ToshiThingObject.get()
+        print(base64.b64decode(ht_id).decode("ascii"))
         return result
 
     def create_scaled_solution(self, upstream_sid, task_id):

--- a/graphql_api/tests/hazard/test_openquake_hazard_as_disagg_task.py
+++ b/graphql_api/tests/hazard/test_openquake_hazard_as_disagg_task.py
@@ -73,8 +73,8 @@ class TestOpenquakeHazardDisaggTask(unittest.TestCase, SetupHelpersMixin):
         haztask = self._build_hazard_task()
 
         print(haztask)
-        self.assertEqual(ToshiThingObject.get("100002").object_content['clazz_name'], "OpenquakeHazardTask")
-        self.assertEqual(ToshiThingObject.get("100002").object_content['task_type'], "disagg")
+        self.assertEqual(ToshiThingObject.get("100001").object_content['clazz_name'], "OpenquakeHazardTask")
+        self.assertEqual(ToshiThingObject.get("100001").object_content['task_type'], "disagg")
 
     def _build_hazard_task(self):
         return super().build_hazard_task(disagg=True)

--- a/graphql_api/tests/hazard/test_openquake_hazard_solution.py
+++ b/graphql_api/tests/hazard/test_openquake_hazard_solution.py
@@ -80,7 +80,7 @@ class TestOpenquakeHazardSolution(unittest.TestCase, SetupHelpersMixin):
         )
 
         result = self.client.execute(query, variable_values=variables)
-        print(result)
+        # print(result)
         oqs = result['data']['create_openquake_hazard_solution']['openquake_hazard_solution']
         self.assertEqual(oqs['csv_archive']['file_name'], "csv_archive.zip")
         self.assertEqual(oqs['produced_by']['id'], haztask_id)
@@ -131,11 +131,11 @@ class TestOpenquakeHazardSolution(unittest.TestCase, SetupHelpersMixin):
             csv_archive_id=csv_archive_id,
             produced_by=haztask_id,
             config=config_id,
-            modified_config=config_id
+            modified_config=archive_id
         )
 
         result = self.client.execute(query, variable_values=variables)
-        # print(result)
+        print(result)
         oqs_id = result['data']['create_openquake_hazard_solution']['openquake_hazard_solution']['id']
 
         query = '''
@@ -154,10 +154,10 @@ class TestOpenquakeHazardSolution(unittest.TestCase, SetupHelpersMixin):
         }
         '''
         result = self.client.execute(query, variable_values=dict(id=oqs_id))
-        # print(result)
+        print(result)
         oqs = result['data']['node']
         self.assertEqual(oqs['config']['id'], config_id)
-        self.assertEqual(oqs['modified_config']['id'], config_id)
+        self.assertEqual(oqs['modified_config']['id'], archive_id)
 
         return result
 
@@ -176,7 +176,7 @@ class TestOpenquakeHazardSolution(unittest.TestCase, SetupHelpersMixin):
         }
         '''
         result = self.client.execute(query, variable_values=dict(id=hazout_id))
-        print(result)
+        # print(result)
 
         delta = dt.datetime.now(tzutc()) - dt.datetime.fromisoformat(result['data']['node']['created'])
         max_delta = dt.timedelta(seconds=1)
@@ -216,7 +216,7 @@ class TestOpenquakeHazardSolution(unittest.TestCase, SetupHelpersMixin):
         task_args_id = archive['data']['create_file']['file_result']['id']
 
         haztask = self.build_hazard_task()
-        print(haztask)
+        # print(haztask)
         haztask_id = haztask['data']['create_openquake_hazard_task']['openquake_hazard_task']['id']
 
         predecessors = [dict(id=upstream_sid, depth=-2), dict(id=nrml_id, depth=-1)]
@@ -268,7 +268,7 @@ class TestOpenquakeHazardSolution(unittest.TestCase, SetupHelpersMixin):
         )
 
         result = self.client.execute(query, variable_values=variables)
-        print(result)
+        # print(result)
         oqs = result['data']['create_openquake_hazard_solution']['openquake_hazard_solution']
 
         self.assertEqual(oqs['predecessors'][0]['depth'], -2)
@@ -306,7 +306,7 @@ class TestOpenquakeHazardSolution(unittest.TestCase, SetupHelpersMixin):
         }
         '''
         result = self.client.execute(query, variable_values=dict(id=hazout_id))
-        print(result)
+        # print(result)
         node = result['data']['node']
         self.assertEqual(node['predecessors'][0]['relationship'], 'Grandparent')
         self.assertEqual(node['predecessors'][1]['relationship'], 'Parent')

--- a/graphql_api/tests/hazard/test_openquake_hazard_task.py
+++ b/graphql_api/tests/hazard/test_openquake_hazard_task.py
@@ -105,6 +105,61 @@ class TestOpenquakeHazardTask(unittest.TestCase, SetupHelpersMixin):
 
         self.assertEqual(haztask['task_type'], "HAZARD")
 
+    def test_bugfix_148(self):
+        '''
+        ref https://github.com/GNS-Science/nshm-toshi-api/issues/148
+        Source models can return File objects as well as InversionSolutionNrml objects.
+        The id for each item should reflect this, but at right now they're always returning the type InversionSolutionNrml.
+        '''
+
+        upstream_sid = self.create_source_solution()  # File 100001
+        inversion_solution_nrml = self.create_inversion_solution_nrml(upstream_sid)  # File 100002
+
+        # setup need to create source models both NRML and ordinary File
+        nrml_id0 = inversion_solution_nrml['data']['create_inversion_solution_nrml']['inversion_solution_nrml']['id']
+        nrml_1 = self.create_file("bgsesimicity-nrml.zip")  # File 100003
+        nrml_id1 = nrml_1['data']['create_file']['file_result']['id']
+
+        archive = self.create_file("config_archive.zip")  # File 100004
+        archive_id = archive['data']['create_file']['file_result']['id']
+
+        config = self.create_openquake_config([nrml_id0, nrml_id1], archive_id)  # Thing 100001
+        config_id = config['data']['create_openquake_hazard_config']['config']['id']
+
+        haztask = self.create_openquake_hazard_task(config=config_id)  # Thing 100002
+        ht_id = haztask['data']['create_openquake_hazard_task']['openquake_hazard_task']['id']
+
+        query = '''
+        query openquake_hazard_task($id: ID!) {
+          node(id:$id) {
+            __typename
+            ... on OpenquakeHazardTask {
+              created
+              config {
+                id
+                created
+                source_models {
+                    ... on Node { id }
+                    ... on FileInterface { file_name }
+                    ... on InversionSolutionNrml {
+                        source_solution {
+                            ... on Node{ id }
+                            ... on FileInterface { file_name }
+                        }
+                    }
+                }
+              }
+            }
+          }
+        }
+        '''
+
+        result = self.client.execute(query, variable_values=dict(id=ht_id))
+        print(result)
+        haztask = result['data']['node']
+        self.assertEqual(haztask['config']['source_models'][0]['id'], nrml_id0)
+        self.assertEqual(haztask['config']['source_models'][1]['id'], nrml_id1)
+
     def test_update_task_with_metrics(self):
         haztask = self._build_hazard_task()
         ht_id = haztask['data']['create_openquake_hazard_task']['openquake_hazard_task']['id']


### PR DESCRIPTION
closes #206 

- make `config` optional and deprecated for `OpenquakeHazardSolution` and `OpenquakeHazardTask`
- we're not removing it completely so that we can still access old data, and so that we can create old-fashioned objects for tests.

