### PR TITLE
Fix/252 table creation error

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.5
+current_version = 0.2.6
 commit = True
 tag = False
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
+## [0.2.6] - 2025-08-07
 
+### Changed
+ - fix for enum types in list attributes (see issue #252)
 
 ## [0.2.5] - 2025-07-21
 ### Changed

--- a/graphql_api/__init__.py
+++ b/graphql_api/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = 'GNS Science'
 __email__ = 'nshm@gns.cri.nz'
-__version__ = '0.2.5'
+__version__ = '0.2.6'

--- a/graphql_api/data/base_data.py
+++ b/graphql_api/data/base_data.py
@@ -383,7 +383,7 @@ class BaseDynamoDBData(BaseData):
         # TODO: this whole approach sucks !@#%$#
         # consider the ENUM problem, and datatime serialisation
         # cant we just use the graphene classes json serialisation ??
-        # UPDATE: there is no such support, I guess grpaphe doesn't expect this sort of use case
+        # UPDATE: there is no such support, I guess graphene doesn't expect this sort of use case?
         # For now we stick with our helper methods `new_body` and 'replace_enums`
         #  and discuss in code review
 

--- a/graphql_api/data/base_data.py
+++ b/graphql_api/data/base_data.py
@@ -51,6 +51,11 @@ def append_uniq(size):
     return str(size) + uniq
 
 
+def json_serialised(obj):
+    """A simple wrapper to facilitate testing."""
+    return json.dumps(obj)
+
+
 def replace_enums(kwargs: Dict) -> Dict:
     """Replace any Enum members with their values.
 
@@ -317,14 +322,15 @@ class BaseDynamoDBData(BaseData):
         # We've been caught out by Schema classes that are not json-serialisable (the ENUM issue).
         # This should make that more obvious if it happens again.
         try:
-            json.dumps(body)
-        except TypeError as err:
-            logging.error(type(err))
-            logging.error(
+            json_serialised(body)
+        except Exception as exc:
+            # logging.error(repr(exc))
+            msg = (
                 "This object cannot be persisted to a PynamoDB.Model,"
                 " check that all enums and types are json serialisable!"
             )
-            raise err
+            logging.error(msg)
+            raise graphql.GraphQLError(f'{__name__}._write_object() method failed with exception. %s' % msg)
 
         toshi_object = self._model(object_id=str(object_id), object_type=body['clazz_name'], object_content=body)
 

--- a/graphql_api/data/base_data.py
+++ b/graphql_api/data/base_data.py
@@ -318,8 +318,8 @@ class BaseDynamoDBData(BaseData):
         # This should make that more obvious if it happens again.
         try:
             json.dumps(body)
-        except Exception as err:
-            logging.error(err)
+        except TypeError as err:
+            logging.error(type(err))
             logging.error(
                 "This object cannot be persisted to a PynamoDB.Model,"
                 " check that all enums and types are json serialisable!"
@@ -378,8 +378,6 @@ class BaseDynamoDBData(BaseData):
         # consider the ENUM problem, and datatime serialisation
         # cant we just use the graphene classes json serialisation ??
         # UPDATE: there is no such support, I guess grpaphe doesn't expect this sort of use case
-        # nornalyy all typote corecion etc would belong inside resolvers etc, rather then apply
-        # to a ocomplete object instance??
         # For now we stick with our helper methods `new_body` and 'replace_enums`
         #  and discuss in code review
 

--- a/graphql_api/data/base_data.py
+++ b/graphql_api/data/base_data.py
@@ -323,8 +323,7 @@ class BaseDynamoDBData(BaseData):
         # This should make that more obvious if it happens again.
         try:
             json_serialised(body)
-        except Exception as exc:
-            # logging.error(repr(exc))
+        except Exception:
             msg = (
                 "This object cannot be persisted to a PynamoDB.Model,"
                 " check that all enums and types are json serialisable!"

--- a/graphql_api/schema/custom/openquake_hazard_solution.py
+++ b/graphql_api/schema/custom/openquake_hazard_solution.py
@@ -60,7 +60,7 @@ class OpenquakeHazardSolution(graphene.ObjectType):
         deprecation_reason="We no longer use this field",
     )
     modified_config = graphene.Field(
-        File, 
+        File,
         description="a zip archive containing modified config files.",
         required=False,
         deprecation_reason="We no longer use this field",
@@ -128,11 +128,12 @@ class CreateOpenquakeHazardSolution(relay.ClientIDMutation):  # graphene.Mutatio
             'graphql_api.schema.custom.predecessor.PredecessorInput', required=False, description="list of predecessors"
         )
 
-        # we're keeping these in here so that we can create old-fashioned entries for tests to ensure 
+        # we're keeping these in here so that we can create old-fashioned entries for tests to ensure
         # we can still read them
         config = graphene.Field(graphene.ID, required=False, deprecation_reason="We no longer store this config")
-        modified_config = graphene.Field(graphene.ID, required=False, deprecation_reason="We no longer store this config")
-
+        modified_config = graphene.Field(
+            graphene.ID, required=False, deprecation_reason="We no longer store this config"
+        )
 
     openquake_hazard_solution = graphene.Field(OpenquakeHazardSolution)
     ok = graphene.Boolean()

--- a/graphql_api/tests/hazard/setup_helpers.py
+++ b/graphql_api/tests/hazard/setup_helpers.py
@@ -6,8 +6,8 @@ The TestCase sub class must setup self.client
 """
 
 import base64
-import json
 import datetime as dt
+import json
 from hashlib import sha256
 from io import BytesIO
 
@@ -344,11 +344,14 @@ class SetupHelpersMixin:
               }
             }'''
 
-        variables = dict(config=config, created=dt.datetime.now(tzutc()).isoformat(), executor=executor, 
-                         srm_logic_tree=json.dumps({"srm": "tree"}),
-                         gmcm_logic_tree=json.dumps({"gmcm": "tree"}),
-                         openquake_config=json.dumps({"openquake": "config"}),
-                         )
+        variables = dict(
+            config=config,
+            created=dt.datetime.now(tzutc()).isoformat(),
+            executor=executor,
+            srm_logic_tree=json.dumps({"srm": "tree"}),
+            gmcm_logic_tree=json.dumps({"gmcm": "tree"}),
+            openquake_config=json.dumps({"openquake": "config"}),
+        )
         result = self.client.execute(query, variable_values=variables)
         print(result)
         ht_id = result['data']['create_openquake_hazard_task']['openquake_hazard_task']['id']

--- a/graphql_api/tests/hazard/test_openquake_hazard_solution.py
+++ b/graphql_api/tests/hazard/test_openquake_hazard_solution.py
@@ -85,7 +85,7 @@ class TestOpenquakeHazardSolution(unittest.TestCase, SetupHelpersMixin):
         self.assertEqual(oqs['csv_archive']['file_name'], "csv_archive.zip")
         self.assertEqual(oqs['produced_by']['id'], haztask_id)
         return result
-    
+
     def test_create_openquake_hazard_solution_deprecated(self):
         '''
         Assert that we can still read deprecated properties
@@ -131,7 +131,7 @@ class TestOpenquakeHazardSolution(unittest.TestCase, SetupHelpersMixin):
             csv_archive_id=csv_archive_id,
             produced_by=haztask_id,
             config=config_id,
-            modified_config=archive_id
+            modified_config=archive_id,
         )
 
         result = self.client.execute(query, variable_values=variables)

--- a/graphql_api/tests/hazard/test_openquake_hazard_task.py
+++ b/graphql_api/tests/hazard/test_openquake_hazard_task.py
@@ -1,15 +1,14 @@
 import datetime as dt
+import json
 import unittest
 
 import boto3
-import json
 from dateutil.tz import tzutc
 from graphene.test import Client
 from graphql_relay import to_global_id
 from moto import mock_dynamodb, mock_s3
 from pynamodb.connection.base import Connection  # for mocking
 from setup_helpers import SetupHelpersMixin
-
 
 from graphql_api.config import REGION, S3_BUCKET_NAME
 from graphql_api.data import data_manager
@@ -54,7 +53,7 @@ class TestOpenquakeHazardTask(unittest.TestCase, SetupHelpersMixin):
         return super().build_hazard_task()
 
     def test_link_tasks(self):
-        haztask = self._build_hazard_task() # Thing 100001
+        haztask = self._build_hazard_task()  # Thing 100001
         ht_id = haztask['data']['create_openquake_hazard_task']['openquake_hazard_task']['id']
 
         self.create_gt_relation(self.new_gt, ht_id)  # Thing 100002
@@ -70,7 +69,7 @@ class TestOpenquakeHazardTask(unittest.TestCase, SetupHelpersMixin):
         )
 
     def test_get_openquake_hazard_task_node(self):
-        haztask = self._build_hazard_task() # Thing 100001
+        haztask = self._build_hazard_task()  # Thing 100001
         ht_id = haztask['data']['create_openquake_hazard_task']['openquake_hazard_task']['id']
 
         query = '''
@@ -170,7 +169,6 @@ class TestOpenquakeHazardTask(unittest.TestCase, SetupHelpersMixin):
         self.assertEqual(haztask['config']['source_models'][0]['id'], nrml_id0)
         self.assertEqual(haztask['config']['source_models'][1]['id'], nrml_id1)
 
-
     def test_deprecated(self):
         '''
         Assert that we can read deprecated properties
@@ -224,7 +222,6 @@ class TestOpenquakeHazardTask(unittest.TestCase, SetupHelpersMixin):
         self.assertEqual(haztask['config']['source_models'][0]['id'], nrml_id0)
         self.assertEqual(haztask['config']['source_models'][1]['id'], nrml_id1)
 
-
     def test_update_task_with_metrics(self):
         haztask = self._build_hazard_task()
         ht_id = haztask['data']['create_openquake_hazard_task']['openquake_hazard_task']['id']
@@ -256,7 +253,9 @@ class TestOpenquakeHazardTask(unittest.TestCase, SetupHelpersMixin):
                 }
             }
         '''
-        executed = self.client.execute(qry, variable_values=dict(task_id=ht_id, hazard_solution_id=ohs_id, executor=executor))
+        executed = self.client.execute(
+            qry, variable_values=dict(task_id=ht_id, hazard_solution_id=ohs_id, executor=executor)
+        )
         print(executed)
         result = executed['data']['update_openquake_hazard_task']['openquake_hazard_task']
         assert result['id'] == ht_id

--- a/graphql_api/tests/test_table_schema_fix_252.py
+++ b/graphql_api/tests/test_table_schema_fix_252.py
@@ -4,19 +4,50 @@ Test for error 252 where table creation is failing.
 
 import unittest
 from unittest import mock
-from graphene.test import Client
-import graphql_api.data  # for mocking
-from graphql_api.schema import root_schema
 
+import boto3
+from graphene.test import Client
 from moto import mock_dynamodb, mock_s3
 from pynamodb.connection.base import Connection  # for mocking
+
+import graphql_api.data  # for mocking
+from graphql_api.config import REGION, S3_BUCKET_NAME
+from graphql_api.data import data_manager
+from graphql_api.dynamodb.models import ToshiIdentity, ToshiTableObject
+from graphql_api.schema import root_schema
+from graphql_api.schema.search_manager import SearchManager
+
+CREATE_TABLE = '''
+mutation create_table (
+    $rows: [[String]]!, $object_id: ID!, $table_name: String!, $headers: [String]!,
+    $column_types: [RowItemType]!, $created: DateTime!, $table_type: TableType!,
+    $dimensions: [KeyValueListPairInput]!
+) {
+    create_table(input: {
+    name: $table_name
+    created: $created
+    table_type: $table_type
+    dimensions: $dimensions
+    object_id: $object_id
+    column_headers: $headers
+    column_types: $column_types
+    rows: $rows
+    })
+    {
+    table {
+        id
+    }
+    }
+}'''
 
 
 class IncrId:
     next_id = -1
+
     def get_next_id(self, *args):
         self.next_id += 1
         return str(self.next_id) + 'RANDM'
+
 
 @mock.patch('graphql_api.data.BaseDynamoDBData._write_object', lambda self, object_id, object_type, body: None)
 class TestFailingMutation(unittest.TestCase):
@@ -37,43 +68,54 @@ class TestFailingMutation(unittest.TestCase):
         # which fails with error message:
         # {'message': 'Object of type EnumMeta is not JSON serializable', 'locations': [{'line': 2, 'column': 3}], 'path': ['create_table']}
 
-        CREATE_TABLE = '''
-        mutation create_table (
-          $rows: [[String]]!, $object_id: ID!, $table_name: String!, $headers: [String]!,
-          $column_types: [RowItemType]!, $created: DateTime!, $table_type: TableType!,
-          $dimensions: [KeyValueListPairInput]!
-        ) {
-          create_table(input: {
-            name: $table_name
-            created: $created
-            table_type: $table_type
-            dimensions: $dimensions
-            object_id: $object_id
-            column_headers: $headers
-            column_types: $column_types
-            rows: $rows
-            })
-          {
-            table {
-              id
-            }
-          }
-        }'''
-
         print(CREATE_TABLE)
         input_variables = {
-            'headers': ['series', 'series_name', 'X', 'Y'], 
+            'headers': ['series', 'series_name', 'X', 'Y'],
             'object_id': 'SW52ZXJzaW9uU29sdXRpb246MTAxOTY2',
             'rows': [['0', 'foo', '1.0', '2.0'], ['1', 'bar', '1.5', '2.5']],
             'column_types': ['integer', 'string', 'double', 'double'],
             'table_name': 'Inversion Solution MFD table',
             'created': '2025-08-06T23:32:58.526823Z',
-            'table_type': 'MFD_CURVES', 
-            'dimensions': []
+            'table_type': 'MFD_CURVES',
+            'dimensions': [],
         }
         result = self.client.execute(CREATE_TABLE, variable_values=input_variables)
         print(result)
         assert result['data']['create_table']['table']['id'] == 'VGFibGU6MFJBTkRN'
 
 
+@mock_s3
+@mock_dynamodb
+class TestFailingMutatioWithMockedServices(unittest.TestCase):
 
+    def setUp(self):
+        self.client = Client(root_schema)
+        # migrate()
+
+        self._s3_conn = boto3.resource('s3', region_name=REGION)
+        self._s3_conn.create_bucket(Bucket=S3_BUCKET_NAME)
+        self._bucket = self._s3_conn.Bucket(S3_BUCKET_NAME)
+        self._connection = Connection(region=REGION)
+
+        # ToshiThingObject.create_table()
+        ToshiTableObject.create_table()
+        ToshiIdentity.create_table()
+
+        self._data_manager = data_manager.DataManager(search_manager=SearchManager('test', 'test', {'fake': 'auth'}))
+
+    def test_create_one_table(self):
+
+        print(CREATE_TABLE)
+        input_variables = {
+            'headers': ['series', 'series_name', 'X', 'Y'],
+            'object_id': 'SW52ZXJzaW9uU29sdXRpb246MTAxOTY2',
+            'rows': [['0', 'foo', '1.0', '2.0'], ['1', 'bar', '1.5', '2.5']],
+            'column_types': ['integer', 'string', 'double', 'double'],
+            'table_name': 'Inversion Solution MFD table',
+            'created': '2025-08-06T23:32:58.526823Z',
+            'table_type': 'MFD_CURVES',
+            'dimensions': [],
+        }
+        result = self.client.execute(CREATE_TABLE, variable_values=input_variables)
+        print(result)
+        assert result['data']['create_table']['table']['id'] == 'VGFibGU6MTAwMDAw'

--- a/graphql_api/tests/test_table_schema_fix_252.py
+++ b/graphql_api/tests/test_table_schema_fix_252.py
@@ -1,0 +1,79 @@
+"""
+Test for error 252 where table creation is failing.
+"""
+
+import unittest
+from unittest import mock
+from graphene.test import Client
+import graphql_api.data  # for mocking
+from graphql_api.schema import root_schema
+
+from moto import mock_dynamodb, mock_s3
+from pynamodb.connection.base import Connection  # for mocking
+
+
+class IncrId:
+    next_id = -1
+    def get_next_id(self, *args):
+        self.next_id += 1
+        return str(self.next_id) + 'RANDM'
+
+@mock.patch('graphql_api.data.BaseDynamoDBData._write_object', lambda self, object_id, object_type, body: None)
+class TestFailingMutation(unittest.TestCase):
+    """
+    All datastore (data) methods are mocked.
+    """
+
+    def setUp(self):
+        self.client = Client(root_schema)
+
+    @mock.patch('graphql_api.data.BaseDynamoDBData.get_next_id', IncrId().get_next_id)
+    def test_create_252_exmple_table(self):
+
+        # this query comes from:
+        # nzshm-runzi/runzi/automation/scaling/toshi_api/toshi_api.py
+        # https://github.com/GNS-Science/nzshm-runzi/blob/8c390a34d3a803fd357846aadfce21b891c9d299/runzi/automation/scaling/toshi_api/toshi_api.py#L250C1-L274C60
+        #
+        # which fails with error message:
+        # {'message': 'Object of type EnumMeta is not JSON serializable', 'locations': [{'line': 2, 'column': 3}], 'path': ['create_table']}
+
+        CREATE_TABLE = '''
+        mutation create_table (
+          $rows: [[String]]!, $object_id: ID!, $table_name: String!, $headers: [String]!,
+          $column_types: [RowItemType]!, $created: DateTime!, $table_type: TableType!,
+          $dimensions: [KeyValueListPairInput]!
+        ) {
+          create_table(input: {
+            name: $table_name
+            created: $created
+            table_type: $table_type
+            dimensions: $dimensions
+            object_id: $object_id
+            column_headers: $headers
+            column_types: $column_types
+            rows: $rows
+            })
+          {
+            table {
+              id
+            }
+          }
+        }'''
+
+        print(CREATE_TABLE)
+        input_variables = {
+            'headers': ['series', 'series_name', 'X', 'Y'], 
+            'object_id': 'SW52ZXJzaW9uU29sdXRpb246MTAxOTY2',
+            'rows': [['0', 'foo', '1.0', '2.0'], ['1', 'bar', '1.5', '2.5']],
+            'column_types': ['integer', 'string', 'double', 'double'],
+            'table_name': 'Inversion Solution MFD table',
+            'created': '2025-08-06T23:32:58.526823Z',
+            'table_type': 'MFD_CURVES', 
+            'dimensions': []
+        }
+        result = self.client.execute(CREATE_TABLE, variable_values=input_variables)
+        print(result)
+        assert result['data']['create_table']['table']['id'] == 'VGFibGU6MFJBTkRN'
+
+
+

--- a/graphql_api/tests/test_table_schema_fix_252.py
+++ b/graphql_api/tests/test_table_schema_fix_252.py
@@ -86,7 +86,7 @@ class TestFailingMutation(unittest.TestCase):
 
 @mock_s3
 @mock_dynamodb
-class TestFailingMutatioWithMockedServices(unittest.TestCase):
+class TestFailingMutationWithMockedServices(unittest.TestCase):
 
     def setUp(self):
         self.client = Client(root_schema)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nzshm22-toshi-api",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "A graphql API for NZSHM22 shared resources using AWS lambda, S3, Dynamodb and ElasticSearch",
   "directories": {
     "lib": "lib"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nshm-toshi-api"
-version = "0.2.5"
+version = "0.2.6"
 description = "the object store used by NZSHM project"
 authors = ["Chris Chamberlain <chrisbc@artisan.co.nz>"]
 license = "AGPL3"


### PR DESCRIPTION
closes #252 

Notes for reviewers:
 - linting has updated a few files that are not related to the PR sorry (I committed these together)
 - `base_data.py` now handles the enums correctly on lists (which was the root problem)
 - I added a test module for this, using two methods of mocking, but only the second method using
   moto reproduced the problem. This implies that we could have other tests that are not getting 
   quite deep enough. I'll raise a new ticket for this.
 - I'm not entirely happy with the code organisation in base_data, but wanted to review with minimal changes
  first.