### PR TITLE
feat: add Strawberry/FastAPI POC for feasibility migration

### DIFF
--- a/spike/strawberry_poc/COVERAGE_GAPS.md
+++ b/spike/strawberry_poc/COVERAGE_GAPS.md
@@ -1,0 +1,618 @@
+# Coverage Gap Analysis: Legacy Graphene/Flask vs Strawberry/FastAPI POC Test Suites
+
+**Date:** 2026-06-04  
+**Scope:** `graphql_api/tests/` (legacy) vs `spike/strawberry_poc/tests/` (POC)
+
+---
+
+## 1. Summary Table
+
+Legend: ✅ Full coverage  ⚠️ Partial coverage  ❌ Not yet ported  N/A (infrastructure/skip)
+
+### Top-level legacy test files
+
+| Legacy test file | Tests | POC test file | POC tests | Status |
+|---|---|---|---|---|
+| `test_general_task_schema.py` | 7 | `test_general_task.py` | 11 | ✅ |
+| `test_automation_task_schema.py` | 6 | `test_smoketest_ab.py` (partial) | — | ⚠️ |
+| `test_rupture_generation_schema.py` | 6 | `test_smoketest_ab.py` + `test_rupture_set.py` | — | ⚠️ |
+| `test_inversion_solution_schema.py` | 4 | `test_inversion_solution.py` + `test_inversion_solution_interface.py` | 10+10 | ✅ |
+| `test_table_schema.py` | 3 | `test_table.py` | 6 | ✅ |
+| `test_table_schema_fix_252.py` | 3 | — | — | ❌ |
+| `test_sms_schema.py` | 6 | `test_smoketest_ab.py` (partial) | — | ⚠️ |
+| `test_sms_file_link_schema.py` | 2 | `test_sms_file.py` + `test_smoketest_ab.py` | 4+partial | ⚠️ |
+| `test_task_task_relations_db.py` | 1 | `test_general_task.py` + `test_smoketest_ab.py` | — | ⚠️ |
+| `test_file_relation_bugfix_126.py` | 5 | `test_file_relation.py` | 3 | ⚠️ |
+| `test_file_relation_compression.py` | 3 | — | — | ❌ |
+| `test_nodes_bugfix_220.py` | 3 | `test_inversion_solution.py` (partial) | — | ⚠️ |
+| `test_general_task_bugfix_29.py` | 1 | `test_general_task.py` | — | ⚠️ |
+| `test_general_task_bugfix_217.py` | 1 | — | — | ❌ |
+| `test_schema.py` | 5 | `test_smoketest_ab.py` | 19 | ⚠️ |
+| `test_search_manager.py` | 9 | `test_smoketest_ab.py` (`@pytest.mark.integration`) | 5 integration | ⚠️ |
+| `test_dynamo_and_s3_queries.py` | 9 | — | — | ❌ |
+| `test_s3_fallback.py` | 2 | — | — | ❌ |
+| `test_api_init.py` | 3 | — | — | N/A |
+| `test_create_file_bugfix_159.py` | 4 | — | — | ❌ |
+| `test_inversion_solution_bug_93.py` | 1 | — | — | ❌ |
+| `test_automation_task_mutation_deep.py` | 1 | — | — | ❌ |
+| `test_file_download_url_bugfix_211.py` | 1 | — | — | ❌ |
+| `test_source_solution_bugfix_214.py` | 1 | — | — | ❌ |
+| `test_thing_relation_bugfix_95.py` | 1 | — | — | ❌ |
+| `smoketests.py` | 0 (helper) | `test_smoketest_ab.py` | 19 | ✅ |
+| `upload_test_s3_extract.py` | 0 (helper) | — | — | N/A |
+
+### `hazard/` subdirectory
+
+| Legacy test file | Tests | POC test file | POC tests | Status |
+|---|---|---|---|---|
+| `hazard/test_openquake_hazard_task.py` | 7 | `test_openquake.py` | 14 | ✅ |
+| `hazard/test_openquake_hazard_solution.py` | 6 | `test_openquake.py` | 14 | ✅ |
+| `hazard/test_openquake_hazard_config.py` | 2 | `test_openquake.py` | 14 | ✅ |
+| `hazard/test_openquake_hazard_as_disagg_task.py` | 6 | — | — | ❌ |
+| `hazard/test_openquake_sources_nrml_solution.py` | 8 | — | — | ❌ |
+| `hazard/test_aggregate_inversion_solution.py` | 6 | `test_aggregate_inversion_solution.py` | 7 | ✅ |
+| `hazard/test_scaled_inversion_solution.py` | 7 | `test_scaled_inversion_solution.py` | 6 | ✅ |
+| `hazard/test_time_dependent_inversion_solution.py` | 6 | `test_time_dependent_inversion_solution.py` | 6 | ✅ |
+| `hazard/test_file.py` | 2 | `test_smoketest_ab.py` (partial) | — | ⚠️ |
+| `hazard/test_inversion_solution.py` | 2 | `test_inversion_solution.py` | 10 | ✅ |
+| `hazard/test_bugfix_167_missing_fileunion.py` | 1 | — | — | ❌ |
+
+### `rupture_set/` subdirectory
+
+| Legacy test file | Tests | POC test file | POC tests | Status |
+|---|---|---|---|---|
+| `rupture_set/test_rupture_set_basic.py` | 4 | `test_rupture_set.py` | 7 | ✅ |
+| `rupture_set/test_rupture_set_mutation_checks.py` | 4 | — | — | ❌ |
+| `rupture_set/test_rupture_set_upload.py` | 1 | — | — | ❌ |
+| `rupture_set/test_handle_legacy_data.py` | 2 | — | — | N/A |
+
+### `simpler_relationships/`, `legacy/`, `e2e_workflows/`, `object_iteration/`, `swept_arguments/`
+
+| Legacy test file | Tests | POC test file | POC tests | Status |
+|---|---|---|---|---|
+| `simpler_relationships/test_automation_task_related_solution_new.py` | 2 | `test_inversion_solution.py` (partial) | — | ⚠️ |
+| `simpler_relationships/test_inversion_solution_file_migration_bug_new.py` | 3 | — | — | ❌ |
+| `simpler_relationships/test_rupture_generation_related_files_new.py` | 1 | `test_smoketest_ab.py` | — | ⚠️ |
+| `legacy/test_automation_task_related_solution.py` | 3 | — | — | N/A |
+| `legacy/test_inversion_solution_file_migration_bug.py` | 3 | — | — | N/A |
+| `legacy/test_rupture_generation_related_files.py` | 1 | — | — | N/A |
+| `e2e_workflows/test_inversion_solution_table_e2e.py` | 1 | `test_inversion_solution.py` | — | ⚠️ |
+| `object_iteration/test_divine_basedata_class_from_schema_name.py` | 3 | — | — | N/A |
+| `object_iteration/test_iterate_items.py` | 2 | — | — | ❌ |
+| `object_iteration/test_iterate_schema_types.py` | 1 | — | — | ❌ |
+| `swept_arguments/test_baseline_swept_arguments.py` | 2 | `test_general_task.py` (partial) | — | ⚠️ |
+| `swept_arguments/test_automation_task_swept_arg_validation.py` | 4 | — | — | ❌ |
+
+**Totals:**
+- Legacy total tests: ~178 (across all directories)
+- POC total tests: ~115 (across all POC test files, excluding integration-only)
+
+---
+
+## 2. API Surface Map
+
+### GeneralTask
+
+| Item | Legacy defined | Legacy tested | In POC schema | POC tested |
+|---|---|---|---|---|
+| Mutation: `create_general_task` | Yes | Yes | Yes | Yes |
+| Mutation: `update_general_task` | Yes | Yes | Yes | Yes |
+| Mutation: `create_task_relation` (GT→child) | Yes | Yes | Yes | Yes |
+| Query: `node(id)` | Yes | Yes | Yes | Yes |
+| Query: `general_tasks` (list) | Yes | Yes | Yes | Yes |
+| Field: `id` | Yes | Yes | Yes | Yes |
+| Field: `title` | Yes | Yes | Yes | Yes |
+| Field: `description` | Yes | Yes | Yes | Yes |
+| Field: `agent_name` | Yes | Yes | Yes | Yes |
+| Field: `created` | Yes | Yes | Yes | Yes |
+| Field: `updated` | Yes | Yes | Yes | Yes |
+| Field: `notes` | Yes | Yes | Yes | Yes |
+| Field: `meta [k v]` | Yes | Yes | Yes | Yes |
+| Field: `argument_lists [k v]` | Yes | Yes | Yes | Yes |
+| Field: `swept_arguments` | Yes | Yes | Yes | Yes |
+| Field: `subtask_count` | Yes | Yes | Yes | Yes |
+| Field: `subtask_type` | Yes | Yes | Yes | Yes |
+| Field: `subtask_result` | Yes | Yes | Yes | Yes |
+| Field: `model_type` | Yes | Yes | Yes | Yes |
+| Field: `children` (connection) | Yes | Yes | Yes | Yes |
+| Field: `parents` (connection) | Yes | Yes | Yes | Yes |
+| Field: `files` (connection) | Yes | Yes | Yes | Yes |
+
+### AutomationTask
+
+| Item | Legacy defined | Legacy tested | In POC schema | POC tested |
+|---|---|---|---|---|
+| Mutation: `create_automation_task` | Yes | Yes | Yes | Yes |
+| Mutation: `update_automation_task` | Yes | Yes | **No** | No |
+| Query: `node(id)` | Yes | Yes | Yes | Yes |
+| Query: `automation_tasks` (list) | Yes | implicit | Yes | Yes |
+| Field: `id` | Yes | Yes | Yes | Yes |
+| Field: `task_type` | Yes | Yes | Yes | Yes |
+| Field: `state` | Yes | Yes | Yes | Yes |
+| Field: `result` | Yes | Yes | Yes | Yes |
+| Field: `created` | Yes | Yes | Yes | Yes |
+| Field: `duration` | Yes | Yes | Yes | Yes |
+| Field: `arguments [k v]` | Yes | Yes | Yes | Yes |
+| Field: `environment [k v]` | Yes | Yes | Yes | Yes |
+| Field: `metrics [k v]` | Yes | Yes | Yes | Yes |
+| Field: `model_type` | Yes | Yes | Yes | Yes |
+| Field: `parents` (connection) | Yes | Yes | Yes | Yes |
+| Field: `children` (connection) | Yes | Yes | Yes | Yes |
+| Field: `files` (connection) | Yes | Yes | Yes | Yes |
+| DateTime validation (timezone required) | Yes | Yes | **Yes (handled by Strawberry)** | Partial |
+| DateTime validation (ISO format) | Yes | Yes | **Yes (handled by Strawberry)** | Partial |
+
+### RuptureGenerationTask
+
+| Item | Legacy defined | Legacy tested | In POC schema | POC tested |
+|---|---|---|---|---|
+| Mutation: `create_rupture_generation_task` | Yes | Yes | Yes | Yes |
+| Mutation: `update_rupture_generation_task` | Yes | Yes | Yes | Yes |
+| Query: `node(id)` | Yes | Yes | Yes | Yes |
+| Query: `rupture_generation_tasks` (list) | Yes | Yes | Yes | Yes |
+| Field: `id`, `state`, `result`, `created`, `duration` | Yes | Yes | Yes | Yes |
+| Field: `arguments [k v]` | Yes | Yes | Yes | Yes |
+| Field: `environment [k v]` | Yes | Yes | Yes | Yes |
+| Field: `metrics [k v]` | Yes | Yes | Yes | Yes |
+| Field: `task_type` | Yes | Yes | Yes | Yes |
+| Legacy field migration (`git_refs` → `environment`) | Yes | Yes | **No** | No |
+| Field: `parents`, `children`, `files` | Yes | Yes | Yes | Yes |
+
+### InversionSolution
+
+| Item | Legacy defined | Legacy tested | In POC schema | POC tested |
+|---|---|---|---|---|
+| Mutation: `create_inversion_solution` | Yes | Yes | Yes | Yes |
+| Mutation: `append_inversion_solution_tables` | Yes | Yes | Yes | Yes |
+| Query: `node(id)` | Yes | Yes | Yes | Yes |
+| Query: `inversion_solutions` (list) | Yes | implicit | Yes | implicit |
+| Field: `id`, `file_name`, `md5_digest`, `file_size`, `created` | Yes | Yes | Yes | Yes |
+| Field: `meta [k v]` | Yes | Yes | Yes | Yes |
+| Field: `metrics [k v]` | Yes | Yes | Yes | Yes |
+| Field: `tables` (LabelledTableRelation list) | Yes | Yes | Yes | Yes |
+| Field: `mfd_table_id` | Yes | Yes | Yes | Yes |
+| Field: `mfd_table` (resolved Table) | Yes | Yes | Yes | Yes |
+| Field: `hazard_table_id` | Yes | Yes | Yes | Yes |
+| Field: `hazard_table` (resolved Table) | Yes | Yes | Yes | Partial (null case only) |
+| Field: `produced_by` (union) | Yes | Yes | Yes | Yes |
+| Field: `predecessors` | Yes | Yes | Yes | Yes |
+| Field: `relations` (total_count) | Yes | Yes | Yes | Yes |
+| Interface: `InversionSolutionInterface` fragment | Yes | Yes | Yes | Yes |
+| Field: `post_url` (S3 pre-signed) | Yes | implicit | Yes (model field) | Not tested |
+
+### ScaledInversionSolution
+
+| Item | Legacy defined | Legacy tested | In POC schema | POC tested |
+|---|---|---|---|---|
+| Mutation: `create_scaled_inversion_solution` | Yes | Yes | Yes | Yes |
+| Query: `node(id)` | Yes | Yes | Yes | Yes |
+| Field: `id`, `file_name`, `md5_digest`, `file_size`, `created` | Yes | Yes | Yes | Yes |
+| Field: `source_solution` (union) | Yes | Yes | Yes | Yes |
+| Field: `produced_by` (union) | Yes | Yes | Yes | Yes |
+| Field: `predecessors` | Yes | Yes | Yes | Yes |
+| Field: `post_url` | Yes | implicit | Yes (model field) | Not tested |
+| Interface: `InversionSolutionInterface` via fragment | Yes | Yes | Yes | Yes |
+
+### AggregateInversionSolution
+
+| Item | Legacy defined | Legacy tested | In POC schema | POC tested |
+|---|---|---|---|---|
+| Mutation: `create_aggregate_inversion_solution` | Yes | Yes | Yes | Yes |
+| Query: `node(id)` | Yes | Yes | Yes | Yes |
+| Field: `source_solutions` (union list) | Yes | Yes | Yes | Yes |
+| Field: `common_rupture_set` | Yes | Yes | Yes | Yes |
+| Field: `aggregation_fn` | Yes | Yes | Yes | Yes |
+| Field: `produced_by` (union) | Yes | Yes | Yes | Yes |
+| Field: `predecessors` | Yes | Yes | Yes | Yes |
+
+### TimeDependentInversionSolution
+
+| Item | Legacy defined | Legacy tested | In POC schema | POC tested |
+|---|---|---|---|---|
+| Mutation: `create_time_dependent_inversion_solution` | Yes | Yes | Yes | Yes |
+| Query: `node(id)` | Yes | Yes | Yes | Yes |
+| Field: `source_solution`, `produced_by`, `predecessors` | Yes | Yes | Yes | Yes |
+| Field: `id`, `file_name`, `md5_digest`, `file_size`, `created` | Yes | Yes | Yes | Yes |
+
+### InversionSolutionNrml
+
+| Item | Legacy defined | Legacy tested | In POC schema | POC tested |
+|---|---|---|---|---|
+| Mutation: `create_inversion_solution_nrml` | Yes | Yes (8 tests) | Yes | **No** |
+| Query: `node(id)` | Yes | Yes | Yes | **No** |
+| Field: `source_solution` (from IS / ScaledIS / TDIS) | Yes | Yes | Yes | **No** |
+| Field: `predecessors` | Yes | Yes | Yes | **No** |
+
+### RuptureSet
+
+| Item | Legacy defined | Legacy tested | In POC schema | POC tested |
+|---|---|---|---|---|
+| Mutation: `create_rupture_set` | Yes | Yes | Yes | Yes |
+| Query: `node(id)` | Yes | Yes | Yes | Yes |
+| Query: `rupture_sets` (list) | Yes | Yes | Yes | Yes |
+| Field: `id`, `file_name`, `md5_digest`, `file_size`, `created` | Yes | Yes | Yes | Yes |
+| Field: `fault_models` | Yes | Yes | Yes | Yes |
+| Field: `metrics [k v]` | Yes | Yes | Yes | Yes |
+| Field: `produced_by` (union) | Yes | Yes | Yes | Yes |
+| Mutation checks (fault model validation, etc.) | Yes | Yes (4 tests) | **No** | No |
+| Presigned upload URL (`post_url`, `post_url_v2`) | Yes | Yes (1 test) | **No** | No |
+
+### Table
+
+| Item | Legacy defined | Legacy tested | In POC schema | POC tested |
+|---|---|---|---|---|
+| Mutation: `create_table` | Yes | Yes | Yes | Yes |
+| Query: `node(id)` | Yes | Yes | Yes | Yes |
+| Field: `id`, `object_id`, `created`, `column_headers`, `column_types`, `rows` | Yes | Yes | Yes | Yes |
+| Field: `meta [k v]` | Yes | Yes | Yes | Yes |
+| Field: `dimensions [k v]` | Yes | Yes | Yes | Yes |
+| Field: `table_type` | Yes | Yes | Yes | Yes |
+| Field: `name` | Yes | Yes (bugfix 252) | **No** | No |
+| Exception handling for un-serializable types (bugfix 252) | Yes | Yes | **No** | No |
+
+### ToshiFile (generic File)
+
+| Item | Legacy defined | Legacy tested | In POC schema | POC tested |
+|---|---|---|---|---|
+| Mutation: `create_file` | Yes | Yes | Yes | Yes |
+| Query: `node(id)` | Yes | Yes | Yes | Yes |
+| Query: `files` (list) | Yes | implicit | Yes | implicit |
+| Field: `id`, `file_name`, `md5_digest`, `file_size` | Yes | Yes | Yes | Yes |
+| Field: `meta [k v]` | Yes | Yes | Yes | Yes |
+| Field: `post_url` (S3 pre-signed) | Yes | Yes | Yes (model field) | Not tested |
+| Field: `relations` (connection) | Yes | Yes | Yes | Yes |
+| Field: `predecessors` | Yes | Yes | Yes | Not explicitly |
+| BigInt file_size validation | Yes | Yes (4 tests: bigint/float/int/string) | **No separate test** | No |
+| Download URL (bugfix 211) | Yes | Yes | **No** | No |
+
+### SmsFile
+
+| Item | Legacy defined | Legacy tested | In POC schema | POC tested |
+|---|---|---|---|---|
+| Mutation: `create_sms_file` | Yes | Yes | Yes | Yes |
+| Query: `node(id)` | Yes | Yes | Yes | Yes |
+| Query: `sms_files` (list) | Yes | implicit | Yes | Yes |
+| Field: `id`, `file_name`, `file_type`, `md5_digest`, `file_size`, `created` | Yes | Yes | Yes | Yes |
+| Field: `relations` (connection) | Yes | Yes | Yes | Yes |
+| `create_sms_file_link` mutation | Yes | Yes (commented out in legacy) | **No** | No |
+
+### StrongMotionStation
+
+| Item | Legacy defined | Legacy tested | In POC schema | POC tested |
+|---|---|---|---|---|
+| Mutation: `create_strong_motion_station` | Yes | Yes | Yes | Yes |
+| Query: `node(id)` | Yes | Yes | Yes | Yes |
+| Query: `strong_motion_stations` (list) | Yes | Yes | Yes | Yes |
+| Field: `id`, `created`, `site_code`, `site_class`, `site_class_basis` | Yes | Yes | Yes | Yes |
+| Field: `Vs30_mean` | Yes | Yes | Yes | Yes |
+| Field: `liquefiable` | Yes | implicit | Yes | implicit |
+| Field: `files` (connection) | Yes | implicit | Yes | Yes |
+| Mutation: `update_strong_motion_station` | Yes | skipped | **No** | No |
+| DateTime validation (timezone required) | Yes | Yes | **Yes (Strawberry)** | Partial |
+
+### OpenquakeHazardTask
+
+| Item | Legacy defined | Legacy tested | In POC schema | POC tested |
+|---|---|---|---|---|
+| Mutation: `create_openquake_hazard_task` | Yes | Yes | Yes | Yes |
+| Mutation: `update_openquake_hazard_task` (with hazard_solution) | Yes | Yes | Yes | Yes |
+| Query: `node(id)` | Yes | Yes | Yes | Yes |
+| Field: `id`, `state`, `result`, `task_type`, `created`, `duration` | Yes | Yes | Yes | Yes |
+| Field: `arguments [k v]`, `environment [k v]`, `metrics [k v]` | Yes | Yes | Yes | Yes |
+| Field: `srm_logic_tree` (JSONString) | Yes | Yes | Yes | Not tested |
+| Field: `gmcm_logic_tree` (JSONString) | Yes | Yes | Yes | Not tested |
+| Field: `openquake_config` (JSONString) | Yes | Yes | Yes | Not tested |
+| Field: `config` (OpenquakeHazardConfig) | Yes | Yes | Yes | Not tested |
+| Field: `hazard_solution` | Yes | Yes | Yes | Yes |
+| Field: `executor` | Yes | Yes | Yes | Yes |
+| Field: `model_type` | Yes | Yes | Yes | Not tested |
+| `task_type: DISAGG` (disagg variant) | Yes | Yes (6 tests) | Yes (enum) | **No** |
+| Legacy task default `task_type` handling | Yes | Yes | **No** | No |
+
+### OpenquakeHazardSolution
+
+| Item | Legacy defined | Legacy tested | In POC schema | POC tested |
+|---|---|---|---|---|
+| Mutation: `create_openquake_hazard_solution` | Yes | Yes | Yes | Yes |
+| Query: `node(id)` | Yes | Yes | Yes | Yes |
+| Field: `id`, `created`, `task_type` | Yes | Yes | Yes | Yes |
+| Field: `metrics [k v]` | Yes | Yes | Yes | Yes |
+| Field: `produced_by` | Yes | Yes | Yes | Yes |
+| Field: `csv_archive` | Yes | Yes | Yes | Not tested |
+| Field: `hdf5_archive` | Yes | Yes | Yes | Not tested |
+| Field: `task_args` | Yes | Yes | Yes | Not tested |
+| Field: `predecessors` | Yes | Yes | Yes | Not tested |
+| Required field validation (`task_type` required) | Yes | Yes (error case) | Yes | **No** |
+
+### OpenquakeHazardConfig
+
+| Item | Legacy defined | Legacy tested | In POC schema | POC tested |
+|---|---|---|---|---|
+| Mutation: `create_openquake_hazard_config` | Yes | Yes | Yes | Yes |
+| Query: `node(id)` | Yes | Yes | Yes | Yes |
+| Field: `id`, `created` | Yes | Yes | Yes | Yes |
+| Field: `template_archive` (resolved File) | Yes | Yes | Yes | Yes |
+| Field: `source_models` (union list: NRML or File) | Yes | Yes | Yes | Yes (ToshiFile case only) |
+| `source_models` resolving to `InversionSolutionNrml` | Yes | Yes | Yes | **No** |
+
+### FileRelation
+
+| Item | Legacy defined | Legacy tested | In POC schema | POC tested |
+|---|---|---|---|---|
+| Mutation: `create_file_relation` | Yes | Yes | Yes | Yes |
+| Query: file.relations.edges.node | Yes | Yes | Yes | Yes |
+| Query: thing.files.edges.node | Yes | Yes | Yes | Yes |
+| Field: `role` | Yes | Yes | Yes | Yes |
+| Field: `file_id` | Yes | Yes | Yes | implicit |
+| Field: `file` (resolved) | Yes | Yes | Yes | Yes |
+| Field: `thing` (resolved) | Yes | Yes | Yes | Yes |
+| Relation compression (large relation lists) | Yes | Yes (3 tests) | **No** | No |
+
+### TaskTaskRelation
+
+| Item | Legacy defined | Legacy tested | In POC schema | POC tested |
+|---|---|---|---|---|
+| Mutation: `create_task_relation` | Yes | Yes | Yes | Yes |
+| Query: thing.parents / thing.children | Yes | Yes | Yes | Yes |
+| Field: `parent_id`, `child_id` | Yes | Yes | Yes | Yes |
+| Field: `parent`, `child` (resolved union) | Yes | Yes | Yes | Yes |
+| Data-layer ThingRelationData test (DB only) | Yes | Yes | **No test** | No |
+
+---
+
+## 3. Coverage Gap Detail
+
+### Gap 1: `update_automation_task` mutation missing from POC
+
+- **Legacy file:** `test_automation_task_schema.py` — `test_update_with_metrics`; also `test_automation_task_mutation_deep.py` — `test_update_with_metrics`
+- **What it exercises:** `update_automation_task` mutation with `duration`, `metrics`, `state`, `result` fields; verifies ES re-indexing is called on update
+- **Closest POC equivalent:** `update_rupture_generation_task` exists; `UpdateAutomationTaskInput` exists in POC models but no corresponding `update_automation_task` resolver or mutation in `schema.py`
+- **Gap severity:** **Critical** — production pipelines (nzshm-runzi) call `update_automation_task` to record metrics and state transitions for every INVERSION task
+
+### Gap 2: `InversionSolutionNrml` — no POC tests at all
+
+- **Legacy files:** `hazard/test_openquake_sources_nrml_solution.py` — 8 tests covering: create NRML from IS, ScaledIS, TDIS; with predecessors; node lookup; with predecessors node; source_solution union resolution
+- **What it exercises:** `create_inversion_solution_nrml` mutation; `source_solution` field resolving to `SourceSolutionUnion`; `InversionSolutionNrml` node lookup; `PredecessorsInterface` on NRML
+- **Closest POC equivalent:** Schema and model are fully implemented in POC; no test file exists
+- **Gap severity:** **Critical** — InversionSolutionNrml is a required intermediate object in the OpenquakeHazardConfig.source_models chain; weka and runzi create these as part of every hazard run
+
+### Gap 3: DISAGG task type not tested in POC
+
+- **Legacy files:** `hazard/test_openquake_hazard_as_disagg_task.py` — 6 tests: create disagg task, node lookup, `task_type: DISAGG` returned correctly; also `test_legacy_hazard_task_has_default_task_type`
+- **What it exercises:** `create_openquake_hazard_task` with `task_type: DISAGG`; verifying returned `task_type` is `DISAGG`; legacy objects where task_type field is absent default gracefully
+- **Closest POC equivalent:** `DISAGG` enum value exists in POC `OpenquakeTaskType`; `test_openquake.py` only tests `HAZARD` variant
+- **Gap severity:** **High** — disaggregation runs are a distinct and regular production workflow
+
+### Gap 4: Rupture set mutation validation and upload not tested
+
+- **Legacy files:** `rupture_set/test_rupture_set_mutation_checks.py` (4 tests: fault model field validation); `rupture_set/test_rupture_set_upload.py` (1 test: S3 presigned URL upload workflow with `post_url` / `post_url_v2`)
+- **What it exercises:** Validation of `fault_models` field; S3 pre-signed POST URL generation and upload using `requests` library; `post_url_v2` format
+- **Closest POC equivalent:** `test_rupture_set.py` tests basic create/lookup; no validation or upload tests
+- **Gap severity:** **High** — rupture set upload is the first step in every production inversion run; `post_url` is the mechanism clients use to transfer files
+
+### Gap 5: Table `name` field and exception handling (bugfix 252)
+
+- **Legacy file:** `test_table_schema_fix_252.py` — 3 tests: `test_create_252_example_table` (uses `name` field in input); `test_create_one_table` (full moto-backed); `test_new_logging_exception_handling` (verifies `json_serialised` error surfaced correctly)
+- **What it exercises:** `name` field in `create_table` input; logging/error propagation when a DynamoDB write fails due to non-serialisable object
+- **Closest POC equivalent:** `test_table.py` tests create/lookup but does not use `name` and has no error case test
+- **Gap severity:** **High** — the `name` field is used by nzshm-runzi when creating tables; the error handling test protects a regression introduced by bugfix 252
+
+### Gap 6: File relation compression
+
+- **Legacy file:** `test_file_relation_compression.py` — 3 tests: counting relations in a 390k-relation scenario; adding with compression; round-trip with compression
+- **What it exercises:** That the data layer compresses and decompresses large `relations` lists stored in DynamoDB
+- **Closest POC equivalent:** None — the POC stores relations differently (as normalised DynamoDB items) and does not need compression; this gap may be intentionally N/A in the POC architecture
+- **Gap severity:** **Low** — only relevant for legacy data migration; POC uses a different storage model
+
+### Gap 7: S3 fallback and DynamoDB + S3 combined queries
+
+- **Legacy files:** `test_s3_fallback.py` (2 tests); `test_dynamo_and_s3_queries.py` (9 tests)
+- **What it exercises:** Reading legacy objects from S3 when not found in DynamoDB; combined queries that retrieve both DynamoDB and S3-backed objects in the same request; parent/child traversal with mixed storage
+- **Closest POC equivalent:** None — the POC uses only DynamoDB; S3 fallback is a legacy concern
+- **Gap severity:** **Low for new data; High for migration** — any migration tooling that reads existing production data from S3 will exercise this path
+
+### Gap 8: Elasticsearch search manager tests
+
+- **Legacy file:** `test_search_manager.py` — 9 tests including `SearchManager` unit tests, `test_query_with_mock_requests`, `total_count` from ES response, and `traversing_into_s3_api_call` (ensures search doesn't trigger expensive S3 reads)
+- **Closest POC equivalent:** `test_smoketest_ab.py` has 5 integration tests (`@pytest.mark.integration`) that run against live ES; no unit tests of the search layer with mocked HTTP
+- **Gap severity:** **Medium** — the POC search layer is thin (`data/search.py`) and works differently; unit tests would catch regressions in the `_dispatch_search` dispatch table
+
+### Gap 9: File download URL (bugfix 211)
+
+- **Legacy file:** `test_file_download_url_bugfix_211.py` — 1 test: calling a resolver that previously made a direct S3 API call is now handled without an `UploadPartCopy` error
+- **What it exercises:** That querying `file_name` on a file object does not incidentally trigger an S3 download
+- **Closest POC equivalent:** None — the POC does not perform S3 API calls for metadata reads
+- **Gap severity:** **Low** — architecture-specific to legacy S3 data access pattern
+
+### Gap 10: `create_file` BigInt / type coercion (bugfix 159)
+
+- **Legacy file:** `test_create_file_bugfix_159.py` — 4 tests: `file_size` as BigInt, float, int, string
+- **What it exercises:** That the `file_size` scalar correctly coerces or rejects non-integer inputs
+- **Closest POC equivalent:** None — POC uses Python's native `int` type; Strawberry handles coercion but no explicit tests exist
+- **Gap severity:** **Medium** — clients in the wild (nzshm-runzi) may send float `file_size` values
+
+### Gap 11: `srm_logic_tree`, `gmcm_logic_tree`, `openquake_config` JSON fields not tested in POC
+
+- **Legacy file:** `hazard/test_openquake_hazard_task.py` — `test_get_openquake_hazard_task_node` and `test_create_oq_hazard_task` verify these JSONString round-trips
+- **What it exercises:** That serialised JSON strings survive the DynamoDB round-trip and are returned correctly
+- **Closest POC equivalent:** POC `test_openquake.py` creates an `OpenquakeHazardTask` but does not set or verify these fields
+- **Gap severity:** **High** — these fields are required by the hazard workflow; every production OpenquakeHazardTask carries all three
+
+### Gap 12: OpenquakeHazardSolution `csv_archive`, `hdf5_archive`, `task_args`, predecessors not tested
+
+- **Legacy file:** `hazard/test_openquake_hazard_solution.py` — `test_create_openquake_hazard_solution_with_predecessors` and `test_get_oq_hazard_solution_with_pred` exercise all three file references and predecessors depth/relationship
+- **Closest POC equivalent:** `test_openquake.py` creates a solution but does not set or verify `csv_archive`, `hdf5_archive`, `task_args`, or predecessors
+- **Gap severity:** **High** — both archives are required inputs in production
+
+### Gap 13: `nodes(id_in: [...])` multi-fetch and interface expansion
+
+- **Legacy file:** `test_nodes_bugfix_220.py` — 3 tests covering `nodes` query with `ScaledInversionSolution` result; interface expansions (`InversionSolutionInterface`, `FileInterface`, `AutomationTaskInterface` with parents navigation)
+- **Closest POC equivalent:** POC `schema.py` implements `nodes` query and it is exercised through individual mutations, but there is no dedicated test for the multi-fetch query with interface fragment expansion including parent traversal
+- **Gap severity:** **Critical** — weka uses `nodes(id_in: [...])` with deep `AutomationTaskInterface.parents` expansion as its primary batch data-retrieval pattern
+
+### Gap 14: Swept argument validation on AutomationTask creation
+
+- **Legacy files:** `swept_arguments/test_automation_task_swept_arg_validation.py` (4 tests) — verifies that AutomationTask arguments must align with the parent GeneralTask's swept arguments; error cases when required swept arg is missing or value not in GT's list
+- **Closest POC equivalent:** `test_general_task.py::test_swept_arguments` tests the GT swept_arguments computation; no AT argument validation against GT exists in POC
+- **Gap severity:** **Medium** — validation was added to prevent malformed experiment data; clients set arguments explicitly so this rarely fails in practice
+
+### Gap 15: `hazard/test_bugfix_167_missing_fileunion.py`
+
+- **Legacy file:** 1 test — verifies that querying a `file_union` field on a type that can return either an `InversionSolution` or a plain `File` returns the correct type
+- **Closest POC equivalent:** `test_inversion_solution_interface.py` and `test_openquake.py` exercise union fields but do not specifically test the "missing file union" scenario
+- **Gap severity:** **Low** — narrow regression test for a specific legacy bug
+
+---
+
+## 4. Mutations Gap Table
+
+| Mutation (legacy) | In POC schema | POC unit test | Notes |
+|---|---|---|---|
+| `create_general_task` | ✅ | ✅ | — |
+| `update_general_task` | ✅ | ✅ | — |
+| `create_automation_task` | ✅ | ✅ | — |
+| `update_automation_task` | ❌ **MISSING** | ❌ | `UpdateAutomationTaskInput` exists in model; mutation not wired in `schema.py` |
+| `create_rupture_generation_task` | ✅ | ✅ | — |
+| `update_rupture_generation_task` | ✅ | ✅ | — |
+| `create_rupture_set` | ✅ | ✅ | — |
+| `create_file` | ✅ | ✅ | — |
+| `create_sms_file` | ✅ | ✅ | — |
+| `create_sms_file_link` | ❌ **MISSING** | ❌ | Legacy also had commented-out test |
+| `create_strong_motion_station` | ✅ | ✅ | — |
+| `update_strong_motion_station` | ❌ **MISSING** | ❌ | Legacy test was skipped |
+| `create_table` | ✅ | ✅ | `name` field not in POC input |
+| `create_task_relation` | ✅ | ✅ | — |
+| `create_file_relation` | ✅ | ✅ | — |
+| `create_inversion_solution` | ✅ | ✅ | — |
+| `append_inversion_solution_tables` | ✅ | ✅ | — |
+| `create_scaled_inversion_solution` | ✅ | ✅ | — |
+| `create_aggregate_inversion_solution` | ✅ | ✅ | — |
+| `create_time_dependent_inversion_solution` | ✅ | ✅ | — |
+| `create_inversion_solution_nrml` | ✅ | ❌ **NOT TESTED** | Mutation in schema; model complete; zero tests |
+| `create_openquake_hazard_config` | ✅ | ✅ | InversionSolutionNrml source_models case untested |
+| `create_openquake_hazard_solution` | ✅ | ⚠️ | `csv_archive`, `hdf5_archive`, `task_args`, predecessors not tested |
+| `create_openquake_hazard_task` | ✅ | ⚠️ | `srm_logic_tree`, `gmcm_logic_tree`, `openquake_config` fields not tested; DISAGG variant not tested |
+| `update_openquake_hazard_task` | ✅ | ✅ | — |
+| `reindex` | ✅ | ✅ | POC addition; no legacy equivalent |
+
+---
+
+## 5. Fields Gap Table
+
+Fields present in legacy schema but absent or different in POC model classes.
+
+### AutomationTask / RuptureGenerationTask (POC: `models/automation_task.py`)
+
+| Legacy field | POC model field | Status |
+|---|---|---|
+| `model_type` (ModelType enum) | `model_type` | ✅ present |
+| `task_type` (TaskSubType enum) | `task_type` | ✅ present |
+| `state`, `result` | `state`, `result` | ✅ present |
+| `duration`, `created`, `updated` | `duration`, `created`, `updated` | ✅ present |
+| `arguments`, `environment`, `metrics` | `arguments`, `environment`, `metrics` | ✅ present |
+| `parents`, `children`, `files` (connections) | `parents`, `children`, `files` | ✅ present |
+| `git_refs` (legacy field, migrated to `environment`) | Not present | ⚠️ legacy migration path untested |
+
+### GeneralTask (POC: `models/general_task.py`)
+
+| Legacy field | POC model field | Status |
+|---|---|---|
+| All core fields | All present | ✅ |
+
+### InversionSolution (POC: `models/inversion_solution.py`)
+
+| Legacy field | POC model field | Status |
+|---|---|---|
+| `mfd_table_id`, `mfd_table` | ✅ present | ✅ |
+| `hazard_table_id`, `hazard_table` | ✅ present | ✅ |
+| `tables` (LabelledTableRelation list) | ✅ present | ✅ |
+| `produced_by` | ✅ present | ✅ |
+| `post_url` | ✅ present (not tested) | ⚠️ |
+| `relations` (total_count, edges) | ✅ present | ✅ |
+
+### Table (POC: `models/table.py`)
+
+| Legacy field | POC model field | Status |
+|---|---|---|
+| `name` | **Not present** | ❌ missing — used by nzshm-runzi bugfix 252 |
+| `column_headers`, `column_types`, `rows` | ✅ present | ✅ |
+| `meta`, `dimensions`, `table_type`, `object_id` | ✅ present | ✅ |
+
+### OpenquakeHazardTask (POC: `models/openquake_hazard_task.py`)
+
+| Legacy field | POC model field | Status |
+|---|---|---|
+| `srm_logic_tree`, `gmcm_logic_tree`, `openquake_config` | ✅ present | ✅ (not tested) |
+| `model_type` | ✅ present | ✅ (not tested) |
+| `config` (resolved) | ✅ present | ✅ (not tested) |
+| `hazard_solution` (resolved) | ✅ present | ✅ |
+| `executor` | ✅ present | ✅ |
+
+### OpenquakeHazardSolution (POC: `models/openquake_hazard_solution.py`)
+
+| Legacy field | POC model field | Status |
+|---|---|---|
+| `csv_archive`, `hdf5_archive`, `task_args` | ✅ present | ✅ (not tested) |
+| `predecessors` | ✅ present | ✅ (not tested) |
+| `task_type` | ✅ present | ✅ |
+| `metrics` | ✅ present | ✅ |
+| `modified_config` | **Not in legacy tests** | N/A |
+
+### RuptureSet (POC: `models/rupture_set.py`)
+
+| Legacy field | POC model field | Status |
+|---|---|---|
+| `fault_models` | ✅ present | ✅ |
+| `post_url`, `post_url_v2` | `post_url` present; `post_url_v2` not present | ⚠️ `post_url_v2` missing |
+| `metrics` | ✅ present | ✅ |
+
+### SmsFile (POC: `models/sms_file.py`)
+
+| Legacy field | POC model field | Status |
+|---|---|---|
+| `file_type` (SmsFileType enum) | ✅ present | ✅ |
+| `relations` | ✅ present | ✅ |
+| `post_url` | ✅ present (not tested) | ⚠️ |
+
+### StrongMotionStation (POC: `models/strong_motion_station.py`)
+
+| Legacy field | POC model field | Status |
+|---|---|---|
+| `site_code`, `site_class`, `site_class_basis` | ✅ present | ✅ |
+| `Vs30_mean` | ✅ present | ✅ |
+| `liquefiable` | ✅ present | ✅ (not explicitly tested) |
+| `updated` | ✅ present | ✅ |
+
+### InversionSolutionNrml (POC: `models/inversion_solution_nrml.py`)
+
+| Legacy field | POC model field | Status |
+|---|---|---|
+| `source_solution` (SourceSolutionUnion) | ✅ present | ✅ (not tested) |
+| `predecessors` | ✅ present | ✅ (not tested) |
+| `file_name`, `md5_digest`, `file_size` | ✅ present | ✅ (not tested) |
+
+---
+
+## 6. Priorities for New POC Tests
+
+The following gaps represent the highest-value work to close, ordered by severity:
+
+1. **`update_automation_task` mutation** — add the mutation to `schema.py` and create `tests/test_automation_task.py` covering state/result/duration/metrics update and ES re-indexing.
+
+2. **`nodes(id_in: [...])` with deep interface expansion** — add a test that fetches a `ScaledInversionSolution` through `nodes`, expands `InversionSolutionInterface.produced_by`, then expands `AutomationTaskInterface.parents` to retrieve the parent `GeneralTask`. This directly mirrors the weka client query pattern from `test_nodes_bugfix_220.py`.
+
+3. **`InversionSolutionNrml` test file** — create `tests/test_inversion_solution_nrml.py` covering: create from IS, ScaledIS, TDIS; with predecessors; node lookup; verify `source_solution` union resolution.
+
+4. **DISAGG task type** — add test for `create_openquake_hazard_task` with `task_type: DISAGG` to `test_openquake.py`.
+
+5. **`srm_logic_tree` / `gmcm_logic_tree` / `openquake_config` JSON round-trip** — extend `test_openquake.py` to set and verify these fields.
+
+6. **`OpenquakeHazardSolution` full fields** — extend `test_openquake.py` to test `csv_archive`, `hdf5_archive`, `task_args`, and predecessors.
+
+7. **Table `name` field** — add `name` to `CreateTableInput` and `Table` model, then add test.
+
+8. **`create_file` type coercion** — add a test asserting `file_size` accepts integer values and rejects non-numeric strings.
+
+9. **Rupture set upload / `post_url`** — if S3 integration is in scope, add a presigned URL test.
+
+10. **`update_automation_task` ES re-indexing** — verify the updated document body is sent to ES (mirrors `test_automation_task_mutation_deep.py`).

--- a/spike/strawberry_poc/README.md
+++ b/spike/strawberry_poc/README.md
@@ -1,0 +1,247 @@
+# Strawberry / FastAPI POC
+
+A side-by-side spike in `spike/strawberry_poc/` that evaluates replacing the current
+Graphene 3 / Flask / PynamoDB stack with Strawberry / FastAPI / boto3 while keeping
+the existing DynamoDB tables and GraphQL API surface unchanged.
+
+## What this is
+
+The current production API (`graphql_api/`) has 44 schema types across 21 files,
+written in Graphene 3 + Flask. It works but is verbose — every type requires a
+`class Meta`, a separate `Connection`, and an `Input` inner class. PynamoDB adds
+another abstraction layer for DynamoDB access.
+
+This POC implements a representative slice of the same API using Strawberry
+(the modern, type-hint-first GraphQL library that has largely displaced Graphene
+in the Python community). The goal was not to rewrite everything — just to exercise
+the hardest problems and produce concrete feasibility signals.
+
+### Types implemented
+
+| Type | Why it was chosen |
+|------|-------------------|
+| `GeneralTask` | Simplest Thing-table record; create + update mutations |
+| `RuptureSet` | File-table record with a `produced_by` relation (union type stress-test) |
+| `RuptureGenerationTask` | Stub; the union member that `produced_by` resolves to |
+| `ToshiFile` | Base file type; covers File-table + relay Node pattern |
+
+Together these exercise: relay Node + Connection, union types, both DynamoDB tables
+(ToshiThingObject and ToshiFileObject), create/update mutations, and relay global IDs.
+
+### Structure
+
+```
+spike/strawberry_poc/
+  app.py               FastAPI + Mangum Lambda entry point
+  schema.py            Root Query + Mutation (~80 lines vs 311 in the original)
+  models/
+    general_task.py    GeneralTask type, input types, resolvers
+    rupture_set.py     RuptureSet + RuptureGenerationTask + union type
+    file.py            ToshiFile type
+    common.py          KeyValuePair, enums (TaskSubType, ModelType)
+  data/
+    dynamo.py          Thin boto3 wrapper: get/create/update/list for Thing + File tables
+    ids.py             ToshiIdentity counter + append_uniq (same logic as base_data.py)
+  tests/
+    conftest.py        moto mock_aws fixtures (same pattern as graphql_api/tests/)
+    test_general_task.py
+    test_rupture_set.py
+  pyproject.toml       Standalone deps: strawberry-graphql[fastapi], boto3, mangum
+```
+
+## Running the tests
+
+```bash
+cd spike/strawberry_poc
+uv run pytest -v
+```
+
+All 44 tests run via `uv run pytest`. No manual service startup needed —
+testcontainers pulls and starts `amazon/dynamodb-local` and
+`elasticsearch:7.1.0` automatically via Docker.
+
+### Docker-in-Docker constraint
+
+All 44 passing tests require Docker (DynamoDB Local + Elasticsearch containers).
+This is fine in CI (GitHub Actions `ubuntu-latest` runs on VMs, not containers)
+but breaks in any environment that is itself a Docker container — e.g. the
+`pyup`/security-patching tool.
+
+**Workaround options:**
+
+| Option | Notes |
+|--------|-------|
+| `pytest -m "not docker"` | Skip container-dependent tests; add `@pytest.mark.docker` to mark them. Fast, portable, no Docker needed. Suitable for dep-bump regression checks. |
+| Socket mount | Pass `-v /var/run/docker.sock:/var/run/docker.sock` to the outer container. Spawned containers become siblings on the host daemon. Works, but gives full Docker access — a concern for a security tool. |
+| Testcontainers Cloud | Docker's commercial product (free tier for OSS). Library talks to a remote Docker host; no local socket needed. Requires `TESTCONTAINERS_CLOUD_TOKEN`. |
+
+Recommended: use `pytest -m "not docker"` in containerised environments and
+let CI run the full suite.
+
+The tests use `moto` to mock DynamoDB and call `schema.execute_sync()` directly —
+no HTTP server required, same pattern as the existing test suite.
+
+## What the tests verify
+
+### `test_general_task.py`
+
+| Test | What it confirms |
+|------|-----------------|
+| `test_create_returns_id` | relay GlobalID is `base64("GeneralTask:<raw_id>")` — **identical to Graphene encoding** |
+| `test_create_fields` | All scalar fields (str, int, enum, list of KV pairs) round-trip cleanly |
+| `test_swept_arguments` | Computed fields (`@strawberry.field`) work alongside stored fields |
+| `test_list_general_tasks` | `relay.ListConnection` + boto3 scan return correct edges |
+| `test_node_lookup` | `node(id: ...)` interface dispatches to the correct type via `resolve_node` |
+| `test_update_general_task` | Partial-update mutation preserves unset fields; returns updated values |
+| `test_update_preserves_id` | Update does not change the relay global ID |
+
+### `test_rupture_set.py`
+
+| Test | What it confirms |
+|------|-----------------|
+| `test_rupture_set_id_encoding` | File-table IDs encode correctly (`RuptureSet:...`) |
+| `test_rupture_gen_task_id_encoding` | Thing-table IDs encode correctly (`RuptureGenerationTask:...`) |
+| `test_rupture_set_fields` | File fields (md5, size, fault_models, metrics) round-trip |
+| `test_produced_by_resolved` | Lazy `produced_by` resolver crosses from File table → Thing table |
+| `test_list_rupture_sets` | File-table list query works independently of Thing-table list |
+| `test_node_lookup` | `node(id: ...)` resolves a RuptureSet and eagerly loads `produced_by` |
+| `test_relay_ids_are_different_types` | File and Thing objects have distinct type prefixes in their IDs |
+
+## Feasibility signals
+
+| Signal | Result | Notes |
+|--------|--------|-------|
+| relay GlobalID encoding | **Compatible with Graphene** | Both use `base64("TypeName:id")` — existing client code and stored IDs work unchanged |
+| `relay.NodeID` pattern | **Clean** | `pk: relay.NodeID[str]` on each type; strawberry handles GlobalID wrapping automatically |
+| `relay.ListConnection` | **Works out of the box** | No custom `Connection` class needed (removes ~1/3 of Graphene boilerplate) |
+| Union types | **Clean** | `strawberry.Private` + lazy `@strawberry.field` for `produced_by`; no `is_type_of` hacks |
+| FastAPI + Mangum | **Drop-in** | `handler = Mangum(app)` replaces `serverless-wsgi`; same Lambda handler interface |
+| Schema verbosity | **~3× reduction** | `schema.py` is 80 lines; Graphene equivalent is 311 lines for same surface area |
+| moto test pattern | **Reusable** | `conftest.py` is identical in structure to `graphql_api/tests/conftest.py` |
+| DynamoDB data migration | **Not required** | Same tables, same JSON layout (`object_content` column) — boto3 reads existing data |
+
+**Version note:** strawberry ≥ 0.300 requires `pk: relay.NodeID[str]` on every
+`relay.Node` subclass. Earlier tutorials and docs show manual `relay.GlobalID(...)` construction
+— that pattern no longer works. Tested against **0.314.3**.
+
+## Pydantic integration experiment
+
+The POC uses Pydantic v2 as a data validation layer between DynamoDB raw dicts and Strawberry
+types. Two integration depths were evaluated:
+
+### Phase 1 — Pydantic as a validation layer (adopted)
+
+`data/models.py` defines one `BaseModel` per DynamoDB type. Each Strawberry type's `from_dict`
+calls `XxxData.model_validate(raw_dict)` for type-safe field access and early validation.
+The Pydantic models and Strawberry types are separate; `from_dict` bridges them.
+
+This is the approach in use. It is straightforward, predictable, and the tests pass unchanged.
+
+### Option C — `strawberry.experimental.pydantic` (evaluated, not adopted)
+
+`@strawberry.experimental.pydantic.type(model=...)` can compose with `relay.Node`. The recipe
+that works:
+
+```python
+@strawberry.experimental.pydantic.type(model=GeneralTaskData)
+class GeneralTask(relay.Node):
+    pk: relay.NodeID[str]          # not in Pydantic model → passed via extra={}
+    title: strawberry.auto         # auto-mapped from Pydantic field
+    subtask_type: strawberry.auto  # works only if Pydantic field type IS the enum
+    argument_lists: strawberry.auto  # works if nested type is also pydantic-experimental
+    files_raw: strawberry.Private[list]
+```
+
+`from_pydantic(model, extra={"pk": ..., "files_raw": ...})` handles conversion. `resolve_node`,
+`@strawberry.field`, and `strawberry.Private` all survive the decorator. `relay.ListConnection`
+generates `Connection`/`Edge` types correctly.
+
+**Why not adopted:**
+
+1. **All-or-nothing coupling.** Every nested type (`KeyValuePair`, `KeyValueListPair`) must also
+   be pydantic-experimental, and `data/models.py` must use enum types (not `str`) so Pydantic
+   coerces values before `from_pydantic` sees them. Any type that is not pydantic-experimental
+   causes `from_pydantic` to fail with a confusing `AttributeError`.
+
+2. **Custom classmethods are dropped.** The decorator rebuilds the class and strips any classmethod
+   not part of the relay interface (e.g. `from_dict`). These must become module-level functions.
+
+3. **Experimental label is load-bearing.** Strawberry has changed this API across minor versions.
+   The `strawberry.auto` annotation and `from_pydantic` signature have both shifted in 0.2xx→0.3xx.
+
+Revisit if Strawberry stabilises the pydantic experimental API in a future major release.
+
+## What remains for a full migration
+
+The POC covers the hard architectural problems. A full migration would be a significant
+but well-understood effort.
+
+### Schema types (44 total, 3 implemented here)
+
+The remaining ~41 types follow the same patterns shown here:
+
+- **Thing types** (stored in `ToshiThingObject`): `AutomationTask`, `RuptureGenerationTask`
+  (full, not stub), `InversionSolution`, `TimeDependentInversionSolution`, `OpenquakeHazardTask`,
+  `OpenquakeHazardSolution`, `AggregateInversionSolution`, `ScaledInversionSolution`,
+  `SubductionInversionSolution`, and ~15 more.
+- **File types** (stored in `ToshiFileObject`): `InversionSolutionFile`,
+  `OpenquakeHazardTaskResult`, `GrandInversionStats`, `LabelledTableRelation`, and ~10 more.
+- **Table types** (stored in `ToshiTableObject`): `StrongMotionStation`, `GroundMotionTable`,
+  `GriddedHazard`, and others.
+- **Relation types**: `FileRelation`, `TaskTaskRelation`, `PredecessorsInterface` —
+  these link objects together and need the same lazy-resolver pattern as `produced_by`.
+
+### Data layer
+
+- `data/dynamo.py` needs a `_table_table` path for `ToshiTableObject` (trivial copy of
+  the Thing/File equivalents).
+- S3 fallback read (legacy data not yet in DynamoDB) — currently omitted. The existing
+  `base_data.py` S3 fallback logic can be ported as a decorator or fallback in `get_thing` /
+  `get_file`.
+- Elasticsearch indexing on write — currently omitted. The existing `ThingData.index_search()`
+  / `FileData.index_search()` calls can be added as post-write hooks in `create_thing` and
+  `create_file`.
+- **ID allocation transaction guard** — the POC's `create_thing` / `create_file` increment
+  the ToshiIdentity counter and save the object as two separate DynamoDB calls. The production
+  code (`base_data._write_object`, line 350) does both atomically via PynamoDB `TransactWrite`,
+  with an exponential-backoff retry on contention. Three things to restore:
+  1. Replace the two-call pattern with a single `boto3` `transact_write_items` that increments
+     the counter and saves the object together
+  2. Add a `backoff` retry on `ClientError` / `TransactionConflict` error code
+  3. Re-add the pre-write consistency check (`identity.object_id == expected_id`) that raises
+     `DynamoWriteConsistencyError` on mismatch
+
+### Auth
+
+The Lambda Authorizer (`spike/auth/authorizer/handler.py`) is already decoupled from the
+web framework — it runs at API Gateway before the request reaches the app. No changes needed.
+
+For request-level scope enforcement (read vs write), the `spike/auth/middleware.py`
+Flask `before_request` hook needs porting to a FastAPI dependency:
+
+```python
+# Strawberry equivalent of the Flask middleware
+async def require_auth(info: Info) -> None:
+    request = info.context["request"]
+    scopes = request.state.authorizer.get("scopes", [])
+    if "toshi/write" not in scopes:
+        raise PermissionError("write scope required")
+```
+
+### Testing
+
+- The existing 11,796-line test suite uses `graphene.test.Client` and Graphene-specific
+  query patterns. Most query strings are reusable (same GraphQL shape), but the client
+  wrapper and assertion helpers need updating to `schema.execute_sync()`.
+- With module-scoped moto fixtures (as used here), a full suite run should be comparable
+  in speed to the current suite.
+
+### Deployment
+
+- Replace `serverless-wsgi` with `mangum` in `serverless.yml` (handler path changes from
+  `graphql_api/wsgi_handler.handler` to `app.handler`).
+- `requirements.txt` / `pyproject.toml` gains `strawberry-graphql[fastapi]`, `mangum`;
+  loses `Flask`, `graphene`, `PynamoDB`.
+- Cold start impact is worth measuring — FastAPI startup is heavier than Flask, but Mangum
+  adds negligible overhead. Strawberry schema compilation happens at import time (same as
+  Graphene).

--- a/spike/strawberry_poc/app.py
+++ b/spike/strawberry_poc/app.py
@@ -1,0 +1,49 @@
+"""
+FastAPI + Mangum entry point.
+
+Replaces Flask + serverless-wsgi. The Lambda handler is `app.handler`.
+
+Local dev:
+    uvicorn app:app --reload
+    # GraphQL playground at http://localhost:8000/graphql
+
+Lambda deploy:
+    handler: spike/strawberry_poc/app.handler
+    (adjust serverless.yml function definition)
+"""
+
+import os
+
+import boto3
+from fastapi import FastAPI, Request
+from mangum import Mangum
+from strawberry.fastapi import GraphQLRouter
+
+from data.search import es_endpoint, es_index
+from schema import schema
+
+app = FastAPI(title="nshm-toshi-api (Strawberry POC)")
+
+
+async def get_context(request: Request) -> dict:
+    """
+    Inject shared resources into the GraphQL context.
+
+    In production, boto3 resource is created once per Lambda container.
+    In tests, the moto-patched resource is passed via request.state.
+    ES_ENDPOINT/ES_INDEX can be overridden via env vars or request.state.
+    """
+    dynamodb = getattr(request.state, "dynamodb", None) or boto3.resource("dynamodb", region_name="ap-southeast-2")
+    return {
+        "dynamodb": dynamodb,
+        "es_endpoint": getattr(request.state, "es_endpoint", None) or es_endpoint(),
+        "es_index": getattr(request.state, "es_index", None) or es_index(),
+        "request": request,
+    }
+
+
+graphql_router = GraphQLRouter(schema, context_getter=get_context)  # type: ignore[arg-type]
+app.include_router(graphql_router, prefix=os.environ.get("GRAPHQL_PATH", "/graphql"))
+
+# Lambda entry point — replaces serverless-wsgi's wsgi_handler.handler
+handler = Mangum(app)

--- a/spike/strawberry_poc/data/dynamo.py
+++ b/spike/strawberry_poc/data/dynamo.py
@@ -1,0 +1,494 @@
+"""
+Thin boto3 wrapper for the three Toshi DynamoDB tables.
+
+Replaces PynamoDB entirely. The DynamoDB table layout is unchanged:
+  - object_id   (String, hash key)
+  - object_type (String) — the Python class name, e.g. "GeneralTask"
+  - object_content (String) — JSON-encoded payload dict
+
+Reading existing data requires no migration — same tables, same JSON.
+"""
+
+import json
+import logging
+import os
+import random
+import time
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+from .ids import append_uniq, read_current_id
+from .search import index_document
+
+logger = logging.getLogger(__name__)
+
+STAGE = os.environ.get("DEPLOYMENT_STAGE", "dev").upper()
+REGION = os.environ.get("REGION", "ap-southeast-2")
+S3_BUCKET_NAME = os.environ.get("S3_BUCKET_NAME", "")
+DB_READ_ONLY = os.environ.get("DB_READ_ONLY", "") not in ("", "0")
+
+
+def _assert_writable() -> None:
+    if DB_READ_ONLY:
+        raise RuntimeError("Aborting write: DB_READ_ONLY is set")
+
+
+def _dynamodb(endpoint_url: str | None = None):
+    kwargs: dict[str, Any] = {"region_name": REGION}
+    if endpoint_url:
+        kwargs["endpoint_url"] = endpoint_url
+    return boto3.resource("dynamodb", **kwargs)
+
+
+def _thing_table(dynamodb, stage: str = STAGE):
+    return dynamodb.Table(f"ToshiThingObject-{stage}")
+
+
+def _file_table(dynamodb, stage: str = STAGE):
+    return dynamodb.Table(f"ToshiFileObject-{stage}")
+
+
+def _table_table(dynamodb, stage: str = STAGE):
+    return dynamodb.Table(f"ToshiTableObject-{stage}")
+
+
+# ── Type → table routing ─────────────────────────────────────────────────────
+THING_CLASSES: frozenset[str] = frozenset(
+    {
+        "GeneralTask",
+        "AutomationTask",
+        "RuptureGenerationTask",
+        "StrongMotionStation",
+        "OpenquakeHazardTask",
+        "OpenquakeHazardSolution",
+        "OpenquakeHazardConfig",
+    }
+)
+FILE_CLASSES: frozenset[str] = frozenset(
+    {
+        "ToshiFile",
+        "File",
+        "SmsFile",
+        "RuptureSet",
+        "InversionSolution",
+        "ScaledInversionSolution",
+        "AggregateInversionSolution",
+        "TimeDependentInversionSolution",
+        "InversionSolutionNrml",
+    }
+)
+# Extend as table-backed models are added to the schema.
+TABLE_CLASSES: frozenset[str] = frozenset(
+    {
+        "Table",
+        "GroundMotionTable",
+        "GriddedHazard",
+    }
+)
+
+
+def get_object(dynamodb, type_name: str, object_id: str, stage: str = STAGE) -> dict | None:
+    """Fetch a single object from the correct table by Strawberry type name."""
+    if type_name in THING_CLASSES:
+        return get_thing(dynamodb, object_id, stage)
+    if type_name in FILE_CLASSES:
+        return get_file(dynamodb, object_id, stage)
+    if type_name in TABLE_CLASSES:
+        return get_table(dynamodb, object_id, stage)
+    return None
+
+
+def es_key_for(type_name: str, object_id: str) -> str:
+    """Return the Elasticsearch document key used during indexing."""
+    if type_name in THING_CLASSES:
+        return f"ThingData_{object_id}"
+    if type_name in TABLE_CLASSES:
+        return f"TableData_{object_id}"
+    return f"FileData_{object_id}"
+
+
+# ── S3 fallback (legacy objects not yet migrated to DynamoDB) ─────────────────
+
+
+def _from_s3(object_id: str, prefix: str) -> dict | None:
+    """
+    Read object.json from S3 for legacy objects not in DynamoDB.
+    Key format: {prefix}/{object_id}/object.json  (matches base_data._from_s3).
+    Returns None if S3_BUCKET_NAME is unset or the object doesn't exist.
+    """
+    if not S3_BUCKET_NAME:
+        return None
+    key = f"{prefix}/{object_id}/object.json"
+    try:
+        s3 = boto3.client("s3", region_name=REGION)
+        obj = s3.get_object(Bucket=S3_BUCKET_NAME, Key=key)
+        return json.loads(obj["Body"].read())
+    except Exception as exc:
+        logger.debug("S3 fallback miss for %s/%s: %s", prefix, object_id, exc)
+        return None
+
+
+# ── Atomic ID allocation ──────────────────────────────────────────────────────
+
+
+def _atomic_put(dynamodb, dest_table_name: str, clazz_name: str, payload: dict, stage: str) -> str:
+    """
+    Atomically increment ToshiIdentity and write the object in a single
+    transact_write_items call. A conditional check on the counter value
+    ensures no two concurrent writers get the same ID; TransactionCanceledException
+    triggers an exponential-backoff retry with a fresh counter read.
+
+    Mirrors base_data._write_object / PynamoDB TransactWrite pattern.
+    Requires real DynamoDB (Local or AWS) — moto 5.x does not support
+    transact_write_items across two tables.
+    """
+    # boto3 resource.meta.client has a serialization issue when used for raw
+    # low-level calls — create a fresh client from the same endpoint instead.
+    endpoint_url = str(dynamodb.meta.client.meta.endpoint_url)
+    client = boto3.client("dynamodb", endpoint_url=endpoint_url, region_name=REGION)
+
+    for attempt in range(10):
+        current_id = read_current_id(dynamodb, stage)
+        object_id = append_uniq(current_id)
+        try:
+            client.transact_write_items(
+                TransactItems=[
+                    {
+                        "Update": {
+                            "TableName": f"ToshiIdentity-{stage}",
+                            "Key": {"table_name": {"S": stage}},
+                            "UpdateExpression": "SET object_id = object_id + :inc",
+                            "ConditionExpression": "object_id = :cur",
+                            "ExpressionAttributeValues": {
+                                ":inc": {"N": "1"},
+                                ":cur": {"N": str(current_id)},
+                            },
+                        }
+                    },
+                    {
+                        "Put": {
+                            "TableName": dest_table_name,
+                            "Item": {
+                                "object_id": {"S": object_id},
+                                "object_type": {"S": clazz_name},
+                                "object_content": {"S": json.dumps(payload)},
+                            },
+                        }
+                    },
+                ]
+            )
+            return object_id
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] not in ("TransactionCanceledException", "TransactionConflictException"):
+                raise
+            wait = (2**attempt) * 0.05 + random.uniform(0, 0.05)
+            logger.debug("TransactionCanceledException attempt %d; retrying in %.2fs", attempt, wait)
+            time.sleep(wait)
+
+    raise RuntimeError("Failed to write object after 10 attempts (persistent TransactionCanceledException)")
+
+
+# ── Thing table (GeneralTask, AutomationTask, etc.) ──────────────────────────
+
+
+def get_thing(dynamodb, object_id: str, stage: str = STAGE) -> dict | None:
+    resp = _thing_table(dynamodb, stage).get_item(Key={"object_id": object_id})
+    item = resp.get("Item")
+    if item:
+        data = json.loads(item["object_content"])
+        data["object_id"] = object_id
+        return data
+    data = _from_s3(object_id, "ThingData")
+    if data is not None:
+        data["object_id"] = object_id
+    return data
+
+
+def create_thing(dynamodb, clazz_name: str, payload: dict, stage: str = STAGE) -> dict:
+    _assert_writable()
+    payload = {k: v for k, v in payload.items() if v is not None}
+    payload["clazz_name"] = clazz_name
+    object_id = _atomic_put(dynamodb, f"ToshiThingObject-{stage}", clazz_name, payload, stage)
+    payload["object_id"] = object_id
+    index_document(f"ThingData_{object_id}", payload)
+    return payload
+
+
+def update_thing(dynamodb, object_id: str, payload: dict, stage: str = STAGE) -> dict | None:
+    _assert_writable()
+    existing = get_thing(dynamodb, object_id, stage)
+    if existing is None:
+        return None
+    updated = {**existing, **{k: v for k, v in payload.items() if v is not None}}
+    _thing_table(dynamodb, stage).put_item(
+        Item={
+            "object_id": object_id,
+            "object_type": updated.get("clazz_name", ""),
+            "object_content": json.dumps({k: v for k, v in updated.items() if k != "object_id"}),
+        }
+    )
+    index_document(f"ThingData_{object_id}", updated)
+    return updated
+
+
+def list_things(dynamodb, clazz_name: str, stage: str = STAGE) -> list[dict]:
+    """Return all items of clazz_name, exhausting DynamoDB pages."""
+    table = _thing_table(dynamodb, stage)
+    kwargs: dict[str, Any] = {
+        "FilterExpression": "object_type = :t",
+        "ExpressionAttributeValues": {":t": clazz_name},
+    }
+    results = []
+    while True:
+        resp = table.scan(**kwargs)
+        for item in resp.get("Items", []):
+            data = json.loads(item["object_content"])
+            data["object_id"] = item["object_id"]
+            results.append(data)
+        last = resp.get("LastEvaluatedKey")
+        if not last:
+            break
+        kwargs["ExclusiveStartKey"] = last
+    return results
+
+
+# ── File table (RuptureSet, InversionSolution, File, etc.) ───────────────────
+
+
+def get_file(dynamodb, object_id: str, stage: str = STAGE) -> dict | None:
+    resp = _file_table(dynamodb, stage).get_item(Key={"object_id": object_id})
+    item = resp.get("Item")
+    if item:
+        data = json.loads(item["object_content"])
+        data["object_id"] = object_id
+        return data
+    data = _from_s3(object_id, "FileData")
+    if data is not None:
+        data["object_id"] = object_id
+    return data
+
+
+def create_file(dynamodb, clazz_name: str, payload: dict, stage: str = STAGE) -> dict:
+    _assert_writable()
+    payload = {k: v for k, v in payload.items() if v is not None}
+    payload["clazz_name"] = clazz_name
+    object_id = _atomic_put(dynamodb, f"ToshiFileObject-{stage}", clazz_name, payload, stage)
+    payload["object_id"] = object_id
+    index_document(f"FileData_{object_id}", payload)
+    return payload
+
+
+def list_files(dynamodb, clazz_name: str, stage: str = STAGE) -> list[dict]:
+    """Return all items of clazz_name, exhausting DynamoDB pages."""
+    table = _file_table(dynamodb, stage)
+    kwargs: dict[str, Any] = {
+        "FilterExpression": "object_type = :t",
+        "ExpressionAttributeValues": {":t": clazz_name},
+    }
+    results = []
+    while True:
+        resp = table.scan(**kwargs)
+        for item in resp.get("Items", []):
+            data = json.loads(item["object_content"])
+            data["object_id"] = item["object_id"]
+            results.append(data)
+        last = resp.get("LastEvaluatedKey")
+        if not last:
+            break
+        kwargs["ExclusiveStartKey"] = last
+    return results
+
+
+# ── Table table (GroundMotionTable, GriddedHazard, etc.) ─────────────────────
+
+
+def get_table(dynamodb, object_id: str, stage: str = STAGE) -> dict | None:
+    resp = _table_table(dynamodb, stage).get_item(Key={"object_id": object_id})
+    item = resp.get("Item")
+    if not item:
+        return None
+    data = json.loads(item["object_content"])
+    data["object_id"] = object_id
+    return data
+
+
+def create_table(dynamodb, clazz_name: str, payload: dict, stage: str = STAGE) -> dict:
+    _assert_writable()
+    payload = {k: v for k, v in payload.items() if v is not None}
+    payload["clazz_name"] = clazz_name
+    object_id = _atomic_put(dynamodb, f"ToshiTableObject-{stage}", clazz_name, payload, stage)
+    payload["object_id"] = object_id
+    index_document(f"TableData_{object_id}", payload)
+    return payload
+
+
+def list_tables(dynamodb, clazz_name: str, stage: str = STAGE) -> list[dict]:
+    """Return all items of clazz_name, exhausting DynamoDB pages."""
+    table = _table_table(dynamodb, stage)
+    kwargs: dict[str, Any] = {
+        "FilterExpression": "object_type = :t",
+        "ExpressionAttributeValues": {":t": clazz_name},
+    }
+    results = []
+    while True:
+        resp = table.scan(**kwargs)
+        for item in resp.get("Items", []):
+            data = json.loads(item["object_content"])
+            data["object_id"] = item["object_id"]
+            results.append(data)
+        last = resp.get("LastEvaluatedKey")
+        if not last:
+            break
+        kwargs["ExclusiveStartKey"] = last
+    return results
+
+
+# ── Paginated scan (for object_identities query) ──────────────────────────────
+
+
+def scan_objects_paginated(
+    dynamodb,
+    object_type: str,
+    limit: int = 5,
+    after_id: str | None = None,
+    stage: str = STAGE,
+) -> tuple[list[dict], bool, str | None]:
+    """Page through one DynamoDB table filtered to object_type.
+
+    Returns (items, has_more, last_object_id).  Uses ExclusiveStartKey for
+    efficient forward pagination — after_id is the object_id of the last item
+    from the previous page (decoded from the cursor by the caller).
+    """
+    if object_type in THING_CLASSES:
+        table = _thing_table(dynamodb, stage)
+    elif object_type in FILE_CLASSES:
+        table = _file_table(dynamodb, stage)
+    elif object_type in TABLE_CLASSES:
+        table = _table_table(dynamodb, stage)
+    else:
+        return [], False, None
+
+    results: list[dict] = []
+    last_id: str | None = None
+    kwargs: dict[str, Any] = {
+        "FilterExpression": "object_type = :t",
+        "ExpressionAttributeValues": {":t": object_type},
+    }
+    if after_id:
+        kwargs["ExclusiveStartKey"] = {"object_id": after_id}
+
+    while len(results) < limit:
+        resp = table.scan(**kwargs)
+        for item in resp.get("Items", []):
+            data = json.loads(item["object_content"])
+            data["object_id"] = item["object_id"]
+            results.append(data)
+            last_id = item["object_id"]
+            if len(results) >= limit:
+                break
+        last_key = resp.get("LastEvaluatedKey")
+        if not last_key or len(results) >= limit:
+            break
+        kwargs["ExclusiveStartKey"] = last_key
+
+    has_more = len(results) >= limit
+    return results[:limit], has_more, last_id
+
+
+# ── Relation helpers ──────────────────────────────────────────────────────────
+# Relations are stored as embedded arrays within the parent objects, NOT as
+# separate DynamoDB records. This mirrors the production pattern in
+# file_relation_data.py and thing_relation_data.py.
+
+
+def _patch_thing(dynamodb, object_id: str, patch_fn, stage: str = STAGE) -> None:
+    """Read a thing, apply patch_fn to its data dict, write it back."""
+    table = _thing_table(dynamodb, stage)
+    item = table.get_item(Key={"object_id": object_id}).get("Item")
+    if not item:
+        raise ValueError(f"Thing {object_id} not found")
+    data = json.loads(item["object_content"])
+    patch_fn(data)
+    table.put_item(
+        Item={
+            "object_id": object_id,
+            "object_type": item["object_type"],
+            "object_content": json.dumps(data),
+        }
+    )
+
+
+def _patch_file(dynamodb, object_id: str, patch_fn, stage: str = STAGE) -> None:
+    """Read a file, apply patch_fn to its data dict, write it back."""
+    table = _file_table(dynamodb, stage)
+    item = table.get_item(Key={"object_id": object_id}).get("Item")
+    if not item:
+        raise ValueError(f"File {object_id} not found")
+    data = json.loads(item["object_content"])
+    patch_fn(data)
+    table.put_item(
+        Item={
+            "object_id": object_id,
+            "object_type": item["object_type"],
+            "object_content": json.dumps(data),
+        }
+    )
+
+
+def create_file_relation(dynamodb, thing_id: str, file_id: str, role: str, stage: str = STAGE) -> None:
+    _assert_writable()
+    """
+    Append a file↔thing relation to both the Thing and File records.
+
+    Thing.files  → [..., {"file_id": file_id, "file_role": role}]
+    File.relations → [..., {"id": thing_id, "role": role}]
+    """
+    _patch_thing(
+        dynamodb, thing_id, lambda d: d.setdefault("files", []).append({"file_id": file_id, "file_role": role}), stage
+    )
+    _patch_file(
+        dynamodb, file_id, lambda d: d.setdefault("relations", []).append({"id": thing_id, "role": role}), stage
+    )
+    thing_data = get_thing(dynamodb, thing_id, stage)
+    if thing_data:
+        index_document(f"ThingData_{thing_id}", thing_data)
+    file_data = get_file(dynamodb, file_id, stage)
+    if file_data:
+        index_document(f"FileData_{file_id}", file_data)
+
+
+def create_task_relation(
+    dynamodb,
+    parent_id: str,
+    parent_clazz: str,
+    child_id: str,
+    child_clazz: str,
+    stage: str = STAGE,
+) -> None:
+    _assert_writable()
+    """
+    Append a parent↔child task relation to both Thing records.
+
+    Parent.children → [..., {"child_id": child_id, "child_clazz": child_clazz}]
+    Child.parents   → [..., {"parent_id": parent_id, "parent_clazz": parent_clazz}]
+    """
+    _patch_thing(
+        dynamodb,
+        parent_id,
+        lambda d: d.setdefault("children", []).append({"child_id": child_id, "child_clazz": child_clazz}),
+        stage,
+    )
+    _patch_thing(
+        dynamodb,
+        child_id,
+        lambda d: d.setdefault("parents", []).append({"parent_id": parent_id, "parent_clazz": parent_clazz}),
+        stage,
+    )
+    parent_data = get_thing(dynamodb, parent_id, stage)
+    if parent_data:
+        index_document(f"ThingData_{parent_id}", parent_data)
+    child_data = get_thing(dynamodb, child_id, stage)
+    if child_data:
+        index_document(f"ThingData_{child_id}", child_data)

--- a/spike/strawberry_poc/data/ids.py
+++ b/spike/strawberry_poc/data/ids.py
@@ -1,0 +1,40 @@
+"""
+ID allocation and relay GlobalID encoding/decoding.
+
+Replicates the append_uniq + ToshiIdentity pattern from base_data.py,
+using raw boto3 instead of PynamoDB (same DynamoDB table, same layout).
+"""
+
+import os
+import random
+from decimal import Decimal
+
+STAGE = os.environ.get("DEPLOYMENT_STAGE", "dev")
+FIRST_ID = int(os.environ.get("FIRST_DYNAMO_ID", "100000"))
+
+_ALPHABET = list("23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz")
+
+
+def append_uniq(size: int) -> str:
+    """Append a 5-char random suffix — matches existing ID format exactly."""
+    uniq = "".join(random.choice(_ALPHABET) for _ in range(5))
+    return str(size) + uniq
+
+
+def read_current_id(dynamodb, stage: str = STAGE) -> int:
+    """
+    Read the current ToshiIdentity counter without incrementing it.
+    Seeds the counter to FIRST_ID if it doesn't exist yet.
+
+    _atomic_put() in dynamo.py reads this, then increments + saves the object
+    atomically via transact_write_items with a conditional check on the value
+    seen here. On concurrent write (TransactionCanceledException), _atomic_put
+    retries from this call so a fresh value is always used.
+    """
+    table = dynamodb.Table(f"ToshiIdentity-{stage}")
+    resp = table.get_item(Key={"table_name": stage})
+    item = resp.get("Item")
+    if item is None:
+        table.put_item(Item={"table_name": stage, "object_id": Decimal(FIRST_ID)})
+        return FIRST_ID
+    return int(item["object_id"])

--- a/spike/strawberry_poc/data/models.py
+++ b/spike/strawberry_poc/data/models.py
@@ -1,0 +1,226 @@
+"""
+Pydantic data models representing the DynamoDB stored schema.
+
+These are pure data/validation models — no Strawberry or GraphQL concerns.
+Each class mirrors the JSON stored in the `object_content` column of its table.
+
+Convention:
+  - All fields are Optional with None defaults (DynamoDB data may be partial).
+  - Relation arrays (files, parents, children, relations) are kept as list[dict]
+    for compatibility with the existing build_* helpers in models/relations.py.
+  - Enum fields are plain str — conversion to Strawberry enums happens in from_dict.
+  - Nested KV pairs use typed sub-models (KVPairModel, KVListPairModel) to catch
+    malformed entries early with a clear ValidationError.
+"""
+
+from pydantic import BaseModel
+
+# ── Shared sub-models ─────────────────────────────────────────────────────────
+
+
+class KVPairModel(BaseModel):
+    k: str
+    v: str
+
+
+class KVListPairModel(BaseModel):
+    k: str
+    v: list[str]
+
+
+# ── Thing types (ToshiThingObject) ────────────────────────────────────────────
+
+
+class GeneralTaskData(BaseModel):
+    object_id: str
+    clazz_name: str | None = None
+    title: str | None = None
+    description: str | None = None
+    agent_name: str | None = None
+    created: str | None = None
+    updated: str | None = None
+    notes: str | None = None
+    subtask_count: int | None = None
+    subtask_type: str | None = None
+    subtask_result: str | None = None
+    model_type: str | None = None
+    argument_lists: list[KVListPairModel] | None = None
+    meta: list[KVPairModel] | None = None
+    files: list[dict] | None = None
+    children: list[dict] | None = None
+    parents: list[dict] | None = None
+
+
+class AutomationTaskData(BaseModel):
+    object_id: str
+    clazz_name: str | None = None
+    state: str | None = None
+    result: str | None = None
+    task_type: str | None = None
+    model_type: str | None = None
+    created: str | None = None
+    duration: float | None = None
+    general_task_id: str | None = None
+    arguments: list[KVPairModel] | None = None
+    environment: list[KVPairModel] | None = None
+    metrics: list[KVPairModel] | None = None
+    files: list[dict] | None = None
+    parents: list[dict] | None = None
+    children: list[dict] | None = None
+
+
+class StrongMotionStationData(BaseModel):
+    object_id: str
+    clazz_name: str | None = None
+    site_code: str | None = None
+    site_class: str | None = None
+    site_class_basis: str | None = None
+    Vs30_mean: list[float] | None = None
+    Vs30_std_dev: list[float] | None = None
+    liquefiable: bool | None = None
+    bedrock_encountered: bool | None = None
+    soft_clay_or_peat: bool | None = None
+    created: str | None = None
+    updated: str | None = None
+    files: list[dict] | None = None
+
+
+# ── File types (ToshiFileObject) ──────────────────────────────────────────────
+
+
+class ToshiFileData(BaseModel):
+    object_id: str
+    clazz_name: str | None = None
+    file_name: str | None = None
+    md5_digest: str | None = None
+    file_size: int | None = None
+    meta: list[KVPairModel] | None = None
+    created: str | None = None
+    relations: list[dict] | None = None
+
+
+class SmsFileData(ToshiFileData):
+    file_type: str | None = None
+
+
+class LabelledTableRelationEntry(BaseModel):
+    identity: str | None = None
+    created: str | None = None
+    produced_by_id: str | None = None
+    label: str | None = None
+    table_id: str | None = None
+    table_type: str | None = None
+    dimensions: list[KVListPairModel] | None = None
+
+
+class PredecessorEntry(BaseModel):
+    id: str  # relay GlobalID string
+    depth: int
+
+
+class InversionSolutionData(ToshiFileData):
+    metrics: list[KVPairModel] | None = None
+    produced_by: str | None = None  # relay GlobalID
+    tables: list[LabelledTableRelationEntry] | None = None
+    predecessors: list[PredecessorEntry] | None = None
+
+
+class RuptureSetData(ToshiFileData):
+    fault_models: list[str] | None = None
+    metrics: list[KVPairModel] | None = None
+    produced_by: str | None = None  # relay GlobalID
+
+
+class ScaledInversionSolutionData(ToshiFileData):
+    metrics: list[KVPairModel] | None = None
+    produced_by: str | None = None
+    source_solution: str | None = None  # relay GlobalID
+    predecessors: list[PredecessorEntry] | None = None
+    tables: list[LabelledTableRelationEntry] | None = None
+
+
+class AggregateInversionSolutionData(ToshiFileData):
+    metrics: list[KVPairModel] | None = None
+    produced_by: str | None = None
+    common_rupture_set: str | None = None  # relay GlobalID
+    source_solutions: list[str] | None = None  # list of relay GlobalIDs
+    aggregation_fn: str | None = None
+    predecessors: list[PredecessorEntry] | None = None
+    tables: list[LabelledTableRelationEntry] | None = None
+
+
+class TimeDependentInversionSolutionData(ToshiFileData):
+    metrics: list[KVPairModel] | None = None
+    produced_by: str | None = None
+    source_solution: str | None = None  # relay GlobalID
+    predecessors: list[PredecessorEntry] | None = None
+    tables: list[LabelledTableRelationEntry] | None = None
+
+
+class InversionSolutionNrmlData(ToshiFileData):
+    source_solution: str | None = None  # relay GlobalID
+    predecessors: list[PredecessorEntry] | None = None
+
+
+# ── Thing types — Openquake ───────────────────────────────────────────────────
+
+
+class OpenquakeHazardConfigData(BaseModel):
+    object_id: str
+    clazz_name: str | None = None
+    created: str | None = None
+    source_models: list[str] | None = None  # list of relay GlobalIDs
+    template_archive: str | None = None  # relay GlobalID
+    files: list[dict] | None = None
+    parents: list[dict] | None = None
+    children: list[dict] | None = None
+
+
+class OpenquakeHazardSolutionData(BaseModel):
+    object_id: str
+    clazz_name: str | None = None
+    created: str | None = None
+    task_type: str | None = None
+    produced_by: str | None = None  # relay GlobalID → OpenquakeHazardTask
+    csv_archive: str | None = None  # relay GlobalID → File
+    hdf5_archive: str | None = None  # relay GlobalID → File
+    task_args: str | None = None  # relay GlobalID → File
+    metrics: list[KVPairModel] | None = None
+    meta: list[KVPairModel] | None = None
+    predecessors: list[PredecessorEntry] | None = None
+    files: list[dict] | None = None
+    parents: list[dict] | None = None
+    children: list[dict] | None = None
+
+
+class OpenquakeHazardTaskData(AutomationTaskData):
+    hazard_solution: str | None = None  # relay GlobalID
+    executor: str | None = None
+    srm_logic_tree: str | None = None  # JSON string
+    gmcm_logic_tree: str | None = None  # JSON string
+    openquake_config: str | None = None  # JSON string
+
+
+class TableData(BaseModel):
+    object_id: str
+    clazz_name: str | None = None
+    name: str | None = None
+    created: str | None = None
+    column_headers: list[str] | None = None
+    column_types: list[str] | None = None
+    rows: list[list[str]] | None = None
+    meta: list[KVPairModel] | None = None
+    table_type: str | None = None
+    dimensions: list[KVListPairModel] | None = None
+
+
+# ── Catch-all for unknown / future types ─────────────────────────────────────
+
+
+class RawObjectData(BaseModel):
+    """Fallback for any object type not yet modelled above."""
+
+    object_id: str
+    clazz_name: str | None = None
+
+    model_config = {"extra": "allow"}

--- a/spike/strawberry_poc/data/s3.py
+++ b/spike/strawberry_poc/data/s3.py
@@ -1,0 +1,67 @@
+"""S3 helpers — presigned download URLs and legacy object enumeration."""
+
+import logging
+import os
+from typing import Any
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+S3_BUCKET_NAME = os.environ.get("S3_BUCKET_NAME", "")
+REGION = os.environ.get("REGION", "ap-southeast-2")
+_URL_TTL = int(os.environ.get("URL_DEFAULT_TTL", "3600"))
+
+
+def presigned_download_url(object_id: str, file_name: str | None) -> str | None:
+    """Return a presigned S3 GET URL for FileData/{object_id}/{file_name}.
+
+    Mirrors file_data.py:get_presigned_url. Returns None if S3 is not configured
+    or file_name is unknown (object not yet uploaded).
+    """
+    if not S3_BUCKET_NAME or not file_name:
+        return None
+    key = f"FileData/{object_id}/{file_name}"
+    s3 = boto3.client("s3", region_name=REGION)
+    return s3.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": S3_BUCKET_NAME, "Key": key},
+        ExpiresIn=_URL_TTL,
+    )
+
+
+def scan_s3_paginated(
+    store_type: str,
+    limit: int = 5,
+    after_id: str | None = None,
+) -> tuple[list[dict], bool, str | None]:
+    """List legacy object IDs from S3 for store_type in File/Thing/Table.
+
+    Returns (items, has_more, last_object_id).  Each item dict has object_id
+    and object_type keys; clazz_name is not available without fetching the JSON.
+    S3 key structure: {store_type}Data/{object_id}/object.json
+    """
+    if not S3_BUCKET_NAME:
+        return [], False, None
+    prefix = f"{store_type}Data/"
+    s3 = boto3.client("s3", region_name=REGION)
+    kwargs: dict[str, Any] = {
+        "Bucket": S3_BUCKET_NAME,
+        "Prefix": prefix,
+        "Delimiter": "/",
+        "MaxKeys": limit,
+    }
+    if after_id:
+        kwargs["StartAfter"] = f"{prefix}{after_id}/"
+    try:
+        resp = s3.list_objects_v2(**kwargs)
+    except Exception as exc:
+        logger.debug("S3 scan error for %s: %s", store_type, exc)
+        return [], False, None
+    items = []
+    for cp in resp.get("CommonPrefixes", []):
+        object_id = cp["Prefix"].rstrip("/").split("/")[-1]
+        items.append({"object_id": object_id, "object_type": store_type})
+    has_more = resp.get("IsTruncated", False)
+    last_id = items[-1]["object_id"] if items else None
+    return items, has_more, last_id

--- a/spike/strawberry_poc/data/search.py
+++ b/spike/strawberry_poc/data/search.py
@@ -1,0 +1,85 @@
+"""
+Thin Elasticsearch wrapper — index and search only.
+
+Uses plain HTTP (requests) rather than the elasticsearch client library, matching
+the spirit of the original search_manager.py which also falls back to raw requests
+for the search call. No AWS auth needed for local docker ES.
+
+Index name and endpoint are read from env vars at import time, but can be
+overridden per-call for testing.
+"""
+
+import os
+
+import requests
+
+_TIMEOUT = 5  # seconds
+
+
+# Read at call time (not import time) so testcontainers can set the env var
+# after startup and have it picked up by all subsequent calls.
+def es_endpoint() -> str:
+    return os.environ.get("ES_ENDPOINT", "http://localhost:9200")
+
+
+def es_index() -> str:
+    return os.environ.get("ES_INDEX", "toshi-index-mapped")
+
+
+def index_document(
+    key: str,
+    document: dict,
+    endpoint: str | None = None,
+    index: str | None = None,
+) -> None:
+    """
+    Index a document in Elasticsearch. No-op if endpoint is empty.
+    Mirrors search_manager.py index_document(), including the
+    relations_compressed hack for File objects.
+    """
+    if endpoint is None:
+        endpoint = es_endpoint()
+    if index is None:
+        index = es_index()
+    if not endpoint:
+        return
+
+    doc = dict(document)
+
+    # relations_compressed hack — ES cannot handle fields that switch between
+    # list and string across documents. Matches original search_manager.py:48-57.
+    if doc.get("clazz_name") == "File" and isinstance(doc.get("relations"), str):
+        doc["relations_compressed"] = doc.pop("relations")
+
+    safe_key = key.replace("/", "_")
+    url = f"{endpoint}/{index}/_doc/{safe_key}"
+    try:
+        requests.put(url, json=doc, timeout=_TIMEOUT)
+    except Exception:
+        pass  # non-fatal — search is best-effort, never break writes
+
+
+def search(
+    term: str,
+    endpoint: str | None = None,
+    index: str | None = None,
+) -> list[dict]:
+    """
+    Lucene query-string search. Returns list of raw _source dicts, each
+    augmented with the ES _id so callers can identify Thing vs File.
+
+    Mirrors search_manager.py search(), minus AWS auth (local docker only).
+    """
+    if endpoint is None:
+        endpoint = es_endpoint()
+    if index is None:
+        index = es_index()
+    if not endpoint:
+        return []
+
+    url = f"{endpoint}/{index}/_search?q={term}"
+    try:
+        resp = requests.get(url, timeout=_TIMEOUT).json()
+        return [{"_id": hit["_id"], **hit["_source"]} for hit in resp.get("hits", {}).get("hits", [])]
+    except Exception:
+        return []

--- a/spike/strawberry_poc/models/aggregate_inversion_solution.py
+++ b/spike/strawberry_poc/models/aggregate_inversion_solution.py
@@ -1,0 +1,132 @@
+"""AggregateInversionSolution — file type with multiple source solutions."""
+
+from collections.abc import Iterable
+from typing import Annotated, Optional
+
+import strawberry
+from strawberry import relay
+from strawberry.relay import GlobalID
+from strawberry.types import Info
+
+from data.dynamo import create_file, get_file, list_files
+from data.models import AggregateInversionSolutionData
+
+from .common import AggregationFn, BigInt, KeyValuePair, KeyValuePairInput, _try_enum
+from .file_interface import FileInterface
+from .inversion_solution import LabelledTableRelation, _ltr_from_dict
+from .inversion_solution_interface import InversionSolutionInterface
+from .predecessor import PredecessorInput
+from .predecessors_interface import PredecessorsInterface
+from .rupture_set import RuptureSet
+from .scaled_inversion_solution import SourceSolutionUnion, dispatch_source_solution
+
+_RuptureSet = Annotated["RuptureSet", strawberry.lazy("models.rupture_set")]
+
+
+@strawberry.type
+class AggregateInversionSolution(relay.Node, FileInterface, InversionSolutionInterface, PredecessorsInterface):
+    pk: relay.NodeID[str]
+    metrics: list[KeyValuePair] | None = None
+    aggregation_fn: AggregationFn | None = None
+    # tables, produced_by, mfd_table, mfd_table_id, hazard_table_id, relations
+    # are all inherited from InversionSolutionInterface.
+
+    produced_by_raw_id: strawberry.Private[str | None] = None
+    common_rupture_set_raw_id: strawberry.Private[str | None] = None
+    source_solutions_raw_ids: strawberry.Private[list[str] | None] = None
+    relations_raw: strawberry.Private[list | None] = None
+    predecessors_raw: strawberry.Private[list | None] = None
+
+    @strawberry.field
+    def common_rupture_set(self, info: Info) -> _RuptureSet | None:
+        if not self.common_rupture_set_raw_id:
+            return None
+        try:
+            raw_id = GlobalID.from_id(self.common_rupture_set_raw_id).node_id
+        except Exception:
+            raw_id = self.common_rupture_set_raw_id
+        data = get_file(info.context["dynamodb"], raw_id)
+        if data is None:
+            return None
+        return RuptureSet.from_dict(data)
+
+    @strawberry.field
+    def source_solutions(self, info: Info) -> list[SourceSolutionUnion] | None:
+        if not self.source_solutions_raw_ids:
+            return None
+        results = []
+        for gid_str in self.source_solutions_raw_ids:
+            try:
+                raw_id = GlobalID.from_id(gid_str).node_id
+            except Exception:
+                raw_id = gid_str
+            data = get_file(info.context["dynamodb"], raw_id)
+            if data:
+                results.append(dispatch_source_solution(data))
+        return results or None
+
+    @classmethod
+    def resolve_node(cls, node_id: str, *, info: Info, **kwargs) -> Optional["AggregateInversionSolution"]:
+        data = get_file(info.context["dynamodb"], node_id)
+        return cls.from_dict(data) if data else None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "AggregateInversionSolution":
+        d = AggregateInversionSolutionData.model_validate(data)
+        agg_fn = _try_enum(AggregationFn, d.aggregation_fn)
+        return cls(
+            pk=d.object_id,
+            file_name=d.file_name,
+            md5_digest=d.md5_digest,
+            file_size=d.file_size,
+            meta=[KeyValuePair(k=i.k, v=i.v) for i in d.meta] if d.meta else None,
+            created=d.created,
+            metrics=[KeyValuePair(k=i.k, v=i.v) for i in d.metrics] if d.metrics else None,
+            aggregation_fn=agg_fn,
+            tables=[_ltr_from_dict(t.model_dump()) for t in d.tables] if d.tables else None,
+            produced_by_raw_id=d.produced_by,
+            common_rupture_set_raw_id=d.common_rupture_set,
+            source_solutions_raw_ids=d.source_solutions,
+            relations_raw=d.relations,
+            predecessors_raw=[p.model_dump() for p in d.predecessors] if d.predecessors else None,
+        )
+
+
+@strawberry.input
+class CreateAggregateInversionSolutionInput:
+    file_name: str
+    common_rupture_set: strawberry.ID
+    source_solutions: list[strawberry.ID]
+    aggregation_fn: AggregationFn
+    produced_by: strawberry.ID | None = None
+    md5_digest: str | None = None
+    file_size: BigInt | None = None
+    meta: list[KeyValuePairInput] | None = None
+    created: str | None = None
+    predecessors: list[PredecessorInput] | None = None
+
+
+def resolve_aggregate_inversion_solutions(info: Info) -> Iterable[AggregateInversionSolution]:
+    items = list_files(info.context["dynamodb"], "AggregateInversionSolution")
+    return [AggregateInversionSolution.from_dict(item) for item in items]
+
+
+def mutate_create_aggregate_inversion_solution(
+    info: Info, input: CreateAggregateInversionSolutionInput
+) -> AggregateInversionSolution:
+    meta = [{"k": i.k, "v": i.v} for i in input.meta] if input.meta else None
+    predecessors = [{"id": str(p.id), "depth": p.depth} for p in input.predecessors] if input.predecessors else None
+    payload = {
+        "file_name": input.file_name,
+        "md5_digest": input.md5_digest,
+        "file_size": input.file_size,
+        "meta": meta,
+        "created": input.created,
+        "produced_by": str(input.produced_by) if input.produced_by else None,
+        "common_rupture_set": str(input.common_rupture_set),
+        "source_solutions": [str(s) for s in input.source_solutions],
+        "aggregation_fn": input.aggregation_fn.value,
+        "predecessors": predecessors,
+    }
+    data = create_file(info.context["dynamodb"], "AggregateInversionSolution", payload)
+    return AggregateInversionSolution.from_dict(data)

--- a/spike/strawberry_poc/models/automation_task.py
+++ b/spike/strawberry_poc/models/automation_task.py
@@ -1,0 +1,252 @@
+"""
+AutomationTask and RuptureGenerationTask — full implementations.
+
+RuptureGenerationTask extends AutomationTask (same storage, same fields,
+different clazz_name). Both live in ToshiThingObject.
+
+Relations (files, parents, children) are stored as embedded arrays in the
+Thing's JSON and assembled into virtual FileRelation / TaskTaskRelation objects.
+"""
+
+from collections.abc import Iterable
+from typing import Optional
+
+import strawberry
+from strawberry import relay
+from strawberry.relay import GlobalID
+from strawberry.types import Info
+
+from data.dynamo import create_thing, get_thing, list_things, update_thing
+from data.models import AutomationTaskData
+
+from .common import EventResult, EventState, KeyValuePair, KeyValuePairInput, ModelType, TaskSubType, _try_enum
+from .relations import (
+    FileRelation,
+    FileRelationsConnection,
+    TaskRelationsConnection,
+    TaskTaskRelation,
+    build_file_relations_for_thing,
+    build_task_children,
+    build_task_parents,
+)
+
+
+def _kv_input_to_list(items) -> list[dict] | None:
+    if not items:
+        return None
+    return [{"k": i.k, "v": i.v} for i in items]
+
+
+# ── AutomationTask ─────────────────────────────────────────────────────────────
+
+
+@strawberry.type
+class AutomationTask(relay.Node):
+    """An automation task in the NSHM process."""
+
+    pk: relay.NodeID[str]
+    state: EventState | None = None
+    result: EventResult | None = None
+    task_type: TaskSubType | None = None
+    model_type: ModelType | None = None
+    created: str | None = None
+    duration: float | None = None
+    general_task_id: strawberry.ID | None = None
+    arguments: list[KeyValuePair] | None = None
+    environment: list[KeyValuePair] | None = None
+    metrics: list[KeyValuePair] | None = None
+
+    # Embedded relation arrays — hidden from schema, resolved lazily
+    files_raw: strawberry.Private[list | None] = None
+    parents_raw: strawberry.Private[list | None] = None
+    children_raw: strawberry.Private[list | None] = None
+
+    @relay.connection(FileRelationsConnection)
+    def files(self, info: Info) -> list[FileRelation]:
+        return build_file_relations_for_thing(self.pk, self.files_raw or [])
+
+    @relay.connection(TaskRelationsConnection)
+    def parents(self, info: Info) -> list[TaskTaskRelation]:
+        return build_task_parents(self.pk, self.parents_raw or [])
+
+    @relay.connection(TaskRelationsConnection)
+    def children(self, info: Info) -> list[TaskTaskRelation]:
+        return build_task_children(self.pk, self.children_raw or [])
+
+    @classmethod
+    def resolve_node(cls, node_id: str, *, info: Info, **kwargs) -> Optional["AutomationTask"]:
+        data = get_thing(info.context["dynamodb"], node_id)
+        return cls.from_dict(data) if data else None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "AutomationTask":
+        d = AutomationTaskData.model_validate(data)
+        return cls(
+            pk=d.object_id,
+            state=_try_enum(EventState, d.state),
+            result=_try_enum(EventResult, d.result),
+            task_type=_try_enum(TaskSubType, d.task_type),
+            model_type=_try_enum(ModelType, d.model_type),
+            created=d.created,
+            duration=d.duration,
+            arguments=[KeyValuePair(k=i.k, v=i.v) for i in d.arguments] if d.arguments else None,
+            environment=[KeyValuePair(k=i.k, v=i.v) for i in d.environment] if d.environment else None,
+            metrics=[KeyValuePair(k=i.k, v=i.v) for i in d.metrics] if d.metrics else None,
+            general_task_id=strawberry.ID(d.general_task_id) if d.general_task_id else None,
+            files_raw=d.files,
+            parents_raw=d.parents,
+            children_raw=d.children,
+        )
+
+
+# ── RuptureGenerationTask ──────────────────────────────────────────────────────
+
+
+@strawberry.type
+class RuptureGenerationTask(relay.Node):
+    """A rupture set generation task — stored identically to AutomationTask."""
+
+    pk: relay.NodeID[str]
+    state: EventState | None = None
+    result: EventResult | None = None
+    task_type: TaskSubType | None = None
+    created: str | None = None
+    duration: float | None = None
+    general_task_id: strawberry.ID | None = None
+    arguments: list[KeyValuePair] | None = None
+    environment: list[KeyValuePair] | None = None
+    metrics: list[KeyValuePair] | None = None
+
+    files_raw: strawberry.Private[list | None] = None
+    parents_raw: strawberry.Private[list | None] = None
+    children_raw: strawberry.Private[list | None] = None
+
+    @relay.connection(FileRelationsConnection)
+    def files(self, info: Info) -> list[FileRelation]:
+        return build_file_relations_for_thing(self.pk, self.files_raw or [])
+
+    @relay.connection(TaskRelationsConnection)
+    def parents(self, info: Info) -> list[TaskTaskRelation]:
+        return build_task_parents(self.pk, self.parents_raw or [])
+
+    @relay.connection(TaskRelationsConnection)
+    def children(self, info: Info) -> list[TaskTaskRelation]:
+        return build_task_children(self.pk, self.children_raw or [])
+
+    @classmethod
+    def resolve_node(cls, node_id: str, *, info: Info, **kwargs) -> Optional["RuptureGenerationTask"]:
+        data = get_thing(info.context["dynamodb"], node_id)
+        return cls.from_dict(data) if data else None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "RuptureGenerationTask":
+        d = AutomationTaskData.model_validate(data)
+        return cls(
+            pk=d.object_id,
+            state=_try_enum(EventState, d.state),
+            result=_try_enum(EventResult, d.result),
+            task_type=_try_enum(TaskSubType, d.task_type),
+            created=d.created,
+            duration=d.duration,
+            arguments=[KeyValuePair(k=i.k, v=i.v) for i in d.arguments] if d.arguments else None,
+            environment=[KeyValuePair(k=i.k, v=i.v) for i in d.environment] if d.environment else None,
+            metrics=[KeyValuePair(k=i.k, v=i.v) for i in d.metrics] if d.metrics else None,
+            general_task_id=strawberry.ID(d.general_task_id) if d.general_task_id else None,
+            files_raw=d.files,
+            parents_raw=d.parents,
+            children_raw=d.children,
+        )
+
+
+# ── Input types ───────────────────────────────────────────────────────────────
+
+
+@strawberry.input
+class CreateAutomationTaskInput:
+    state: EventState
+    result: EventResult
+    created: str
+    task_type: TaskSubType
+    duration: float | None = None
+    model_type: ModelType | None = None
+    arguments: list[KeyValuePairInput] | None = None
+    environment: list[KeyValuePairInput] | None = None
+    metrics: list[KeyValuePairInput] | None = None
+
+
+@strawberry.input
+class UpdateAutomationTaskInput:
+    task_id: strawberry.ID
+    state: EventState | None = None
+    result: EventResult | None = None
+    duration: float | None = None
+    arguments: list[KeyValuePairInput] | None = None
+    environment: list[KeyValuePairInput] | None = None
+    metrics: list[KeyValuePairInput] | None = None
+
+
+# ── Resolvers ─────────────────────────────────────────────────────────────────
+
+
+def resolve_automation_tasks(info: Info) -> Iterable[AutomationTask]:
+    items = list_things(info.context["dynamodb"], "AutomationTask")
+    return [AutomationTask.from_dict(item) for item in items]
+
+
+def resolve_rupture_generation_tasks(info: Info) -> Iterable[RuptureGenerationTask]:
+    items = list_things(info.context["dynamodb"], "RuptureGenerationTask")
+    return [RuptureGenerationTask.from_dict(item) for item in items]
+
+
+def _build_payload(input, clazz_name: str) -> dict:
+    return {
+        "state": input.state.value if input.state else None,
+        "result": input.result.value if input.result else None,
+        "task_type": input.task_type.value if input.task_type else None,
+        "model_type": input.model_type.value if hasattr(input, "model_type") and input.model_type else None,
+        "created": input.created if hasattr(input, "created") else None,
+        "duration": input.duration if input.duration else None,
+        "arguments": _kv_input_to_list(input.arguments) if input.arguments else None,
+        "environment": _kv_input_to_list(input.environment) if input.environment else None,
+        "metrics": _kv_input_to_list(input.metrics) if input.metrics else None,
+    }
+
+
+def mutate_create_automation_task(info: Info, input: CreateAutomationTaskInput) -> AutomationTask:
+    payload = _build_payload(input, "AutomationTask")
+    data = create_thing(info.context["dynamodb"], "AutomationTask", payload)
+    return AutomationTask.from_dict(data)
+
+
+def mutate_create_rupture_generation_task(info: Info, input: CreateAutomationTaskInput) -> RuptureGenerationTask:
+    payload = _build_payload(input, "RuptureGenerationTask")
+    data = create_thing(info.context["dynamodb"], "RuptureGenerationTask", payload)
+    return RuptureGenerationTask.from_dict(data)
+
+
+def mutate_update_automation_task(info: Info, input: UpdateAutomationTaskInput) -> AutomationTask | None:
+    gid = GlobalID.from_id(input.task_id)
+    payload = {
+        "state": input.state.value if input.state else None,
+        "result": input.result.value if input.result else None,
+        "duration": input.duration,
+        "arguments": _kv_input_to_list(input.arguments),
+        "environment": _kv_input_to_list(input.environment),
+        "metrics": _kv_input_to_list(input.metrics),
+    }
+    data = update_thing(info.context["dynamodb"], gid.node_id, payload)
+    return AutomationTask.from_dict(data) if data else None
+
+
+def mutate_update_rupture_generation_task(info: Info, input: UpdateAutomationTaskInput) -> RuptureGenerationTask | None:
+    gid = GlobalID.from_id(input.task_id)
+    payload = {
+        "state": input.state.value if input.state else None,
+        "result": input.result.value if input.result else None,
+        "duration": input.duration,
+        "arguments": _kv_input_to_list(input.arguments),
+        "environment": _kv_input_to_list(input.environment),
+        "metrics": _kv_input_to_list(input.metrics),
+    }
+    data = update_thing(info.context["dynamodb"], gid.node_id, payload)
+    return RuptureGenerationTask.from_dict(data) if data else None

--- a/spike/strawberry_poc/models/common.py
+++ b/spike/strawberry_poc/models/common.py
@@ -1,0 +1,167 @@
+"""Shared scalar types and enums used across schema types."""
+
+import enum
+from typing import NewType, TypeVar
+
+import strawberry
+
+_E = TypeVar("_E", bound=enum.Enum)
+
+
+def _try_enum(enum_cls: type[_E], value: str | None) -> _E | None:
+    """Construct an enum from a string value, returning None for unknown/missing values."""
+    if value is None:
+        return None
+    try:
+        return enum_cls(value)
+    except ValueError:
+        return None
+
+
+# ── Custom scalars ────────────────────────────────────────────────────────────
+
+BigInt = strawberry.scalar(
+    NewType("BigInt", int),
+    serialize=int,
+    parse_value=int,
+    description="A signed integer with arbitrary precision (not limited to GraphQL Int 32-bit). "
+    "Used for file_size where production values can exceed 2GB.",
+)
+
+
+@strawberry.type
+class KeyValuePair:
+    k: str
+    v: str
+
+
+@strawberry.input
+class KeyValuePairInput:
+    k: str
+    v: str
+
+
+@strawberry.type
+class KeyValueListPair:
+    k: str
+    v: list[str]
+
+
+@strawberry.input
+class KeyValueListPairInput:
+    k: str
+    v: list[str]
+
+
+# ── Task enums ────────────────────────────────────────────────────────────────
+# Values match the production Graphene schema (lowercase stored values).
+
+
+@strawberry.enum
+class TaskSubType(enum.Enum):
+    RUPTURE_SET = "rupture_set"
+    INVERSION = "inversion"
+    HAZARD = "hazard"
+    DISAGG = "disagg"
+    REPORT = "report"
+    SCALE_SOLUTION = "scale_solution"
+    AGGREGATE_SOLUTION = "aggregate_solution"
+    SOLUTION_TO_NRML = "solution_to_nrml"
+    OPENQUAKE_HAZARD = "openquake_hazard"
+    TIME_DEPENDENT_SOLUTION = "time_dependent_solution"
+    UNDEFINED = "undefined"
+
+
+@strawberry.enum
+class ModelType(enum.Enum):
+    CRUSTAL = "crustal"
+    SUBDUCTION = "subduction"
+    COMPOSITE = "composite"
+
+
+@strawberry.enum
+class EventResult(enum.Enum):
+    FAILURE = "fail"
+    PARTIAL = "partial"
+    SUCCESS = "success"
+    UNDEFINED = "undefined"
+
+
+@strawberry.enum
+class EventState(enum.Enum):
+    SCHEDULED = "scheduled"
+    STARTED = "started"
+    DONE = "done"
+    UNDEFINED = "undefined"
+
+
+# ── File relation enums ───────────────────────────────────────────────────────
+
+
+@strawberry.enum
+class FileRole(enum.Enum):
+    READ = "read"
+    WRITE = "write"
+    READ_WRITE = "read_write"
+    UNDEFINED = "undefined"
+
+
+# ── SMS / StrongMotionStation enums ───────────────────────────────────────────
+
+
+@strawberry.enum
+class SmsSiteClass(enum.Enum):
+    A = "A"
+    B = "B"
+    C = "C"
+    D = "D"
+    E = "E"
+
+
+@strawberry.enum
+class SmsSiteClassBasis(enum.Enum):
+    Vs = "Vs"
+    SPT = "SPT"
+    su = "su"
+
+
+@strawberry.enum
+class SmsFileType(enum.Enum):
+    BH = "bh"
+    CPT = "cpt"
+    DH = "dh"
+    HVSR = "hvsr"
+    SW = "sw"
+
+
+# ── Openquake / hazard enums ──────────────────────────────────────────────────
+
+
+@strawberry.enum
+class OpenquakeTaskType(enum.Enum):
+    HAZARD = "hazard"
+    DISAGG = "disagg"
+    UNDEFINED = "undefined"
+
+
+@strawberry.enum
+class AggregationFn(enum.Enum):
+    MEAN = "mean"
+
+
+@strawberry.enum
+class TableType(enum.Enum):
+    HAZARD_GRIDDED = "hazard_gridded"
+    HAZARD_SITES = "hazard_sites"
+    MFD_CURVES = "mfd_curves"
+    MFD_CURVES_V2 = "mfd_curves_v2"
+    GENERAL = "general"
+
+
+@strawberry.enum
+class AncestryLabel(enum.Enum):
+    SIBLING = 0
+    PARENT = -1
+    GRANDPARENT = -2
+    GREAT_GRANDPARENT = -3
+    GREAT_GREAT_GRANDPARENT = -4

--- a/spike/strawberry_poc/models/file.py
+++ b/spike/strawberry_poc/models/file.py
@@ -1,0 +1,85 @@
+"""
+ToshiFile — base file type.
+
+Equivalent to graphql_api/schema/file.py FileInterface + File.
+In Strawberry there's no separate Interface class needed — relay.Node
+acts as the node interface, and shared fields are just inherited.
+"""
+
+from collections.abc import Iterable
+from typing import Optional
+
+import strawberry
+from strawberry import relay
+from strawberry.types import Info
+
+from data.dynamo import create_file, get_file, list_files
+from data.models import ToshiFileData
+
+from .common import BigInt, KeyValuePair, KeyValuePairInput
+from .file_interface import FileInterface
+from .relations import FileRelation, FileRelationsConnection, build_file_relations_for_file
+
+
+@strawberry.type
+class ToshiFile(relay.Node, FileInterface):
+    """A file stored in S3 and indexed in DynamoDB."""
+
+    pk: relay.NodeID[str]
+
+    relations_raw: strawberry.Private[list | None] = None
+
+    @relay.connection(FileRelationsConnection)
+    def relations(self, info: Info) -> list[FileRelation]:
+        return build_file_relations_for_file(self.pk, self.relations_raw or [])
+
+    @classmethod
+    def resolve_node(
+        cls,
+        node_id: str,
+        *,
+        info: Info,
+        **kwargs,
+    ) -> Optional["ToshiFile"]:
+        data = get_file(info.context["dynamodb"], node_id)
+        return cls.from_dict(data) if data else None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ToshiFile":
+        d = ToshiFileData.model_validate(data)
+        return cls(
+            pk=d.object_id,
+            file_name=d.file_name,
+            md5_digest=d.md5_digest,
+            file_size=d.file_size,
+            meta=[KeyValuePair(k=i.k, v=i.v) for i in d.meta] if d.meta else None,
+            created=d.created,
+            relations_raw=d.relations,
+        )
+
+
+@strawberry.input
+class CreateFileInput:
+    file_name: str
+    md5_digest: str | None = None
+    file_size: BigInt | None = None
+    meta: list[KeyValuePairInput] | None = None
+    created: str | None = None
+
+
+def resolve_files(info: Info) -> Iterable[ToshiFile]:
+    items = list_files(info.context["dynamodb"], "File")
+    return [ToshiFile.from_dict(item) for item in items]
+
+
+def mutate_create_file(info: Info, input: CreateFileInput) -> ToshiFile:
+    meta = [{"k": i.k, "v": i.v} for i in input.meta] if input.meta else None
+    payload = {
+        "file_name": input.file_name,
+        "md5_digest": input.md5_digest,
+        "file_size": input.file_size,
+        "meta": meta,
+        "created": input.created,
+    }
+    data = create_file(info.context["dynamodb"], "File", payload)
+    return ToshiFile.from_dict(data)

--- a/spike/strawberry_poc/models/file_interface.py
+++ b/spike/strawberry_poc/models/file_interface.py
@@ -1,0 +1,35 @@
+"""FileInterface — matches legacy graphql_api.schema.file.FileInterface."""
+
+import strawberry
+from strawberry.types import Info
+
+from data.s3 import presigned_download_url
+
+from .common import BigInt, KeyValuePair
+
+
+@strawberry.interface
+class FileInterface:
+    """Common fields shared by all file types (File, RuptureSet, InversionSolution, etc.)."""
+
+    file_name: str | None = None
+    md5_digest: str | None = None
+    file_size: BigInt | None = None
+    created: str | None = None
+    meta: list[KeyValuePair] | None = None
+
+    @strawberry.field
+    def file_url(self, info: Info) -> str | None:
+        return presigned_download_url(self.pk, self.file_name)  # type: ignore[attr-defined]
+
+    @strawberry.field
+    def post_url(self) -> str | None:
+        return None
+
+    @strawberry.field
+    def post_url_v2(self) -> str | None:
+        return None
+
+    @strawberry.field
+    def post_data_v2(self) -> str | None:
+        return None

--- a/spike/strawberry_poc/models/general_task.py
+++ b/spike/strawberry_poc/models/general_task.py
@@ -1,0 +1,197 @@
+"""
+GeneralTask — Strawberry/relay equivalent of graphql_api/schema/custom/general_task.py
+
+Key differences vs Graphene:
+  - No Meta class, no separate Connection class — relay.ListConnection[GeneralTask] handles it
+  - Input types are @strawberry.input dataclasses, not inner classes
+  - get_node() becomes resolve_node() classmethod
+  - Children/parents relations omitted in POC (same pattern as produced_by on RuptureSet)
+"""
+
+from collections.abc import Iterable
+from typing import Optional
+
+import strawberry
+from strawberry import relay
+from strawberry.types import Info
+
+from data.dynamo import create_thing, get_thing, list_things, update_thing
+from data.models import GeneralTaskData
+
+from .common import (
+    EventResult,
+    KeyValueListPair,
+    KeyValueListPairInput,
+    KeyValuePair,
+    KeyValuePairInput,
+    ModelType,
+    TaskSubType,
+    _try_enum,
+)
+from .relations import (
+    FileRelation,
+    FileRelationsConnection,
+    TaskRelationsConnection,
+    TaskTaskRelation,
+    build_file_relations_for_thing,
+    build_task_children,
+    build_task_parents,
+)
+
+
+@strawberry.type
+class GeneralTask(relay.Node):
+    """
+    A General Task captures metadata and related inputs/outputs for arbitrary tasks.
+    """
+
+    pk: relay.NodeID[str]
+    title: str | None = None
+    description: str | None = None
+    agent_name: str | None = None
+    created: str | None = None
+    updated: str | None = None
+    notes: str | None = None
+    subtask_count: int | None = None
+    subtask_type: TaskSubType | None = None
+    subtask_result: EventResult | None = None
+    model_type: ModelType | None = None
+    argument_lists: list[KeyValueListPair] | None = None
+    meta: list[KeyValuePair] | None = None
+
+    files_raw: strawberry.Private[list | None] = None
+    children_raw: strawberry.Private[list | None] = None
+    parents_raw: strawberry.Private[list | None] = None
+
+    @relay.connection(FileRelationsConnection)
+    def files(self, info: Info) -> list[FileRelation]:
+        return build_file_relations_for_thing(self.pk, self.files_raw or [])
+
+    @relay.connection(TaskRelationsConnection)
+    def children(self, info: Info) -> list[TaskTaskRelation]:
+        return build_task_children(self.pk, self.children_raw or [])
+
+    @relay.connection(TaskRelationsConnection)
+    def parents(self, info: Info) -> list[TaskTaskRelation]:
+        return build_task_parents(self.pk, self.parents_raw or [])
+
+    @strawberry.field
+    def swept_arguments(self) -> list[str]:
+        """Keys with >1 value in argument_lists."""
+        if not self.argument_lists:
+            return []
+        return [item.k for item in self.argument_lists if len(item.v) > 1]
+
+    @classmethod
+    def resolve_node(
+        cls,
+        node_id: str,
+        *,
+        info: Info,
+        **kwargs,
+    ) -> Optional["GeneralTask"]:
+        data = get_thing(info.context["dynamodb"], node_id)
+        return cls.from_dict(data) if data else None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "GeneralTask":
+        d = GeneralTaskData.model_validate(data)
+        return cls(
+            pk=d.object_id,
+            title=d.title,
+            description=d.description,
+            agent_name=d.agent_name,
+            created=d.created,
+            updated=d.updated,
+            notes=d.notes,
+            subtask_count=d.subtask_count,
+            subtask_type=_try_enum(TaskSubType, d.subtask_type),
+            subtask_result=_try_enum(EventResult, d.subtask_result),
+            model_type=_try_enum(ModelType, d.model_type),
+            argument_lists=[KeyValueListPair(k=i.k, v=i.v) for i in d.argument_lists] if d.argument_lists else None,
+            meta=[KeyValuePair(k=i.k, v=i.v) for i in d.meta] if d.meta else None,
+            files_raw=d.files,
+            children_raw=d.children,
+            parents_raw=d.parents,
+        )
+
+
+@strawberry.input
+class CreateGeneralTaskInput:
+    title: str | None = None
+    description: str | None = None
+    agent_name: str | None = None
+    created: str | None = None
+    notes: str | None = None
+    subtask_count: int | None = None
+    subtask_type: TaskSubType | None = None
+    subtask_result: EventResult | None = None
+    model_type: ModelType | None = None
+    argument_lists: list[KeyValueListPairInput] | None = None
+    meta: list[KeyValuePairInput] | None = None
+
+
+@strawberry.input
+class UpdateGeneralTaskInput:
+    task_id: strawberry.ID
+    title: str | None = None
+    description: str | None = None
+    agent_name: str | None = None
+    updated: str | None = None
+    notes: str | None = None
+    subtask_count: int | None = None
+    subtask_type: TaskSubType | None = None
+    subtask_result: EventResult | None = None
+    model_type: ModelType | None = None
+    argument_lists: list[KeyValueListPairInput] | None = None
+    meta: list[KeyValuePairInput] | None = None
+
+
+def resolve_general_tasks(info: Info) -> Iterable[GeneralTask]:
+    items = list_things(info.context["dynamodb"], "GeneralTask")
+    return [GeneralTask.from_dict(item) for item in items]
+
+
+def mutate_create_general_task(info: Info, input: CreateGeneralTaskInput) -> GeneralTask:
+    def _kvl(items):
+        return [{"k": i.k, "v": i.v} for i in items] if items else None
+
+    payload = {
+        "title": input.title,
+        "description": input.description,
+        "agent_name": input.agent_name,
+        "created": input.created,
+        "notes": input.notes,
+        "subtask_count": input.subtask_count,
+        "subtask_type": input.subtask_type.value if input.subtask_type else None,
+        "subtask_result": input.subtask_result.value if input.subtask_result else None,
+        "model_type": input.model_type.value if input.model_type else None,
+        "argument_lists": _kvl(input.argument_lists),
+        "meta": _kvl(input.meta),
+    }
+    data = create_thing(info.context["dynamodb"], "GeneralTask", payload)
+    return GeneralTask.from_dict(data)
+
+
+def mutate_update_general_task(info: Info, input: UpdateGeneralTaskInput) -> GeneralTask | None:
+    # Decode relay global ID → raw object_id
+    gid = relay.GlobalID.from_id(input.task_id)
+    object_id = gid.node_id
+
+    def _kvl(items):
+        return [{"k": i.k, "v": i.v} for i in items] if items else None
+
+    payload = {
+        "title": input.title,
+        "description": input.description,
+        "agent_name": input.agent_name,
+        "updated": input.updated,
+        "notes": input.notes,
+        "subtask_count": input.subtask_count,
+        "subtask_type": input.subtask_type.value if input.subtask_type else None,
+        "model_type": input.model_type.value if input.model_type else None,
+        "argument_lists": _kvl(input.argument_lists),
+        "meta": _kvl(input.meta),
+    }
+    data = update_thing(info.context["dynamodb"], object_id, payload)
+    return GeneralTask.from_dict(data) if data else None

--- a/spike/strawberry_poc/models/inversion_solution.py
+++ b/spike/strawberry_poc/models/inversion_solution.py
@@ -1,0 +1,198 @@
+"""
+InversionSolution — file type with produced_by (AutomationTaskUnion),
+embedded LabelledTableRelation list, and optional predecessors.
+
+LabelledTableRelation is stored inline in the parent's JSON; it has no
+separate DynamoDB record and is not a relay.Node.
+"""
+
+import json
+import uuid
+from collections.abc import Iterable
+from typing import Optional
+
+import strawberry
+from strawberry import relay
+from strawberry.relay import GlobalID
+from strawberry.types import Info
+
+from data.dynamo import _file_table, create_file, get_file, list_files
+from data.models import InversionSolutionData
+
+from .common import (
+    BigInt,
+    KeyValueListPair,
+    KeyValueListPairInput,
+    KeyValuePair,
+    KeyValuePairInput,
+    TableType,
+    _try_enum,
+)
+from .file_interface import FileInterface
+from .inversion_solution_interface import (  # noqa: F401 — re-export AutomationTaskUnion for other modules
+    AutomationTaskUnion,
+    InversionSolutionInterface,
+    _dispatch_automation_task,
+)
+from .predecessor import Predecessor, PredecessorInput  # noqa: F401 — re-exported for other models
+from .predecessors_interface import PredecessorsInterface
+from .table import Table  # noqa: F401 — re-exported; also needed for mfd_table return type
+
+
+# ── LabelledTableRelation (embedded — not a relay.Node) ───────────────────────
+
+
+@strawberry.type
+class LabelledTableRelation:
+    """A labelled reference to a ToshiTableObject, stored inline in the parent."""
+
+    identity: str | None = None
+    created: str | None = None
+    produced_by_id: strawberry.ID | None = None
+    label: str | None = None
+    table_id: strawberry.ID | None = None
+    table_type: TableType | None = None
+    dimensions: list[KeyValueListPair] | None = None
+
+
+@strawberry.input
+class LabelledTableRelationInput:
+    table_id: strawberry.ID
+    table_type: TableType
+    label: str | None = None
+    produced_by_id: strawberry.ID | None = None
+    dimensions: list[KeyValueListPairInput] | None = None
+
+
+def _ltr_from_dict(d: dict) -> LabelledTableRelation:
+    dims = d.get("dimensions")
+    tt = _try_enum(TableType, d.get("table_type"))
+    return LabelledTableRelation(
+        identity=d.get("identity"),
+        created=d.get("created"),
+        produced_by_id=d.get("produced_by_id"),
+        label=d.get("label"),
+        table_id=d.get("table_id"),
+        table_type=tt,
+        dimensions=[KeyValueListPair(k=x["k"], v=x["v"]) for x in dims] if dims else None,
+    )
+
+
+def _ltr_to_dict(inp: LabelledTableRelationInput) -> dict:
+    dims = [{"k": d.k, "v": d.v} for d in inp.dimensions] if inp.dimensions else None
+    return {
+        "identity": str(uuid.uuid4()),
+        "table_id": str(inp.table_id),
+        "table_type": inp.table_type.value if inp.table_type else None,
+        "label": inp.label,
+        "produced_by_id": str(inp.produced_by_id) if inp.produced_by_id else None,
+        "dimensions": dims,
+    }
+
+
+# ── InversionSolution ──────────────────────────────────────────────────────────
+
+
+@strawberry.type
+class InversionSolution(relay.Node, FileInterface, InversionSolutionInterface, PredecessorsInterface):
+    """An Inversion Solution file produced by an automation task."""
+
+    pk: relay.NodeID[str]
+    metrics: list[KeyValuePair] | None = None
+    # tables, produced_by, mfd_table, mfd_table_id, hazard_table_id, relations
+    # are all inherited from InversionSolutionInterface.
+
+    produced_by_raw_id: strawberry.Private[str | None] = None
+    relations_raw: strawberry.Private[list | None] = None
+    predecessors_raw: strawberry.Private[list | None] = None
+
+    @classmethod
+    def resolve_node(cls, node_id: str, *, info: Info, **kwargs) -> Optional["InversionSolution"]:
+        data = get_file(info.context["dynamodb"], node_id)
+        return cls.from_dict(data) if data else None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "InversionSolution":
+        d = InversionSolutionData.model_validate(data)
+        return cls(
+            pk=d.object_id,
+            file_name=d.file_name,
+            md5_digest=d.md5_digest,
+            file_size=d.file_size,
+            meta=[KeyValuePair(k=i.k, v=i.v) for i in d.meta] if d.meta else None,
+            created=d.created,
+            metrics=[KeyValuePair(k=i.k, v=i.v) for i in d.metrics] if d.metrics else None,
+            tables=[_ltr_from_dict(t.model_dump()) for t in d.tables] if d.tables else None,
+            produced_by_raw_id=d.produced_by,
+            relations_raw=d.relations,
+            predecessors_raw=[p.model_dump() for p in d.predecessors] if d.predecessors else None,
+        )
+
+
+# ── Input types ───────────────────────────────────────────────────────────────
+
+
+@strawberry.input
+class CreateInversionSolutionInput:
+    file_name: str
+    md5_digest: str | None = None
+    file_size: BigInt | None = None
+    meta: list[KeyValuePairInput] | None = None
+    created: str | None = None
+    produced_by: strawberry.ID | None = None
+    metrics: list[KeyValuePairInput] | None = None
+    tables: list[LabelledTableRelationInput] | None = None
+    predecessors: list[PredecessorInput] | None = None
+
+
+@strawberry.input
+class AppendInversionSolutionTablesInput:
+    id: strawberry.ID
+    tables: list[LabelledTableRelationInput]
+
+
+# ── Resolvers + mutations ─────────────────────────────────────────────────────
+
+
+def resolve_inversion_solutions(info: Info) -> Iterable[InversionSolution]:
+    items = list_files(info.context["dynamodb"], "InversionSolution")
+    return [InversionSolution.from_dict(item) for item in items]
+
+
+def mutate_create_inversion_solution(info: Info, input: CreateInversionSolutionInput) -> InversionSolution:
+    meta = [{"k": i.k, "v": i.v} for i in input.meta] if input.meta else None
+    metrics = [{"k": i.k, "v": i.v} for i in input.metrics] if input.metrics else None
+    tables = [_ltr_to_dict(t) for t in input.tables] if input.tables else None
+    predecessors = [{"id": str(p.id), "depth": p.depth} for p in input.predecessors] if input.predecessors else None
+    payload = {
+        "file_name": input.file_name,
+        "md5_digest": input.md5_digest,
+        "file_size": input.file_size,
+        "meta": meta,
+        "created": input.created,
+        "produced_by": str(input.produced_by) if input.produced_by else None,
+        "metrics": metrics,
+        "tables": tables,
+        "predecessors": predecessors,
+    }
+    data = create_file(info.context["dynamodb"], "InversionSolution", payload)
+    return InversionSolution.from_dict(data)
+
+
+def mutate_append_inversion_solution_tables(
+    info: Info, input: AppendInversionSolutionTablesInput
+) -> InversionSolution | None:
+    gid = GlobalID.from_id(input.id)
+    existing = get_file(info.context["dynamodb"], gid.node_id)
+    if existing is None:
+        return None
+    existing_tables = existing.get("tables") or []
+    existing["tables"] = existing_tables + [_ltr_to_dict(t) for t in input.tables]
+    _file_table(info.context["dynamodb"]).put_item(
+        Item={
+            "object_id": gid.node_id,
+            "object_type": "InversionSolution",
+            "object_content": json.dumps({k: v for k, v in existing.items() if k != "object_id"}),
+        }
+    )
+    return InversionSolution.from_dict(existing)

--- a/spike/strawberry_poc/models/inversion_solution_interface.py
+++ b/spike/strawberry_poc/models/inversion_solution_interface.py
@@ -1,0 +1,140 @@
+"""
+InversionSolutionInterface — Strawberry interface for the IS family types.
+
+Implements the legacy graphql_api InversionSolutionInterface, providing
+mfd_table_id, hazard_table_id, mfd_table, tables, produced_by, relations,
+created, file_name and all FileInterface fields on one abstract type.
+
+All four concrete solution types implement this interface:
+  InversionSolution, ScaledInversionSolution,
+  AggregateInversionSolution, TimeDependentInversionSolution.
+
+Note: this interface is standalone (does not inherit FileInterface) to keep
+the Strawberry schema simple; concrete types implement both interfaces.
+"""
+
+from typing import Annotated
+
+import strawberry
+from strawberry.relay import GlobalID
+from strawberry.types import Info
+
+from data.dynamo import get_table, get_thing
+
+from .common import BigInt, KeyValuePair, TableType
+from .relations import InversionSolutionRelations, build_file_relations_for_file
+
+# ── Lazy forward refs ─────────────────────────────────────────────────────────
+# These types are defined in modules that import *this* module (circular),
+# so strawberry.lazy is required to break the import cycle.
+
+_AutomationTask = Annotated["AutomationTask", strawberry.lazy("models.automation_task")]
+_RuptureGenerationTask = Annotated["RuptureGenerationTask", strawberry.lazy("models.automation_task")]
+_LabelledTableRelation = Annotated["LabelledTableRelation", strawberry.lazy("models.inversion_solution")]
+_Table = Annotated["Table", strawberry.lazy("models.table")]
+
+# Registered once here; inversion_solution.py re-exports it via import.
+AutomationTaskUnion = Annotated[
+    _RuptureGenerationTask | _AutomationTask,
+    strawberry.union(name="AutomationTaskUnion"),
+]
+
+
+def _dispatch_automation_task(data: dict):
+    """Instantiate the correct task type from a raw thing dict."""
+    from models.automation_task import AutomationTask, RuptureGenerationTask  # noqa: PLC0415
+
+    clazz = data.get("clazz_name", "")
+    if clazz == "RuptureGenerationTask":
+        return RuptureGenerationTask.from_dict(data)
+    return AutomationTask.from_dict(data)
+
+
+# ── InversionSolutionInterface ────────────────────────────────────────────────
+
+
+@strawberry.interface
+class InversionSolutionInterface:
+    """
+    Shared interface for all InversionSolution family types.
+
+    Declares all fields that weka queries via
+      `... on InversionSolutionInterface { ... }`,
+    including file fields (file_name, created, meta, …) and IS-specific fields
+    (mfd_table_id, hazard_table_id, mfd_table, tables, produced_by, relations).
+
+    Concrete types also implement FileInterface directly; the overlap is valid
+    GraphQL (same field name, compatible types).
+    """
+
+    # ── FileInterface-overlapping fields ──────────────────────────────────────
+    # Re-declared here so that `... on InversionSolutionInterface { file_name }`
+    # is a valid GQL fragment selection.
+    file_name: str | None = None
+    md5_digest: str | None = None
+    file_size: BigInt | None = None
+    created: str | None = None
+    meta: list[KeyValuePair] | None = None
+
+    @strawberry.field
+    def file_url(self) -> str | None:
+        return None  # resolved by FileInterface on concrete types
+
+    # ── IS-specific fields ────────────────────────────────────────────────────
+
+    tables: list[_LabelledTableRelation] | None = None
+
+    @strawberry.field
+    def relations(self, info: Info) -> InversionSolutionRelations | None:
+        pk = self.pk  # type: ignore[attr-defined]
+        relations_raw = self.relations_raw  # type: ignore[attr-defined]
+        if not relations_raw:
+            return InversionSolutionRelations()
+        return InversionSolutionRelations(edges=build_file_relations_for_file(pk, relations_raw))
+
+    @strawberry.field
+    def produced_by(self, info: Info) -> AutomationTaskUnion | None:
+        raw_id = self.produced_by_raw_id  # type: ignore[attr-defined]
+        if not raw_id:
+            return None
+        try:
+            node_id = GlobalID.from_id(raw_id).node_id
+        except Exception:
+            node_id = raw_id
+        data = get_thing(info.context["dynamodb"], node_id)
+        return _dispatch_automation_task(data) if data else None
+
+    @strawberry.field
+    def mfd_table(self, info: Info) -> _Table | None:
+        if not self.tables:
+            return None
+        for t in self.tables:  # type: ignore[union-attr]
+            if t.table_type == TableType.MFD_CURVES_V2 and t.table_id:  # type: ignore[attr-defined]
+                try:
+                    raw_id = GlobalID.from_id(str(t.table_id)).node_id  # type: ignore[attr-defined]
+                except Exception:
+                    raw_id = str(t.table_id)  # type: ignore[attr-defined]
+                data = get_table(info.context["dynamodb"], raw_id)
+                if data:
+                    from models.table import Table  # noqa: PLC0415
+
+                    return Table.from_dict(data)
+        return None
+
+    @strawberry.field
+    def mfd_table_id(self) -> str | None:
+        if not self.tables:
+            return None
+        for t in self.tables:  # type: ignore[union-attr]
+            if t.table_type == TableType.MFD_CURVES_V2:  # type: ignore[attr-defined]
+                return str(t.table_id) if t.table_id else None  # type: ignore[attr-defined]
+        return None
+
+    @strawberry.field
+    def hazard_table_id(self) -> str | None:
+        if not self.tables:
+            return None
+        for t in self.tables:  # type: ignore[union-attr]
+            if t.table_type in (TableType.HAZARD_GRIDDED, TableType.HAZARD_SITES):  # type: ignore[attr-defined]
+                return str(t.table_id) if t.table_id else None  # type: ignore[attr-defined]
+        return None

--- a/spike/strawberry_poc/models/inversion_solution_nrml.py
+++ b/spike/strawberry_poc/models/inversion_solution_nrml.py
@@ -1,0 +1,88 @@
+"""InversionSolutionNrml — file type used as an Openquake source model."""
+
+from collections.abc import Iterable
+from typing import Optional
+
+import strawberry
+from strawberry import relay
+from strawberry.relay import GlobalID
+from strawberry.types import Info
+
+from data.dynamo import create_file, get_file, list_files
+from data.models import InversionSolutionNrmlData
+
+from .common import BigInt, KeyValuePair, KeyValuePairInput
+from .file_interface import FileInterface
+from .predecessor import PredecessorInput
+from .predecessors_interface import PredecessorsInterface
+from .scaled_inversion_solution import SourceSolutionUnion, dispatch_source_solution
+
+
+@strawberry.type
+class InversionSolutionNrml(relay.Node, FileInterface, PredecessorsInterface):
+    pk: relay.NodeID[str]
+
+    source_solution_raw_id: strawberry.Private[str | None] = None
+    predecessors_raw: strawberry.Private[list | None] = None
+
+    @strawberry.field
+    def source_solution(self, info: Info) -> SourceSolutionUnion | None:
+        if not self.source_solution_raw_id:
+            return None
+        try:
+            raw_id = GlobalID.from_id(self.source_solution_raw_id).node_id
+        except Exception:
+            raw_id = self.source_solution_raw_id
+        data = get_file(info.context["dynamodb"], raw_id)
+        return dispatch_source_solution(data) if data else None
+
+    @classmethod
+    def resolve_node(cls, node_id: str, *, info: Info, **kwargs) -> Optional["InversionSolutionNrml"]:
+        data = get_file(info.context["dynamodb"], node_id)
+        return cls.from_dict(data) if data else None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "InversionSolutionNrml":
+        d = InversionSolutionNrmlData.model_validate(data)
+        return cls(
+            pk=d.object_id,
+            file_name=d.file_name,
+            md5_digest=d.md5_digest,
+            file_size=d.file_size,
+            meta=[KeyValuePair(k=i.k, v=i.v) for i in d.meta] if d.meta else None,
+            created=d.created,
+            source_solution_raw_id=d.source_solution,
+            predecessors_raw=[p.model_dump() for p in d.predecessors] if d.predecessors else None,
+        )
+
+
+@strawberry.input
+class CreateInversionSolutionNrmlInput:
+    file_name: str
+    source_solution: strawberry.ID | None = None
+    md5_digest: str | None = None
+    file_size: BigInt | None = None
+    meta: list[KeyValuePairInput] | None = None
+    created: str | None = None
+    predecessors: list[PredecessorInput] | None = None
+
+
+def resolve_inversion_solution_nrmls(info: Info) -> Iterable[InversionSolutionNrml]:
+    items = list_files(info.context["dynamodb"], "InversionSolutionNrml")
+    return [InversionSolutionNrml.from_dict(item) for item in items]
+
+
+def mutate_create_inversion_solution_nrml(info: Info, input: CreateInversionSolutionNrmlInput) -> InversionSolutionNrml:
+    meta = [{"k": i.k, "v": i.v} for i in input.meta] if input.meta else None
+    predecessors = [{"id": str(p.id), "depth": p.depth} for p in input.predecessors] if input.predecessors else None
+    payload = {
+        "file_name": input.file_name,
+        "md5_digest": input.md5_digest,
+        "file_size": input.file_size,
+        "meta": meta,
+        "created": input.created,
+        "source_solution": str(input.source_solution) if input.source_solution else None,
+        "predecessors": predecessors,
+    }
+    data = create_file(info.context["dynamodb"], "InversionSolutionNrml", payload)
+    return InversionSolutionNrml.from_dict(data)

--- a/spike/strawberry_poc/models/object_identity.py
+++ b/spike/strawberry_poc/models/object_identity.py
@@ -1,0 +1,71 @@
+"""ObjectIdentity — types for object_identities and legacy_object_identities queries."""
+
+import base64
+
+import strawberry
+from strawberry.relay import GlobalID
+
+
+@strawberry.type
+class ObjectIdentity:
+    object_type: str | None = None
+    object_id: str | None = None
+    clazz_name: str | None = None
+    node_id: strawberry.ID | None = None
+
+
+@strawberry.type
+class ObjectIdentitiesEdge:
+    node: ObjectIdentity | None = None
+    cursor: str = ""
+
+
+@strawberry.type
+class ObjectIdentitiesPageInfo:
+    has_next_page: bool = False
+    end_cursor: str | None = None
+
+
+@strawberry.type
+class ObjectIdentitiesConnection:
+    edges: list[ObjectIdentitiesEdge] = strawberry.field(default_factory=list)
+    page_info: ObjectIdentitiesPageInfo = strawberry.field(default_factory=ObjectIdentitiesPageInfo)
+
+
+def encode_cursor(object_id: str) -> str:
+    return base64.b64encode(f"ObjectIdentitiesConnectionCursor:{object_id}".encode()).decode()
+
+
+def decode_cursor(cursor: str) -> str | None:
+    try:
+        decoded = base64.b64decode(cursor.encode()).decode()
+        _, _, node_id = decoded.partition(":")
+        return node_id or None
+    except Exception:
+        return None
+
+
+def make_object_identities_connection(
+    items: list[dict],
+    has_more: bool,
+    last_id: str | None,
+) -> ObjectIdentitiesConnection:
+    edges = []
+    for item in items:
+        object_id = item.get("object_id", "")
+        clazz = item.get("clazz_name") or item.get("object_type", "")
+        node_id = strawberry.ID(str(GlobalID(type_name=clazz, node_id=object_id))) if clazz else None
+        node = ObjectIdentity(
+            object_type=clazz,
+            object_id=object_id,
+            clazz_name=item.get("clazz_name"),
+            node_id=node_id,
+        )
+        edges.append(ObjectIdentitiesEdge(node=node, cursor=encode_cursor(object_id)))
+    return ObjectIdentitiesConnection(
+        edges=edges,
+        page_info=ObjectIdentitiesPageInfo(
+            has_next_page=has_more,
+            end_cursor=encode_cursor(last_id) if last_id else None,
+        ),
+    )

--- a/spike/strawberry_poc/models/openquake_hazard_config.py
+++ b/spike/strawberry_poc/models/openquake_hazard_config.py
@@ -1,0 +1,106 @@
+"""OpenquakeHazardConfig — Thing type holding source model references."""
+
+from collections.abc import Iterable
+from typing import Annotated, Optional
+
+import strawberry
+from strawberry import relay
+from strawberry.relay import GlobalID
+from strawberry.types import Info
+
+from data.dynamo import create_thing, get_file, get_thing, list_things
+from data.models import OpenquakeHazardConfigData
+from models.file import ToshiFile
+from models.inversion_solution_nrml import InversionSolutionNrml
+
+# ── OpenquakeNrmlUnion ────────────────────────────────────────────────────────
+
+_ToshiFile = Annotated["ToshiFile", strawberry.lazy("models.file")]
+_InversionSolutionNrml = Annotated["InversionSolutionNrml", strawberry.lazy("models.inversion_solution_nrml")]
+
+OpenquakeNrmlUnion = Annotated[
+    _ToshiFile | _InversionSolutionNrml,
+    strawberry.union(name="OpenquakeNrmlUnion"),
+]
+
+
+def dispatch_nrml(data: dict):
+    clazz = data.get("clazz_name", "")
+    if clazz == "InversionSolutionNrml":
+        return InversionSolutionNrml.from_dict(data)
+    return ToshiFile.from_dict(data)
+
+
+# ── OpenquakeHazardConfig ─────────────────────────────────────────────────────
+
+
+@strawberry.type
+class OpenquakeHazardConfig(relay.Node):
+    pk: relay.NodeID[str]
+    created: str | None = None
+
+    source_models_raw_ids: strawberry.Private[list[str] | None] = None
+    template_archive_raw_id: strawberry.Private[str | None] = None
+
+    @strawberry.field
+    def source_models(self, info: Info) -> list[OpenquakeNrmlUnion] | None:
+        if not self.source_models_raw_ids:
+            return None
+        results = []
+        for gid_str in self.source_models_raw_ids:
+            try:
+                raw_id = GlobalID.from_id(gid_str).node_id
+            except Exception:
+                raw_id = gid_str
+            data = get_file(info.context["dynamodb"], raw_id)
+            if data:
+                results.append(dispatch_nrml(data))
+        return results or None
+
+    @strawberry.field
+    def template_archive(self, info: Info) -> _ToshiFile | None:
+        if not self.template_archive_raw_id:
+            return None
+        try:
+            raw_id = GlobalID.from_id(self.template_archive_raw_id).node_id
+        except Exception:
+            raw_id = self.template_archive_raw_id
+        data = get_file(info.context["dynamodb"], raw_id)
+        return ToshiFile.from_dict(data) if data else None
+
+    @classmethod
+    def resolve_node(cls, node_id: str, *, info: Info, **kwargs) -> Optional["OpenquakeHazardConfig"]:
+        data = get_thing(info.context["dynamodb"], node_id)
+        return cls.from_dict(data) if data else None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "OpenquakeHazardConfig":
+        d = OpenquakeHazardConfigData.model_validate(data)
+        return cls(
+            pk=d.object_id,
+            created=d.created,
+            source_models_raw_ids=d.source_models,
+            template_archive_raw_id=d.template_archive,
+        )
+
+
+@strawberry.input
+class CreateOpenquakeHazardConfigInput:
+    template_archive: strawberry.ID
+    source_models: list[strawberry.ID] | None = None
+    created: str | None = None
+
+
+def resolve_openquake_hazard_configs(info: Info) -> Iterable[OpenquakeHazardConfig]:
+    items = list_things(info.context["dynamodb"], "OpenquakeHazardConfig")
+    return [OpenquakeHazardConfig.from_dict(item) for item in items]
+
+
+def mutate_create_openquake_hazard_config(info: Info, input: CreateOpenquakeHazardConfigInput) -> OpenquakeHazardConfig:
+    payload = {
+        "created": input.created,
+        "template_archive": str(input.template_archive),
+        "source_models": [str(s) for s in input.source_models] if input.source_models else None,
+    }
+    data = create_thing(info.context["dynamodb"], "OpenquakeHazardConfig", payload)
+    return OpenquakeHazardConfig.from_dict(data)

--- a/spike/strawberry_poc/models/openquake_hazard_solution.py
+++ b/spike/strawberry_poc/models/openquake_hazard_solution.py
@@ -1,0 +1,133 @@
+"""OpenquakeHazardSolution — Thing type produced by an OpenquakeHazardTask."""
+
+from collections.abc import Iterable
+from typing import Annotated, Optional
+
+import strawberry
+from strawberry import relay
+from strawberry.relay import GlobalID
+from strawberry.types import Info
+
+from data.dynamo import create_thing, get_file, get_thing, list_things
+from data.models import OpenquakeHazardSolutionData
+from models.file import ToshiFile
+from models.openquake_hazard_task import OpenquakeHazardTask
+
+from .common import KeyValuePair, KeyValuePairInput, OpenquakeTaskType
+from .predecessor import PredecessorInput
+from .predecessors_interface import PredecessorsInterface
+
+_OpenquakeHazardTask = Annotated["OpenquakeHazardTask", strawberry.lazy("models.openquake_hazard_task")]
+_ToshiFile = Annotated["ToshiFile", strawberry.lazy("models.file")]
+
+
+@strawberry.type
+class OpenquakeHazardSolution(relay.Node, PredecessorsInterface):
+    pk: relay.NodeID[str]
+    created: str | None = None
+    task_type: OpenquakeTaskType | None = None
+    metrics: list[KeyValuePair] | None = None
+    meta: list[KeyValuePair] | None = None
+
+    produced_by_raw_id: strawberry.Private[str | None] = None
+    csv_archive_raw_id: strawberry.Private[str | None] = None
+    hdf5_archive_raw_id: strawberry.Private[str | None] = None
+    task_args_raw_id: strawberry.Private[str | None] = None
+    predecessors_raw: strawberry.Private[list | None] = None
+
+    def _resolve_file(self, info: Info, raw_id: str | None):
+        if not raw_id:
+            return None
+        try:
+            node_id = GlobalID.from_id(raw_id).node_id
+        except Exception:
+            node_id = raw_id
+        data = get_file(info.context["dynamodb"], node_id)
+        return ToshiFile.from_dict(data) if data else None
+
+    @strawberry.field
+    def produced_by(self, info: Info) -> _OpenquakeHazardTask | None:
+        if not self.produced_by_raw_id:
+            return None
+        try:
+            raw_id = GlobalID.from_id(self.produced_by_raw_id).node_id
+        except Exception:
+            raw_id = self.produced_by_raw_id
+        data = get_thing(info.context["dynamodb"], raw_id)
+        return OpenquakeHazardTask.from_dict(data) if data else None
+
+    @strawberry.field
+    def csv_archive(self, info: Info) -> _ToshiFile | None:
+        return self._resolve_file(info, self.csv_archive_raw_id)
+
+    @strawberry.field
+    def hdf5_archive(self, info: Info) -> _ToshiFile | None:
+        return self._resolve_file(info, self.hdf5_archive_raw_id)
+
+    @strawberry.field
+    def task_args(self, info: Info) -> _ToshiFile | None:
+        return self._resolve_file(info, self.task_args_raw_id)
+
+    @classmethod
+    def resolve_node(cls, node_id: str, *, info: Info, **kwargs) -> Optional["OpenquakeHazardSolution"]:
+        data = get_thing(info.context["dynamodb"], node_id)
+        return cls.from_dict(data) if data else None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "OpenquakeHazardSolution":
+        d = OpenquakeHazardSolutionData.model_validate(data)
+        try:
+            task_type = OpenquakeTaskType(d.task_type) if d.task_type else None
+        except ValueError:
+            task_type = None
+        return cls(
+            pk=d.object_id,
+            created=d.created,
+            task_type=task_type,
+            metrics=[KeyValuePair(k=i.k, v=i.v) for i in d.metrics] if d.metrics else None,
+            meta=[KeyValuePair(k=i.k, v=i.v) for i in d.meta] if d.meta else None,
+            produced_by_raw_id=d.produced_by,
+            csv_archive_raw_id=d.csv_archive,
+            hdf5_archive_raw_id=d.hdf5_archive,
+            task_args_raw_id=d.task_args,
+            predecessors_raw=[p.model_dump() for p in d.predecessors] if d.predecessors else None,
+        )
+
+
+@strawberry.input
+class CreateOpenquakeHazardSolutionInput:
+    produced_by: strawberry.ID
+    task_type: OpenquakeTaskType
+    created: str | None = None
+    csv_archive: strawberry.ID | None = None
+    hdf5_archive: strawberry.ID | None = None
+    task_args: strawberry.ID | None = None
+    metrics: list[KeyValuePairInput] | None = None
+    meta: list[KeyValuePairInput] | None = None
+    predecessors: list[PredecessorInput] | None = None
+
+
+def resolve_openquake_hazard_solutions(info: Info) -> Iterable[OpenquakeHazardSolution]:
+    items = list_things(info.context["dynamodb"], "OpenquakeHazardSolution")
+    return [OpenquakeHazardSolution.from_dict(item) for item in items]
+
+
+def mutate_create_openquake_hazard_solution(
+    info: Info, input: CreateOpenquakeHazardSolutionInput
+) -> OpenquakeHazardSolution:
+    metrics = [{"k": i.k, "v": i.v} for i in input.metrics] if input.metrics else None
+    meta = [{"k": i.k, "v": i.v} for i in input.meta] if input.meta else None
+    predecessors = [{"id": str(p.id), "depth": p.depth} for p in input.predecessors] if input.predecessors else None
+    payload = {
+        "created": input.created,
+        "task_type": input.task_type.value,
+        "produced_by": str(input.produced_by),
+        "csv_archive": str(input.csv_archive) if input.csv_archive else None,
+        "hdf5_archive": str(input.hdf5_archive) if input.hdf5_archive else None,
+        "task_args": str(input.task_args) if input.task_args else None,
+        "metrics": metrics,
+        "meta": meta,
+        "predecessors": predecessors,
+    }
+    data = create_thing(info.context["dynamodb"], "OpenquakeHazardSolution", payload)
+    return OpenquakeHazardSolution.from_dict(data)

--- a/spike/strawberry_poc/models/openquake_hazard_task.py
+++ b/spike/strawberry_poc/models/openquake_hazard_task.py
@@ -1,0 +1,177 @@
+"""OpenquakeHazardTask — Thing type extending AutomationTask with hazard-specific fields."""
+
+from collections.abc import Iterable
+from typing import Annotated, Optional
+
+import strawberry
+from strawberry import relay
+from strawberry.relay import GlobalID
+from strawberry.types import Info
+
+from data.dynamo import create_thing, get_thing, list_things, update_thing
+from data.models import OpenquakeHazardTaskData
+
+from .common import EventResult, EventState, KeyValuePair, KeyValuePairInput, ModelType, TaskSubType, _try_enum
+from .relations import (
+    FileRelation,
+    FileRelationsConnection,
+    TaskRelationsConnection,
+    TaskTaskRelation,
+    build_file_relations_for_thing,
+    build_task_children,
+    build_task_parents,
+)
+
+_OpenquakeHazardSolution = Annotated["OpenquakeHazardSolution", strawberry.lazy("models.openquake_hazard_solution")]
+
+
+@strawberry.type
+class OpenquakeHazardTask(relay.Node):
+    pk: relay.NodeID[str]
+    state: EventState | None = None
+    result: EventResult | None = None
+    task_type: TaskSubType | None = None
+    model_type: ModelType | None = None
+    created: str | None = None
+    duration: float | None = None
+    general_task_id: strawberry.ID | None = None
+    arguments: list[KeyValuePair] | None = None
+    environment: list[KeyValuePair] | None = None
+    metrics: list[KeyValuePair] | None = None
+    executor: str | None = None
+    srm_logic_tree: str | None = None  # JSON string
+    gmcm_logic_tree: str | None = None  # JSON string
+    openquake_config: str | None = None  # JSON string
+
+    files_raw: strawberry.Private[list | None] = None
+    parents_raw: strawberry.Private[list | None] = None
+    children_raw: strawberry.Private[list | None] = None
+    hazard_solution_raw_id: strawberry.Private[str | None] = None
+
+    @relay.connection(FileRelationsConnection)
+    def files(self, info: Info) -> list[FileRelation]:
+        return build_file_relations_for_thing(self.pk, self.files_raw or [])
+
+    @relay.connection(TaskRelationsConnection)
+    def parents(self, info: Info) -> list[TaskTaskRelation]:
+        return build_task_parents(self.pk, self.parents_raw or [])
+
+    @relay.connection(TaskRelationsConnection)
+    def children(self, info: Info) -> list[TaskTaskRelation]:
+        return build_task_children(self.pk, self.children_raw or [])
+
+    @strawberry.field
+    def hazard_solution(self, info: Info) -> _OpenquakeHazardSolution | None:
+        if not self.hazard_solution_raw_id:
+            return None
+        from models.openquake_hazard_solution import OpenquakeHazardSolution  # noqa: PLC0415
+
+        try:
+            raw_id = GlobalID.from_id(self.hazard_solution_raw_id).node_id
+        except Exception:
+            raw_id = self.hazard_solution_raw_id
+        data = get_thing(info.context["dynamodb"], raw_id)
+        return OpenquakeHazardSolution.from_dict(data) if data else None
+
+    @classmethod
+    def resolve_node(cls, node_id: str, *, info: Info, **kwargs) -> Optional["OpenquakeHazardTask"]:
+        data = get_thing(info.context["dynamodb"], node_id)
+        return cls.from_dict(data) if data else None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "OpenquakeHazardTask":
+        d = OpenquakeHazardTaskData.model_validate(data)
+        return cls(
+            pk=d.object_id,
+            state=_try_enum(EventState, d.state),
+            result=_try_enum(EventResult, d.result),
+            task_type=_try_enum(TaskSubType, d.task_type),
+            model_type=_try_enum(ModelType, d.model_type),
+            created=d.created,
+            duration=d.duration,
+            general_task_id=strawberry.ID(d.general_task_id) if d.general_task_id else None,
+            arguments=[KeyValuePair(k=i.k, v=i.v) for i in d.arguments] if d.arguments else None,
+            environment=[KeyValuePair(k=i.k, v=i.v) for i in d.environment] if d.environment else None,
+            metrics=[KeyValuePair(k=i.k, v=i.v) for i in d.metrics] if d.metrics else None,
+            executor=d.executor,
+            srm_logic_tree=d.srm_logic_tree,
+            gmcm_logic_tree=d.gmcm_logic_tree,
+            openquake_config=d.openquake_config,
+            files_raw=d.files,
+            parents_raw=d.parents,
+            children_raw=d.children,
+            hazard_solution_raw_id=d.hazard_solution,
+        )
+
+
+@strawberry.input
+class CreateOpenquakeHazardTaskInput:
+    state: EventState
+    result: EventResult
+    created: str
+    task_type: TaskSubType
+    duration: float | None = None
+    model_type: ModelType | None = None
+    arguments: list[KeyValuePairInput] | None = None
+    environment: list[KeyValuePairInput] | None = None
+    metrics: list[KeyValuePairInput] | None = None
+    executor: str | None = None
+    srm_logic_tree: str | None = None
+    gmcm_logic_tree: str | None = None
+    openquake_config: str | None = None
+    hazard_solution: strawberry.ID | None = None
+
+
+@strawberry.input
+class UpdateOpenquakeHazardTaskInput:
+    task_id: strawberry.ID
+    state: EventState | None = None
+    result: EventResult | None = None
+    duration: float | None = None
+    arguments: list[KeyValuePairInput] | None = None
+    environment: list[KeyValuePairInput] | None = None
+    metrics: list[KeyValuePairInput] | None = None
+    hazard_solution: strawberry.ID | None = None
+
+
+def resolve_openquake_hazard_tasks(info: Info) -> Iterable[OpenquakeHazardTask]:
+    items = list_things(info.context["dynamodb"], "OpenquakeHazardTask")
+    return [OpenquakeHazardTask.from_dict(item) for item in items]
+
+
+def mutate_create_openquake_hazard_task(info: Info, input: CreateOpenquakeHazardTaskInput) -> OpenquakeHazardTask:
+    payload = {
+        "state": input.state.value,
+        "result": input.result.value,
+        "created": input.created,
+        "task_type": input.task_type.value,
+        "duration": input.duration,
+        "model_type": input.model_type.value if input.model_type else None,
+        "arguments": [{"k": i.k, "v": i.v} for i in input.arguments] if input.arguments else None,
+        "environment": [{"k": i.k, "v": i.v} for i in input.environment] if input.environment else None,
+        "metrics": [{"k": i.k, "v": i.v} for i in input.metrics] if input.metrics else None,
+        "executor": input.executor,
+        "srm_logic_tree": input.srm_logic_tree,
+        "gmcm_logic_tree": input.gmcm_logic_tree,
+        "openquake_config": input.openquake_config,
+        "hazard_solution": str(input.hazard_solution) if input.hazard_solution else None,
+    }
+    data = create_thing(info.context["dynamodb"], "OpenquakeHazardTask", payload)
+    return OpenquakeHazardTask.from_dict(data)
+
+
+def mutate_update_openquake_hazard_task(
+    info: Info, input: UpdateOpenquakeHazardTaskInput
+) -> OpenquakeHazardTask | None:
+    gid = GlobalID.from_id(input.task_id)
+    payload = {
+        "state": input.state.value if input.state else None,
+        "result": input.result.value if input.result else None,
+        "duration": input.duration,
+        "arguments": [{"k": i.k, "v": i.v} for i in input.arguments] if input.arguments else None,
+        "environment": [{"k": i.k, "v": i.v} for i in input.environment] if input.environment else None,
+        "metrics": [{"k": i.k, "v": i.v} for i in input.metrics] if input.metrics else None,
+        "hazard_solution": str(input.hazard_solution) if input.hazard_solution else None,
+    }
+    data = update_thing(info.context["dynamodb"], gid.node_id, payload)
+    return OpenquakeHazardTask.from_dict(data) if data else None

--- a/spike/strawberry_poc/models/predecessor.py
+++ b/spike/strawberry_poc/models/predecessor.py
@@ -1,0 +1,34 @@
+"""Predecessor — embedded provenance type (not a relay.Node)."""
+
+import strawberry
+from strawberry.relay import GlobalID
+
+from .common import AncestryLabel
+
+
+@strawberry.type
+class Predecessor:
+    """An ancestor in the provenance chain, stored inline in the parent."""
+
+    id: strawberry.ID
+    depth: int
+
+    @strawberry.field
+    def typename(self) -> str | None:
+        try:
+            return GlobalID.from_id(self.id).type_name
+        except Exception:
+            return None
+
+    @strawberry.field
+    def relationship(self) -> str | None:
+        try:
+            return AncestryLabel(self.depth).name.lower()
+        except ValueError:
+            return None
+
+
+@strawberry.input
+class PredecessorInput:
+    id: strawberry.ID
+    depth: int

--- a/spike/strawberry_poc/models/predecessors_interface.py
+++ b/spike/strawberry_poc/models/predecessors_interface.py
@@ -1,0 +1,16 @@
+"""PredecessorsInterface — matches legacy graphql_api.schema.custom.common.PredecessorsInterface."""
+
+import strawberry
+
+from .predecessor import Predecessor
+
+
+@strawberry.interface
+class PredecessorsInterface:
+    """Shared by types that carry an inline provenance chain."""
+
+    @strawberry.field
+    def predecessors(self) -> list[Predecessor] | None:
+        if not self.predecessors_raw:  # type: ignore[attr-defined]
+            return None
+        return [Predecessor(id=p["id"], depth=p["depth"]) for p in self.predecessors_raw]  # type: ignore[attr-defined]

--- a/spike/strawberry_poc/models/relations.py
+++ b/spike/strawberry_poc/models/relations.py
@@ -1,0 +1,369 @@
+"""
+FileRelation and TaskTaskRelation — virtual join types.
+
+Neither is stored as a separate DynamoDB record. Both are assembled on-the-fly
+from embedded arrays inside Thing / File objects:
+  - Thing.files      → list of {"file_id": ..., "file_role": ...}
+  - File.relations   → list of {"id": thing_id, "role": ...}
+  - Thing.children   → list of {"child_id": ..., "child_clazz": ...}
+  - Thing.parents    → list of {"parent_id": ..., "parent_clazz": ...}
+
+strawberry.lazy is used to reference types defined in other modules without
+causing circular imports at schema build time.
+"""
+
+from typing import Annotated
+
+import strawberry
+from strawberry import relay
+from strawberry.relay import GlobalID
+from strawberry.types import Info
+
+from data.dynamo import create_file_relation, create_task_relation, get_file, get_thing
+
+from .common import FileRole
+
+# ── Lazy forward references (break circular deps) ─────────────────────────────
+
+_ToshiFile = Annotated["ToshiFile", strawberry.lazy("models.file")]
+_SmsFile = Annotated["SmsFile", strawberry.lazy("models.sms_file")]
+_RuptureSet = Annotated["RuptureSet", strawberry.lazy("models.rupture_set")]
+_InversionSolution = Annotated["InversionSolution", strawberry.lazy("models.inversion_solution")]
+_ScaledInversionSolution = Annotated["ScaledInversionSolution", strawberry.lazy("models.scaled_inversion_solution")]
+_AggregateInversionSolution = Annotated[
+    "AggregateInversionSolution", strawberry.lazy("models.aggregate_inversion_solution")
+]
+_TimeDependentInversionSolution = Annotated[
+    "TimeDependentInversionSolution", strawberry.lazy("models.time_dependent_inversion_solution")
+]
+_InversionSolutionNrml = Annotated["InversionSolutionNrml", strawberry.lazy("models.inversion_solution_nrml")]
+_GeneralTask = Annotated["GeneralTask", strawberry.lazy("models.general_task")]
+_RuptureGenerationTask = Annotated["RuptureGenerationTask", strawberry.lazy("models.automation_task")]
+_AutomationTask = Annotated["AutomationTask", strawberry.lazy("models.automation_task")]
+_StrongMotionStation = Annotated["StrongMotionStation", strawberry.lazy("models.strong_motion_station")]
+_OpenquakeHazardTask = Annotated["OpenquakeHazardTask", strawberry.lazy("models.openquake_hazard_task")]
+_OpenquakeHazardSolution = Annotated["OpenquakeHazardSolution", strawberry.lazy("models.openquake_hazard_solution")]
+_OpenquakeHazardConfig = Annotated["OpenquakeHazardConfig", strawberry.lazy("models.openquake_hazard_config")]
+
+# Union types — referenced as return types of @strawberry.field methods
+FileUnion = Annotated[
+    _ToshiFile
+    | _SmsFile
+    | _RuptureSet
+    | _InversionSolution
+    | _ScaledInversionSolution
+    | _AggregateInversionSolution
+    | _TimeDependentInversionSolution
+    | _InversionSolutionNrml,
+    strawberry.union(name="FileUnion"),
+]
+
+ThingUnion = Annotated[
+    _GeneralTask
+    | _RuptureGenerationTask
+    | _AutomationTask
+    | _StrongMotionStation
+    | _OpenquakeHazardTask
+    | _OpenquakeHazardSolution
+    | _OpenquakeHazardConfig,
+    strawberry.union(name="ThingUnion"),
+]
+
+ChildTaskUnion = Annotated[
+    _GeneralTask
+    | _RuptureGenerationTask
+    | _AutomationTask
+    | _StrongMotionStation
+    | _OpenquakeHazardTask
+    | _OpenquakeHazardSolution,
+    strawberry.union(name="ChildTaskUnion"),
+]
+
+
+# ── InversionSolutionRelations ────────────────────────────────────────────────
+
+
+@strawberry.type
+class InversionSolutionRelations:
+    """Return type for InversionSolutionInterface.relations; provides total_count."""
+
+    edges: list["FileRelation"] = strawberry.field(default_factory=list)
+
+    @strawberry.field
+    def total_count(self) -> int:
+        return len(self.edges)
+
+
+# ── FileRelation ──────────────────────────────────────────────────────────────
+
+
+@strawberry.type
+class FileRelation:
+    """
+    Virtual type linking a File to a Thing.
+    Assembled from the embedded arrays in both records (not a stored entity).
+    """
+
+    role: FileRole
+    file_raw_id: strawberry.Private[str]
+    thing_raw_id: strawberry.Private[str]
+
+    @strawberry.field
+    def file(self, info: Info) -> FileUnion | None:
+        data = get_file(info.context["dynamodb"], self.file_raw_id)
+        return _dispatch_file(data) if data else None
+
+    @strawberry.field
+    def thing(self, info: Info) -> ThingUnion | None:
+        data = get_thing(info.context["dynamodb"], self.thing_raw_id)
+        return _dispatch_thing(data) if data else None
+
+
+# ── TaskTaskRelation ──────────────────────────────────────────────────────────
+
+
+@strawberry.type
+class TaskTaskRelation:
+    """
+    Virtual type linking a parent task to a child task.
+    Assembled from the embedded children/parents arrays.
+    """
+
+    parent_raw_id: strawberry.Private[str]
+    child_raw_id: strawberry.Private[str]
+    child_clazz: strawberry.Private[str]
+
+    @strawberry.field
+    def parent(self, info: Info) -> _GeneralTask | None:
+        from models.general_task import GeneralTask  # noqa: PLC0415
+
+        data = get_thing(info.context["dynamodb"], self.parent_raw_id)
+        return GeneralTask.from_dict(data) if data else None
+
+    @strawberry.field
+    def child(self, info: Info) -> ChildTaskUnion | None:
+        data = get_thing(info.context["dynamodb"], self.child_raw_id)
+        return _dispatch_thing(data) if data else None
+
+
+# ── Connection types with total_count ────────────────────────────────────────
+#
+# Strawberry optimisation: when the query does not request `edges`, it skips
+# building edges entirely (should_resolve_list_connection_edges → False).
+# Overriding resolve_connection lets us count BEFORE that optimisation fires.
+
+
+@strawberry.type
+class FileRelationsConnection(relay.ListConnection[FileRelation]):
+    """Relay connection for FileRelation that exposes total_count."""
+
+    _total: strawberry.Private[int] = 0
+
+    @strawberry.field
+    def total_count(self) -> int:
+        return self._total
+
+    @classmethod
+    def resolve_connection(cls, nodes, *, info, **kwargs):
+        nodes_list = list(nodes)
+        conn = super().resolve_connection(nodes_list, info=info, **kwargs)
+        conn._total = len(nodes_list)
+        return conn
+
+
+@strawberry.type
+class TaskRelationsConnection(relay.ListConnection[TaskTaskRelation]):
+    """Relay connection for TaskTaskRelation that exposes total_count."""
+
+    _total: strawberry.Private[int] = 0
+
+    @strawberry.field
+    def total_count(self) -> int:
+        return self._total
+
+    @classmethod
+    def resolve_connection(cls, nodes, *, info, **kwargs):
+        nodes_list = list(nodes)
+        conn = super().resolve_connection(nodes_list, info=info, **kwargs)
+        conn._total = len(nodes_list)
+        return conn
+
+
+# ── Dispatch helpers ──────────────────────────────────────────────────────────
+
+
+def _dispatch_file(data: dict):
+    """Instantiate the right Strawberry file type from a raw data dict."""
+    clazz = data.get("clazz_name", "")
+    if clazz == "SmsFile":
+        from models.sms_file import SmsFile  # noqa: PLC0415
+
+        return SmsFile.from_dict(data)
+    if clazz == "RuptureSet":
+        from models.rupture_set import RuptureSet  # noqa: PLC0415
+
+        return RuptureSet.from_dict(data)
+    if clazz == "InversionSolution":
+        from models.inversion_solution import InversionSolution  # noqa: PLC0415
+
+        return InversionSolution.from_dict(data)
+    if clazz == "ScaledInversionSolution":
+        from models.scaled_inversion_solution import ScaledInversionSolution  # noqa: PLC0415
+
+        return ScaledInversionSolution.from_dict(data)
+    if clazz == "AggregateInversionSolution":
+        from models.aggregate_inversion_solution import AggregateInversionSolution  # noqa: PLC0415
+
+        return AggregateInversionSolution.from_dict(data)
+    if clazz == "TimeDependentInversionSolution":
+        from models.time_dependent_inversion_solution import TimeDependentInversionSolution  # noqa: PLC0415
+
+        return TimeDependentInversionSolution.from_dict(data)
+    if clazz == "InversionSolutionNrml":
+        from models.inversion_solution_nrml import InversionSolutionNrml  # noqa: PLC0415
+
+        return InversionSolutionNrml.from_dict(data)
+    from models.file import ToshiFile  # noqa: PLC0415
+
+    return ToshiFile.from_dict(data)
+
+
+def _dispatch_thing(data: dict):
+    """Instantiate the right Strawberry thing type from a raw data dict."""
+    clazz = data.get("clazz_name", "")
+    if clazz == "RuptureGenerationTask":
+        from models.automation_task import RuptureGenerationTask  # noqa: PLC0415
+
+        return RuptureGenerationTask.from_dict(data)
+    if clazz == "AutomationTask":
+        from models.automation_task import AutomationTask  # noqa: PLC0415
+
+        return AutomationTask.from_dict(data)
+    if clazz == "StrongMotionStation":
+        from models.strong_motion_station import StrongMotionStation  # noqa: PLC0415
+
+        return StrongMotionStation.from_dict(data)
+    if clazz == "OpenquakeHazardTask":
+        from models.openquake_hazard_task import OpenquakeHazardTask  # noqa: PLC0415
+
+        return OpenquakeHazardTask.from_dict(data)
+    if clazz == "OpenquakeHazardSolution":
+        from models.openquake_hazard_solution import OpenquakeHazardSolution  # noqa: PLC0415
+
+        return OpenquakeHazardSolution.from_dict(data)
+    if clazz == "OpenquakeHazardConfig":
+        from models.openquake_hazard_config import OpenquakeHazardConfig  # noqa: PLC0415
+
+        return OpenquakeHazardConfig.from_dict(data)
+    from models.general_task import GeneralTask  # noqa: PLC0415
+
+    return GeneralTask.from_dict(data)
+
+
+# ── Input types for mutations ─────────────────────────────────────────────────
+
+
+@strawberry.input
+class CreateFileRelationInput:
+    thing_id: strawberry.ID
+    file_id: strawberry.ID
+    role: FileRole
+
+
+@strawberry.input
+class CreateTaskRelationInput:
+    parent_id: strawberry.ID
+    child_id: strawberry.ID
+
+
+# ── Builder helpers (called from Thing/File from_dict) ────────────────────────
+
+
+def build_file_relations_for_thing(thing_raw_id: str, files_raw: list) -> list[FileRelation]:
+    """Build FileRelation list from a Thing's embedded files array."""
+    result = []
+    for entry in files_raw or []:
+        file_id = entry.get("file_id")
+        if not file_id:
+            continue
+        try:
+            role = FileRole(entry.get("file_role", "undefined"))
+        except ValueError:
+            role = FileRole.UNDEFINED
+        result.append(FileRelation(role=role, file_raw_id=file_id, thing_raw_id=thing_raw_id))
+    return result
+
+
+def build_file_relations_for_file(file_raw_id: str, relations_raw: list) -> list[FileRelation]:
+    """Build FileRelation list from a File's embedded relations array."""
+    result = []
+    for entry in relations_raw or []:
+        thing_id = entry.get("id")
+        if not thing_id:
+            continue
+        try:
+            role = FileRole(entry.get("role", "undefined"))
+        except ValueError:
+            role = FileRole.UNDEFINED
+        result.append(FileRelation(role=role, file_raw_id=file_raw_id, thing_raw_id=thing_id))
+    return result
+
+
+def build_task_children(parent_raw_id: str, children_raw: list) -> list[TaskTaskRelation]:
+    return [
+        TaskTaskRelation(
+            parent_raw_id=parent_raw_id,
+            child_raw_id=entry["child_id"],
+            child_clazz=entry.get("child_clazz", ""),
+        )
+        for entry in (children_raw or [])
+        if "child_id" in entry
+    ]
+
+
+def build_task_parents(child_raw_id: str, parents_raw: list) -> list[TaskTaskRelation]:
+    return [
+        TaskTaskRelation(
+            parent_raw_id=entry["parent_id"],
+            child_raw_id=child_raw_id,
+            child_clazz="",
+        )
+        for entry in (parents_raw or [])
+        if "parent_id" in entry
+    ]
+
+
+# ── Mutation resolvers ────────────────────────────────────────────────────────
+
+
+def mutate_create_file_relation(info: Info, input: CreateFileRelationInput) -> bool:
+    thing_gid = GlobalID.from_id(input.thing_id)
+    file_gid = GlobalID.from_id(input.file_id)
+    create_file_relation(
+        info.context["dynamodb"],
+        thing_id=thing_gid.node_id,
+        file_id=file_gid.node_id,
+        role=input.role.value,
+    )
+    return True
+
+
+def mutate_create_task_relation(info: Info, input: CreateTaskRelationInput) -> TaskTaskRelation:
+    parent_gid = GlobalID.from_id(input.parent_id)
+    child_gid = GlobalID.from_id(input.child_id)
+    parent_data = get_thing(info.context["dynamodb"], parent_gid.node_id)
+    child_data = get_thing(info.context["dynamodb"], child_gid.node_id)
+    parent_clazz = parent_data.get("clazz_name", "") if parent_data else ""
+    child_clazz = child_data.get("clazz_name", "") if child_data else ""
+    create_task_relation(
+        info.context["dynamodb"],
+        parent_id=parent_gid.node_id,
+        parent_clazz=parent_clazz,
+        child_id=child_gid.node_id,
+        child_clazz=child_clazz,
+    )
+    return TaskTaskRelation(
+        parent_raw_id=parent_gid.node_id,
+        child_raw_id=child_gid.node_id,
+        child_clazz=child_clazz,
+    )

--- a/spike/strawberry_poc/models/rupture_set.py
+++ b/spike/strawberry_poc/models/rupture_set.py
@@ -1,0 +1,103 @@
+"""
+RuptureSet — file type with a produced_by relation.
+
+This is the union-type stress test: produced_by can be a RuptureGenerationTask
+(or other automation task types in future). In Strawberry, unions are explicit
+annotated types — much cleaner than Graphene's dynamic dispatch.
+"""
+
+from collections.abc import Iterable
+from typing import Optional
+
+import strawberry
+from strawberry import relay
+from strawberry.relay import GlobalID
+from strawberry.types import Info
+
+from data.dynamo import create_file, get_file, get_thing, list_files
+from data.models import RuptureSetData
+
+from .automation_task import RuptureGenerationTask  # noqa: F401 — re-exported for schema.py
+from .common import BigInt, KeyValuePair, KeyValuePairInput
+from .file_interface import FileInterface
+
+# ── RuptureSet ────────────────────────────────────────────────────────────────
+
+
+@strawberry.type
+class RuptureSet(relay.Node, FileInterface):
+    """A RuptureSet file produced by a RuptureGenerationTask."""
+
+    pk: relay.NodeID[str]
+    fault_models: list[str] | None = None
+    metrics: list[KeyValuePair] | None = None
+    # stored as raw object_id; resolved lazily (hidden from GraphQL schema)
+    produced_by_raw_id: strawberry.Private[str | None] = None
+
+    @strawberry.field
+    def produced_by(self, info: Info) -> RuptureGenerationTask | None:
+        if not self.produced_by_raw_id:
+            return None
+        # produced_by is stored as a relay global ID string
+        try:
+            gid = GlobalID.from_id(self.produced_by_raw_id)
+            raw_id = gid.node_id
+        except Exception:
+            raw_id = self.produced_by_raw_id
+        data = get_thing(info.context["dynamodb"], raw_id)
+        return RuptureGenerationTask.from_dict(data) if data else None
+
+    @classmethod
+    def resolve_node(cls, node_id: str, *, info: Info, **kwargs) -> Optional["RuptureSet"]:
+        data = get_file(info.context["dynamodb"], node_id)
+        return cls.from_dict(data) if data else None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "RuptureSet":
+        d = RuptureSetData.model_validate(data)
+        return cls(
+            pk=d.object_id,
+            file_name=d.file_name,
+            md5_digest=d.md5_digest,
+            file_size=d.file_size,
+            created=d.created,
+            meta=[KeyValuePair(k=i.k, v=i.v) for i in d.meta] if d.meta else None,
+            fault_models=d.fault_models,
+            metrics=[KeyValuePair(k=i.k, v=i.v) for i in d.metrics] if d.metrics else None,
+            produced_by_raw_id=d.produced_by,
+        )
+
+
+@strawberry.input
+class CreateRuptureSetInput:
+    file_name: str
+    produced_by: strawberry.ID
+    md5_digest: str | None = None
+    file_size: BigInt | None = None
+    created: str | None = None
+    fault_models: list[str] | None = None
+    metrics: list[KeyValuePairInput] | None = None
+
+
+def resolve_rupture_sets(info: Info) -> Iterable[RuptureSet]:
+    items = list_files(info.context["dynamodb"], "RuptureSet")
+    return [RuptureSet.from_dict(item) for item in items]
+
+
+def mutate_create_rupture_set(info: Info, input: CreateRuptureSetInput) -> RuptureSet:
+    # Validate produced_by is a RuptureGenerationTask global ID
+    gid = relay.GlobalID.from_id(input.produced_by)
+    assert gid.type_name == "RuptureGenerationTask", f"produced_by must be a RuptureGenerationTask, got {gid.type_name}"
+
+    metrics = [{"k": i.k, "v": i.v} for i in input.metrics] if input.metrics else None
+    payload = {
+        "file_name": input.file_name,
+        "produced_by": str(input.produced_by),
+        "md5_digest": input.md5_digest,
+        "file_size": input.file_size,
+        "created": input.created,
+        "fault_models": input.fault_models,
+        "metrics": metrics,
+    }
+    data = create_file(info.context["dynamodb"], "RuptureSet", payload)
+    return RuptureSet.from_dict(data)

--- a/spike/strawberry_poc/models/scaled_inversion_solution.py
+++ b/spike/strawberry_poc/models/scaled_inversion_solution.py
@@ -1,0 +1,136 @@
+"""ScaledInversionSolution — file type with a source_solution (SourceSolutionUnion)."""
+
+from collections.abc import Iterable
+from typing import Annotated, Optional
+
+import strawberry
+from strawberry import relay
+from strawberry.relay import GlobalID
+from strawberry.types import Info
+
+from data.dynamo import create_file, get_file, list_files
+from data.models import ScaledInversionSolutionData
+
+from .common import BigInt, KeyValuePair, KeyValuePairInput
+from .file_interface import FileInterface
+from .inversion_solution import InversionSolution, LabelledTableRelation, _ltr_from_dict
+from .inversion_solution_interface import InversionSolutionInterface
+from .predecessor import PredecessorInput
+from .predecessors_interface import PredecessorsInterface
+from .time_dependent_inversion_solution import TimeDependentInversionSolution
+
+# ── SourceSolutionUnion (lazy — defined once here, imported elsewhere) ────────
+
+_InversionSolution = Annotated["InversionSolution", strawberry.lazy("models.inversion_solution")]
+_ScaledInversionSolution = Annotated["ScaledInversionSolution", strawberry.lazy("models.scaled_inversion_solution")]
+_AggregateInversionSolution = Annotated[
+    "AggregateInversionSolution", strawberry.lazy("models.aggregate_inversion_solution")
+]
+_TimeDependentInversionSolution = Annotated[
+    "TimeDependentInversionSolution", strawberry.lazy("models.time_dependent_inversion_solution")
+]
+
+SourceSolutionUnion = Annotated[
+    _InversionSolution | _ScaledInversionSolution | _AggregateInversionSolution | _TimeDependentInversionSolution,
+    strawberry.union(name="SourceSolutionUnion"),
+]
+
+
+def dispatch_source_solution(data: dict):
+    """Instantiate the correct Strawberry type from a raw file dict."""
+    clazz = data.get("clazz_name", "")
+    if clazz == "ScaledInversionSolution":
+        return ScaledInversionSolution.from_dict(data)
+    if clazz == "AggregateInversionSolution":
+        from models.aggregate_inversion_solution import AggregateInversionSolution  # noqa: PLC0415
+
+        return AggregateInversionSolution.from_dict(data)
+    if clazz == "TimeDependentInversionSolution":
+        return TimeDependentInversionSolution.from_dict(data)
+    return InversionSolution.from_dict(data)
+
+
+# ── ScaledInversionSolution ───────────────────────────────────────────────────
+
+
+@strawberry.type
+class ScaledInversionSolution(relay.Node, FileInterface, InversionSolutionInterface, PredecessorsInterface):
+    pk: relay.NodeID[str]
+    metrics: list[KeyValuePair] | None = None
+    # tables, produced_by, mfd_table, mfd_table_id, hazard_table_id, relations
+    # are all inherited from InversionSolutionInterface.
+
+    produced_by_raw_id: strawberry.Private[str | None] = None
+    source_solution_raw_id: strawberry.Private[str | None] = None
+    relations_raw: strawberry.Private[list | None] = None
+    predecessors_raw: strawberry.Private[list | None] = None
+
+    @strawberry.field
+    def source_solution(self, info: Info) -> SourceSolutionUnion | None:
+        if not self.source_solution_raw_id:
+            return None
+        try:
+            raw_id = GlobalID.from_id(self.source_solution_raw_id).node_id
+        except Exception:
+            raw_id = self.source_solution_raw_id
+        data = get_file(info.context["dynamodb"], raw_id)
+        return dispatch_source_solution(data) if data else None
+
+    @classmethod
+    def resolve_node(cls, node_id: str, *, info: Info, **kwargs) -> Optional["ScaledInversionSolution"]:
+        data = get_file(info.context["dynamodb"], node_id)
+        return cls.from_dict(data) if data else None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ScaledInversionSolution":
+        d = ScaledInversionSolutionData.model_validate(data)
+        return cls(
+            pk=d.object_id,
+            file_name=d.file_name,
+            md5_digest=d.md5_digest,
+            file_size=d.file_size,
+            meta=[KeyValuePair(k=i.k, v=i.v) for i in d.meta] if d.meta else None,
+            created=d.created,
+            metrics=[KeyValuePair(k=i.k, v=i.v) for i in d.metrics] if d.metrics else None,
+            tables=[_ltr_from_dict(t.model_dump()) for t in d.tables] if d.tables else None,
+            produced_by_raw_id=d.produced_by,
+            source_solution_raw_id=d.source_solution,
+            relations_raw=d.relations,
+            predecessors_raw=[p.model_dump() for p in d.predecessors] if d.predecessors else None,
+        )
+
+
+@strawberry.input
+class CreateScaledInversionSolutionInput:
+    file_name: str
+    source_solution: strawberry.ID
+    produced_by: strawberry.ID | None = None
+    md5_digest: str | None = None
+    file_size: BigInt | None = None
+    meta: list[KeyValuePairInput] | None = None
+    created: str | None = None
+    predecessors: list[PredecessorInput] | None = None
+
+
+def resolve_scaled_inversion_solutions(info: Info) -> Iterable[ScaledInversionSolution]:
+    items = list_files(info.context["dynamodb"], "ScaledInversionSolution")
+    return [ScaledInversionSolution.from_dict(item) for item in items]
+
+
+def mutate_create_scaled_inversion_solution(
+    info: Info, input: CreateScaledInversionSolutionInput
+) -> ScaledInversionSolution:
+    meta = [{"k": i.k, "v": i.v} for i in input.meta] if input.meta else None
+    predecessors = [{"id": str(p.id), "depth": p.depth} for p in input.predecessors] if input.predecessors else None
+    payload = {
+        "file_name": input.file_name,
+        "md5_digest": input.md5_digest,
+        "file_size": input.file_size,
+        "meta": meta,
+        "created": input.created,
+        "produced_by": str(input.produced_by) if input.produced_by else None,
+        "source_solution": str(input.source_solution),
+        "predecessors": predecessors,
+    }
+    data = create_file(info.context["dynamodb"], "ScaledInversionSolution", payload)
+    return ScaledInversionSolution.from_dict(data)

--- a/spike/strawberry_poc/models/sms_file.py
+++ b/spike/strawberry_poc/models/sms_file.py
@@ -1,0 +1,76 @@
+"""
+SmsFile — File type for Strong Motion Station data files.
+"""
+
+from collections.abc import Iterable
+from typing import Optional
+
+import strawberry
+from strawberry import relay
+from strawberry.types import Info
+
+from data.dynamo import create_file, get_file, list_files
+from data.models import SmsFileData
+
+from .common import BigInt, KeyValuePair, SmsFileType, _try_enum
+from .file_interface import FileInterface
+from .relations import FileRelation, FileRelationsConnection, build_file_relations_for_file
+
+
+@strawberry.type
+class SmsFile(relay.Node, FileInterface):
+    """A file associated with a Strong Motion Station."""
+
+    pk: relay.NodeID[str]
+    file_type: SmsFileType | None = None
+
+    relations_raw: strawberry.Private[list | None] = None
+
+    @relay.connection(FileRelationsConnection)
+    def relations(self, info: Info) -> list[FileRelation]:
+        return build_file_relations_for_file(self.pk, self.relations_raw or [])
+
+    @classmethod
+    def resolve_node(cls, node_id: str, *, info: Info, **kwargs) -> Optional["SmsFile"]:
+        data = get_file(info.context["dynamodb"], node_id)
+        return cls.from_dict(data) if data else None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SmsFile":
+        d = SmsFileData.model_validate(data)
+        return cls(
+            pk=d.object_id,
+            file_name=d.file_name,
+            md5_digest=d.md5_digest,
+            file_size=d.file_size,
+            file_type=_try_enum(SmsFileType, d.file_type),
+            created=d.created,
+            meta=[KeyValuePair(k=i.k, v=i.v) for i in d.meta] if d.meta else None,
+            relations_raw=d.relations,
+        )
+
+
+@strawberry.input
+class CreateSmsFileInput:
+    file_name: str
+    file_type: SmsFileType
+    md5_digest: str | None = None
+    file_size: BigInt | None = None
+    created: str | None = None
+
+
+def resolve_sms_files(info: Info) -> Iterable[SmsFile]:
+    items = list_files(info.context["dynamodb"], "SmsFile")
+    return [SmsFile.from_dict(item) for item in items]
+
+
+def mutate_create_sms_file(info: Info, input: CreateSmsFileInput) -> SmsFile:
+    payload = {
+        "file_name": input.file_name,
+        "file_type": input.file_type.value,
+        "md5_digest": input.md5_digest,
+        "file_size": input.file_size,
+        "created": input.created,
+    }
+    data = create_file(info.context["dynamodb"], "SmsFile", payload)
+    return SmsFile.from_dict(data)

--- a/spike/strawberry_poc/models/strong_motion_station.py
+++ b/spike/strawberry_poc/models/strong_motion_station.py
@@ -1,0 +1,98 @@
+"""
+StrongMotionStation — Thing type with file relations.
+"""
+
+from collections.abc import Iterable
+from typing import Optional
+
+import strawberry
+from strawberry import relay
+from strawberry.types import Info
+
+from data.dynamo import create_thing, get_thing, list_things
+from data.models import StrongMotionStationData
+
+from .common import SmsSiteClass, SmsSiteClassBasis, _try_enum
+from .relations import FileRelation, FileRelationsConnection, build_file_relations_for_thing
+
+
+@strawberry.type
+class StrongMotionStation(relay.Node):
+    """An NSHM Strong Motion Station record."""
+
+    pk: relay.NodeID[str]
+    site_code: str | None = None
+    site_class: SmsSiteClass | None = None
+    site_class_basis: SmsSiteClassBasis | None = None
+    Vs30_mean: list[float] | None = None
+    Vs30_std_dev: list[float] | None = None
+    liquefiable: bool | None = None
+    bedrock_encountered: bool | None = None
+    soft_clay_or_peat: bool | None = None
+    created: str | None = None
+    updated: str | None = None
+
+    files_raw: strawberry.Private[list | None] = None
+
+    @relay.connection(FileRelationsConnection)
+    def files(self, info: Info) -> list[FileRelation]:
+        return build_file_relations_for_thing(self.pk, self.files_raw or [])
+
+    @classmethod
+    def resolve_node(cls, node_id: str, *, info: Info, **kwargs) -> Optional["StrongMotionStation"]:
+        data = get_thing(info.context["dynamodb"], node_id)
+        return cls.from_dict(data) if data else None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "StrongMotionStation":
+        d = StrongMotionStationData.model_validate(data)
+        return cls(
+            pk=d.object_id,
+            site_code=d.site_code,
+            site_class=_try_enum(SmsSiteClass, d.site_class),
+            site_class_basis=_try_enum(SmsSiteClassBasis, d.site_class_basis),
+            Vs30_mean=d.Vs30_mean,
+            Vs30_std_dev=d.Vs30_std_dev,
+            liquefiable=d.liquefiable,
+            bedrock_encountered=d.bedrock_encountered,
+            soft_clay_or_peat=d.soft_clay_or_peat,
+            created=d.created,
+            updated=d.updated,
+            files_raw=d.files,
+        )
+
+
+@strawberry.input
+class CreateStrongMotionStationInput:
+    site_code: str | None = None
+    site_class: SmsSiteClass | None = None
+    site_class_basis: SmsSiteClassBasis | None = None
+    Vs30_mean: list[float] | None = None
+    Vs30_std_dev: list[float] | None = None
+    liquefiable: bool | None = None
+    bedrock_encountered: bool | None = None
+    soft_clay_or_peat: bool | None = None
+    created: str | None = None
+    updated: str | None = None
+
+
+def resolve_strong_motion_stations(info: Info) -> Iterable[StrongMotionStation]:
+    items = list_things(info.context["dynamodb"], "StrongMotionStation")
+    return [StrongMotionStation.from_dict(item) for item in items]
+
+
+def mutate_create_strong_motion_station(info: Info, input: CreateStrongMotionStationInput) -> StrongMotionStation:
+    payload = {
+        "site_code": input.site_code,
+        "site_class": input.site_class.value if input.site_class else None,
+        "site_class_basis": input.site_class_basis.value if input.site_class_basis else None,
+        "Vs30_mean": input.Vs30_mean,
+        "Vs30_std_dev": input.Vs30_std_dev,
+        "liquefiable": input.liquefiable,
+        "bedrock_encountered": input.bedrock_encountered,
+        "soft_clay_or_peat": input.soft_clay_or_peat,
+        "created": input.created,
+        "updated": input.updated,
+    }
+    data = create_thing(info.context["dynamodb"], "StrongMotionStation", payload)
+    return StrongMotionStation.from_dict(data)

--- a/spike/strawberry_poc/models/table.py
+++ b/spike/strawberry_poc/models/table.py
@@ -1,0 +1,79 @@
+"""Table — relay.Node for ToshiTableObject records."""
+
+from typing import Optional
+
+import strawberry
+from strawberry import relay
+from strawberry.types import Info
+
+from data.dynamo import create_table, get_table
+from data.models import TableData
+
+from .common import KeyValueListPair, KeyValueListPairInput, KeyValuePair, KeyValuePairInput, TableType, _try_enum
+
+
+@strawberry.type
+class Table(relay.Node):
+    pk: relay.NodeID[str]
+    object_id: strawberry.ID | None = None
+    name: str | None = None
+    created: str | None = None
+    column_headers: list[str] | None = None
+    column_types: list[str] | None = None
+    rows: list[list[str]] | None = None
+    meta: list[KeyValuePair] | None = None
+    table_type: TableType | None = None
+    dimensions: list[KeyValueListPair] | None = None
+
+    @classmethod
+    def resolve_node(cls, node_id: str, *, info: Info, **kwargs) -> Optional["Table"]:
+        data = get_table(info.context["dynamodb"], node_id)
+        return cls.from_dict(data) if data else None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Table":
+        d = TableData.model_validate(data)
+        table_type = _try_enum(TableType, d.table_type)
+        return cls(
+            pk=d.object_id,
+            object_id=strawberry.ID(d.object_id),
+            name=d.name,
+            created=d.created,
+            column_headers=d.column_headers,
+            column_types=d.column_types,
+            rows=d.rows,
+            meta=[KeyValuePair(k=i.k, v=i.v) for i in d.meta] if d.meta else None,
+            table_type=table_type,
+            dimensions=[KeyValueListPair(k=i.k, v=i.v) for i in d.dimensions] if d.dimensions else None,
+        )
+
+
+@strawberry.input
+class CreateTableInput:
+    object_id: strawberry.ID
+    name: str | None = None
+    created: str | None = None
+    column_headers: list[str] | None = None
+    column_types: list[str] | None = None
+    rows: list[list[str]] | None = None
+    meta: list[KeyValuePairInput] | None = None
+    table_type: TableType | None = None
+    dimensions: list[KeyValueListPairInput] | None = None
+
+
+def mutate_create_table(info: Info, input: CreateTableInput) -> Table:
+    meta = [{"k": i.k, "v": i.v} for i in input.meta] if input.meta else None
+    dimensions = [{"k": i.k, "v": i.v} for i in input.dimensions] if input.dimensions else None
+    payload = {
+        "object_id": str(input.object_id),
+        "name": input.name,
+        "created": input.created,
+        "column_headers": input.column_headers,
+        "column_types": input.column_types,
+        "rows": input.rows,
+        "meta": meta,
+        "table_type": input.table_type.value if input.table_type else None,
+        "dimensions": dimensions,
+    }
+    data = create_table(info.context["dynamodb"], "Table", payload)
+    return Table.from_dict(data)

--- a/spike/strawberry_poc/models/time_dependent_inversion_solution.py
+++ b/spike/strawberry_poc/models/time_dependent_inversion_solution.py
@@ -1,0 +1,104 @@
+"""TimeDependentInversionSolution — file type with a single InversionSolution source."""
+
+from collections.abc import Iterable
+from typing import Annotated, Optional
+
+import strawberry
+from strawberry import relay
+from strawberry.relay import GlobalID
+from strawberry.types import Info
+
+from data.dynamo import create_file, get_file, list_files
+from data.models import TimeDependentInversionSolutionData
+
+from .common import BigInt, KeyValuePair, KeyValuePairInput
+from .file_interface import FileInterface
+from .inversion_solution import InversionSolution, LabelledTableRelation, _ltr_from_dict
+from .inversion_solution_interface import InversionSolutionInterface
+from .predecessor import PredecessorInput
+from .predecessors_interface import PredecessorsInterface
+
+_InversionSolution = Annotated["InversionSolution", strawberry.lazy("models.inversion_solution")]
+
+
+@strawberry.type
+class TimeDependentInversionSolution(relay.Node, FileInterface, InversionSolutionInterface, PredecessorsInterface):
+    pk: relay.NodeID[str]
+    metrics: list[KeyValuePair] | None = None
+    # tables, produced_by, mfd_table, mfd_table_id, hazard_table_id, relations
+    # are all inherited from InversionSolutionInterface.
+
+    produced_by_raw_id: strawberry.Private[str | None] = None
+    source_solution_raw_id: strawberry.Private[str | None] = None
+    relations_raw: strawberry.Private[list | None] = None
+    predecessors_raw: strawberry.Private[list | None] = None
+
+    @strawberry.field
+    def source_solution(self, info: Info) -> _InversionSolution | None:
+        if not self.source_solution_raw_id:
+            return None
+        try:
+            raw_id = GlobalID.from_id(self.source_solution_raw_id).node_id
+        except Exception:
+            raw_id = self.source_solution_raw_id
+        data = get_file(info.context["dynamodb"], raw_id)
+        return InversionSolution.from_dict(data) if data else None
+
+    @classmethod
+    def resolve_node(cls, node_id: str, *, info: Info, **kwargs) -> Optional["TimeDependentInversionSolution"]:
+        data = get_file(info.context["dynamodb"], node_id)
+        return cls.from_dict(data) if data else None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "TimeDependentInversionSolution":
+        d = TimeDependentInversionSolutionData.model_validate(data)
+        return cls(
+            pk=d.object_id,
+            file_name=d.file_name,
+            md5_digest=d.md5_digest,
+            file_size=d.file_size,
+            meta=[KeyValuePair(k=i.k, v=i.v) for i in d.meta] if d.meta else None,
+            created=d.created,
+            metrics=[KeyValuePair(k=i.k, v=i.v) for i in d.metrics] if d.metrics else None,
+            tables=[_ltr_from_dict(t.model_dump()) for t in d.tables] if d.tables else None,
+            produced_by_raw_id=d.produced_by,
+            source_solution_raw_id=d.source_solution,
+            relations_raw=d.relations,
+            predecessors_raw=[p.model_dump() for p in d.predecessors] if d.predecessors else None,
+        )
+
+
+@strawberry.input
+class CreateTimeDependentInversionSolutionInput:
+    file_name: str
+    source_solution: strawberry.ID
+    produced_by: strawberry.ID | None = None
+    md5_digest: str | None = None
+    file_size: BigInt | None = None
+    meta: list[KeyValuePairInput] | None = None
+    created: str | None = None
+    predecessors: list[PredecessorInput] | None = None
+
+
+def resolve_time_dependent_inversion_solutions(info: Info) -> Iterable[TimeDependentInversionSolution]:
+    items = list_files(info.context["dynamodb"], "TimeDependentInversionSolution")
+    return [TimeDependentInversionSolution.from_dict(item) for item in items]
+
+
+def mutate_create_time_dependent_inversion_solution(
+    info: Info, input: CreateTimeDependentInversionSolutionInput
+) -> TimeDependentInversionSolution:
+    meta = [{"k": i.k, "v": i.v} for i in input.meta] if input.meta else None
+    predecessors = [{"id": str(p.id), "depth": p.depth} for p in input.predecessors] if input.predecessors else None
+    payload = {
+        "file_name": input.file_name,
+        "md5_digest": input.md5_digest,
+        "file_size": input.file_size,
+        "meta": meta,
+        "created": input.created,
+        "produced_by": str(input.produced_by) if input.produced_by else None,
+        "source_solution": str(input.source_solution),
+        "predecessors": predecessors,
+    }
+    data = create_file(info.context["dynamodb"], "TimeDependentInversionSolution", payload)
+    return TimeDependentInversionSolution.from_dict(data)

--- a/spike/strawberry_poc/pyproject.toml
+++ b/spike/strawberry_poc/pyproject.toml
@@ -1,0 +1,84 @@
+[project]
+name = "strawberry-poc"
+version = "0.1.0"
+description = "Strawberry+FastAPI POC for nshm-toshi-api — feasibility spike"
+requires-python = ">=3.12"
+dependencies = [
+    "strawberry-graphql[fastapi]>=0.243.0",
+    "boto3>=1.26",
+    "mangum>=0.17",
+    "pydantic>=2.0",
+    "python-dotenv>=1.0",
+    "requests>=2.28",
+]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+# POC has a flat layout (data/, models/, schema.py at root). pythonpath=["."]
+# in pytest config makes them importable at test time. Declaring an empty
+# package list tells setuptools to install only the project's [project]
+# dependencies without trying to package the source tree as a wheel.
+py-modules = []
+
+[tool.uv]
+package = false
+
+[tool.uv.workspace]
+members = ["."]
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP", "G004", "PLC0415"]
+
+[tool.ruff.lint.per-file-ignores]
+# strawberry.lazy() uses string forward refs that are intentionally not imported
+"models/*.py" = ["F821"]
+# test helpers / fixtures use local imports for clarity and testcontainer lazy-start patterns
+"tests/*.py" = ["PLC0415"]
+
+[tool.mypy]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "models.*"
+# Strawberry relay.Node **kwargs pattern triggers false-positive override warnings;
+# ListConnection[FileRelation/TaskTaskRelation] triggers false-positive type-var warnings;
+# strawberry.lazy() string forward refs trigger false-positive name-defined warnings.
+disable_error_code = ["override", "type-var", "name-defined"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]
+addopts = "--cov=. --cov-branch --cov-report=term-missing --cov-report=xml"
+markers = [
+    "integration: requires a live Elasticsearch instance (ES_ENDPOINT env var)",
+]
+
+[tool.coverage.run]
+omit = ["tests/*"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+]
+
+[dependency-groups]
+dev = [
+    "httpx>=0.27",
+    "mypy>=2.1.0",
+    "pytest>=8.0",
+    "pytest-cov>=7.1.0",
+    "testcontainers[dynamodb]>=4.0",
+    "tox",
+    "tox-uv",
+    "types-requests>=2.33.0.20260518",
+]

--- a/spike/strawberry_poc/schema.py
+++ b/spike/strawberry_poc/schema.py
@@ -1,0 +1,641 @@
+"""
+Root schema — Query + Mutation.
+
+Designed as a drop-in replacement for the Graphene stack:
+  - auto_camel_case=False  → field/mutation names stay snake_case
+  - Payload wrapper types  → mutation return shapes match Graphene's relay
+                             ClientIDMutation pattern exactly
+
+This means all existing client query strings work unchanged against
+either the old (Graphene/Flask) or new (Strawberry/FastAPI) stack.
+"""
+
+from collections.abc import Iterable
+from typing import Annotated
+
+import strawberry
+from strawberry import relay
+from strawberry.relay import GlobalID
+from strawberry.schema.config import StrawberryConfig
+
+import data.search as _data_search
+from data.dynamo import es_key_for, get_object, scan_objects_paginated
+from data.s3 import scan_s3_paginated
+from data.search import search as es_search
+from models.aggregate_inversion_solution import (
+    AggregateInversionSolution,
+    CreateAggregateInversionSolutionInput,
+    mutate_create_aggregate_inversion_solution,
+    resolve_aggregate_inversion_solutions,
+)
+from models.automation_task import (
+    AutomationTask,
+    CreateAutomationTaskInput,
+    RuptureGenerationTask,
+    UpdateAutomationTaskInput,
+    mutate_create_automation_task,
+    mutate_create_rupture_generation_task,
+    mutate_update_automation_task,
+    mutate_update_rupture_generation_task,
+    resolve_automation_tasks,
+    resolve_rupture_generation_tasks,
+)
+from models.file import CreateFileInput, ToshiFile, mutate_create_file, resolve_files
+from models.general_task import (
+    CreateGeneralTaskInput,
+    GeneralTask,
+    UpdateGeneralTaskInput,
+    mutate_create_general_task,
+    mutate_update_general_task,
+    resolve_general_tasks,
+)
+from models.inversion_solution import (
+    AppendInversionSolutionTablesInput,
+    CreateInversionSolutionInput,
+    InversionSolution,
+    mutate_append_inversion_solution_tables,
+    mutate_create_inversion_solution,
+    resolve_inversion_solutions,
+)
+from models.inversion_solution_nrml import (
+    CreateInversionSolutionNrmlInput,
+    InversionSolutionNrml,
+    mutate_create_inversion_solution_nrml,
+    resolve_inversion_solution_nrmls,
+)
+from models.object_identity import (
+    ObjectIdentitiesConnection,
+    decode_cursor,
+    make_object_identities_connection,
+)
+from models.openquake_hazard_config import (
+    CreateOpenquakeHazardConfigInput,
+    OpenquakeHazardConfig,
+    mutate_create_openquake_hazard_config,
+    resolve_openquake_hazard_configs,
+)
+from models.openquake_hazard_solution import (
+    CreateOpenquakeHazardSolutionInput,
+    OpenquakeHazardSolution,
+    mutate_create_openquake_hazard_solution,
+    resolve_openquake_hazard_solutions,
+)
+from models.openquake_hazard_task import (
+    CreateOpenquakeHazardTaskInput,
+    OpenquakeHazardTask,
+    UpdateOpenquakeHazardTaskInput,
+    mutate_create_openquake_hazard_task,
+    mutate_update_openquake_hazard_task,
+    resolve_openquake_hazard_tasks,
+)
+from models.relations import (
+    CreateFileRelationInput,
+    CreateTaskRelationInput,
+    TaskTaskRelation,
+    mutate_create_file_relation,
+    mutate_create_task_relation,
+)
+from models.rupture_set import (
+    CreateRuptureSetInput,
+    RuptureSet,
+    mutate_create_rupture_set,
+    resolve_rupture_sets,
+)
+from models.scaled_inversion_solution import (
+    CreateScaledInversionSolutionInput,
+    ScaledInversionSolution,
+    mutate_create_scaled_inversion_solution,
+    resolve_scaled_inversion_solutions,
+)
+from models.sms_file import CreateSmsFileInput, SmsFile, mutate_create_sms_file, resolve_sms_files
+from models.strong_motion_station import (
+    CreateStrongMotionStationInput,
+    StrongMotionStation,
+    mutate_create_strong_motion_station,
+    resolve_strong_motion_stations,
+)
+from models.table import CreateTableInput, Table, mutate_create_table
+from models.time_dependent_inversion_solution import (
+    CreateTimeDependentInversionSolutionInput,
+    TimeDependentInversionSolution,
+    mutate_create_time_dependent_inversion_solution,
+    resolve_time_dependent_inversion_solutions,
+)
+
+# ── SearchResult union + connection ───────────────────────────────────────────
+
+SearchResult = Annotated[
+    GeneralTask
+    | RuptureGenerationTask
+    | AutomationTask
+    | StrongMotionStation
+    | OpenquakeHazardTask
+    | OpenquakeHazardSolution
+    | OpenquakeHazardConfig
+    | ToshiFile
+    | SmsFile
+    | RuptureSet
+    | InversionSolution
+    | ScaledInversionSolution
+    | AggregateInversionSolution
+    | TimeDependentInversionSolution
+    | InversionSolutionNrml,
+    strawberry.union(name="SearchResult"),
+]
+
+
+@strawberry.type
+class SearchResultEdge:
+    node: SearchResult | None = None
+
+
+@strawberry.type
+class SearchResultConnection:
+    edges: list[SearchResultEdge] = strawberry.field(default_factory=list)
+
+
+@strawberry.type
+class SearchPayload:
+    search_result: SearchResultConnection | None = None
+
+
+def _dispatch_search(hit: dict) -> SearchResult | None:  # noqa: C901
+    """Instantiate the right Strawberry type from an ES _source dict."""
+    clazz = hit.get("clazz_name", "")
+    try:
+        if clazz == "GeneralTask":
+            return GeneralTask.from_dict(hit)
+        elif clazz == "RuptureGenerationTask":
+            return RuptureGenerationTask.from_dict(hit)
+        elif clazz == "AutomationTask":
+            return AutomationTask.from_dict(hit)
+        elif clazz == "StrongMotionStation":
+            return StrongMotionStation.from_dict(hit)
+        elif clazz == "OpenquakeHazardTask":
+            return OpenquakeHazardTask.from_dict(hit)
+        elif clazz == "OpenquakeHazardSolution":
+            return OpenquakeHazardSolution.from_dict(hit)
+        elif clazz == "OpenquakeHazardConfig":
+            return OpenquakeHazardConfig.from_dict(hit)
+        elif clazz == "SmsFile":
+            return SmsFile.from_dict(hit)
+        elif clazz == "RuptureSet":
+            return RuptureSet.from_dict(hit)
+        elif clazz == "InversionSolution":
+            return InversionSolution.from_dict(hit)
+        elif clazz == "ScaledInversionSolution":
+            return ScaledInversionSolution.from_dict(hit)
+        elif clazz == "AggregateInversionSolution":
+            return AggregateInversionSolution.from_dict(hit)
+        elif clazz == "TimeDependentInversionSolution":
+            return TimeDependentInversionSolution.from_dict(hit)
+        elif clazz == "InversionSolutionNrml":
+            return InversionSolutionNrml.from_dict(hit)
+        else:
+            return ToshiFile.from_dict(hit)
+    except Exception:
+        return None
+
+
+# ── Payload wrapper types (mirrors Graphene's ClientIDMutation Output pattern) ─
+
+
+@strawberry.type
+class CreateGeneralTaskPayload:
+    general_task: GeneralTask | None = None
+
+
+@strawberry.type
+class UpdateGeneralTaskPayload:
+    general_task: GeneralTask | None = None
+
+
+@strawberry.type
+class CreateRuptureGenerationTaskPayload:
+    task_result: RuptureGenerationTask | None = None
+
+
+@strawberry.type
+class UpdateRuptureGenerationTaskPayload:
+    task_result: RuptureGenerationTask | None = None
+
+
+@strawberry.type
+class CreateAutomationTaskPayload:
+    task_result: AutomationTask | None = None
+
+
+@strawberry.type
+class UpdateAutomationTaskPayload:
+    task_result: AutomationTask | None = None
+
+
+@strawberry.type
+class CreateFilePayload:
+    ok: bool | None = None
+    file_result: ToshiFile | None = None
+
+
+@strawberry.type
+class CreateSmsFilePayload:
+    ok: bool | None = None
+    file_result: SmsFile | None = None
+
+
+@strawberry.type
+class CreateStrongMotionStationPayload:
+    strong_motion_station: StrongMotionStation | None = None
+
+
+@strawberry.type
+class CreateRuptureSetPayload:
+    ok: bool | None = None
+    rupture_set: RuptureSet | None = None
+
+
+@strawberry.type
+class CreateFileRelationPayload:
+    ok: bool | None = None
+
+
+@strawberry.type
+class CreateTaskRelationPayload:
+    ok: bool | None = None
+    thing_relation: TaskTaskRelation | None = None
+
+
+@strawberry.type
+class CreateInversionSolutionPayload:
+    ok: bool | None = None
+    inversion_solution: InversionSolution | None = None
+
+
+@strawberry.type
+class AppendInversionSolutionTablesPayload:
+    ok: bool | None = None
+    inversion_solution: InversionSolution | None = None
+
+
+@strawberry.type
+class CreateScaledInversionSolutionPayload:
+    ok: bool | None = None
+    solution: ScaledInversionSolution | None = None
+
+
+@strawberry.type
+class CreateAggregateInversionSolutionPayload:
+    ok: bool | None = None
+    solution: AggregateInversionSolution | None = None
+
+
+@strawberry.type
+class CreateTimeDependentInversionSolutionPayload:
+    ok: bool | None = None
+    solution: TimeDependentInversionSolution | None = None
+
+
+@strawberry.type
+class CreateInversionSolutionNrmlPayload:
+    ok: bool | None = None
+    inversion_solution_nrml: InversionSolutionNrml | None = None
+
+
+@strawberry.type
+class CreateOpenquakeHazardConfigPayload:
+    ok: bool | None = None
+    config: OpenquakeHazardConfig | None = None
+
+
+@strawberry.type
+class CreateOpenquakeHazardSolutionPayload:
+    ok: bool | None = None
+    openquake_hazard_solution: OpenquakeHazardSolution | None = None
+
+
+@strawberry.type
+class CreateOpenquakeHazardTaskPayload:
+    ok: bool | None = None
+    task_result: OpenquakeHazardTask | None = None
+
+
+@strawberry.type
+class UpdateOpenquakeHazardTaskPayload:
+    ok: bool | None = None
+    task_result: OpenquakeHazardTask | None = None
+
+
+@strawberry.type
+class NodeFilterPayload:
+    ok: bool = False
+    result: SearchResultConnection = strawberry.field(default_factory=SearchResultConnection)
+
+
+@strawberry.type
+class CreateTablePayload:
+    ok: bool | None = None
+    table: Table | None = None
+
+
+@strawberry.type
+class ReindexPayload:
+    ok: bool = False
+    reindexed_ids: list[str] = strawberry.field(default_factory=list)
+
+
+# ── Query ──────────────────────────────────────────────────────────────────────
+
+
+@strawberry.type
+class Query:
+    node: relay.Node = relay.node()
+
+    @strawberry.field
+    def about(self) -> str:
+        return "Hello, I am nshm_toshi_api (Strawberry POC)! [AUTH]"
+
+    @relay.connection(relay.ListConnection[GeneralTask])
+    def general_tasks(self, info: strawberry.types.Info) -> Iterable[GeneralTask]:
+        return resolve_general_tasks(info)
+
+    @relay.connection(relay.ListConnection[RuptureSet])
+    def rupture_sets(self, info: strawberry.types.Info) -> Iterable[RuptureSet]:
+        return resolve_rupture_sets(info)
+
+    @relay.connection(relay.ListConnection[ToshiFile])
+    def files(self, info: strawberry.types.Info) -> Iterable[ToshiFile]:
+        return resolve_files(info)
+
+    @relay.connection(relay.ListConnection[SmsFile])
+    def sms_files(self, info: strawberry.types.Info) -> Iterable[SmsFile]:
+        return resolve_sms_files(info)
+
+    @relay.connection(relay.ListConnection[StrongMotionStation])
+    def strong_motion_stations(self, info: strawberry.types.Info) -> Iterable[StrongMotionStation]:
+        return resolve_strong_motion_stations(info)
+
+    @relay.connection(relay.ListConnection[AutomationTask])
+    def automation_tasks(self, info: strawberry.types.Info) -> Iterable[AutomationTask]:
+        return resolve_automation_tasks(info)
+
+    @relay.connection(relay.ListConnection[RuptureGenerationTask])
+    def rupture_generation_tasks(self, info: strawberry.types.Info) -> Iterable[RuptureGenerationTask]:
+        return resolve_rupture_generation_tasks(info)
+
+    @relay.connection(relay.ListConnection[InversionSolution])
+    def inversion_solutions(self, info: strawberry.types.Info) -> Iterable[InversionSolution]:
+        return resolve_inversion_solutions(info)
+
+    @relay.connection(relay.ListConnection[ScaledInversionSolution])
+    def scaled_inversion_solutions(self, info: strawberry.types.Info) -> Iterable[ScaledInversionSolution]:
+        return resolve_scaled_inversion_solutions(info)
+
+    @relay.connection(relay.ListConnection[AggregateInversionSolution])
+    def aggregate_inversion_solutions(self, info: strawberry.types.Info) -> Iterable[AggregateInversionSolution]:
+        return resolve_aggregate_inversion_solutions(info)
+
+    @relay.connection(relay.ListConnection[TimeDependentInversionSolution])
+    def time_dependent_inversion_solutions(
+        self, info: strawberry.types.Info
+    ) -> Iterable[TimeDependentInversionSolution]:
+        return resolve_time_dependent_inversion_solutions(info)
+
+    @relay.connection(relay.ListConnection[InversionSolutionNrml])
+    def inversion_solution_nrmls(self, info: strawberry.types.Info) -> Iterable[InversionSolutionNrml]:
+        return resolve_inversion_solution_nrmls(info)
+
+    @relay.connection(relay.ListConnection[OpenquakeHazardConfig])
+    def openquake_hazard_configs(self, info: strawberry.types.Info) -> Iterable[OpenquakeHazardConfig]:
+        return resolve_openquake_hazard_configs(info)
+
+    @relay.connection(relay.ListConnection[OpenquakeHazardSolution])
+    def openquake_hazard_solutions(self, info: strawberry.types.Info) -> Iterable[OpenquakeHazardSolution]:
+        return resolve_openquake_hazard_solutions(info)
+
+    @relay.connection(relay.ListConnection[OpenquakeHazardTask])
+    def openquake_hazard_tasks(self, info: strawberry.types.Info) -> Iterable[OpenquakeHazardTask]:
+        return resolve_openquake_hazard_tasks(info)
+
+    @strawberry.field
+    def object_identities(
+        self,
+        info: strawberry.types.Info,
+        object_type: str,
+        first: int = 5,
+        after: str | None = None,
+    ) -> ObjectIdentitiesConnection:
+        after_id = decode_cursor(after) if after else None
+        items, has_more, last_id = scan_objects_paginated(
+            info.context["dynamodb"], object_type, limit=first, after_id=after_id
+        )
+        return make_object_identities_connection(items, has_more, last_id)
+
+    @strawberry.field
+    def legacy_object_identities(
+        self,
+        info: strawberry.types.Info,
+        store_type: str,
+        first: int = 5,
+        after: str | None = None,
+    ) -> ObjectIdentitiesConnection:
+        if store_type not in ("File", "Thing", "Table"):
+            return ObjectIdentitiesConnection()
+        after_id = decode_cursor(after) if after else None
+        items, has_more, last_id = scan_s3_paginated(store_type, limit=first, after_id=after_id)
+        return make_object_identities_connection(items, has_more, last_id)
+
+    @strawberry.field
+    def nodes(self, info: strawberry.types.Info, id_in: list[strawberry.ID]) -> NodeFilterPayload:
+        edges = []
+        for gid_str in id_in:
+            try:
+                gid = GlobalID.from_id(str(gid_str))
+                data = get_object(info.context["dynamodb"], gid.type_name, gid.node_id)
+            except Exception:
+                continue
+            if data and (node := _dispatch_search(data)) is not None:
+                edges.append(SearchResultEdge(node=node))
+        return NodeFilterPayload(ok=True, result=SearchResultConnection(edges=edges))
+
+    @strawberry.field
+    def search(self, info: strawberry.types.Info, search_term: str) -> SearchPayload:
+        ctx = info.context
+        hits = es_search(
+            search_term,
+            endpoint=ctx.get("es_endpoint", ""),
+            index=ctx.get("es_index", "toshi-index-mapped"),
+        )
+        edges = [SearchResultEdge(node=node) for hit in hits if (node := _dispatch_search(hit)) is not None]
+        return SearchPayload(search_result=SearchResultConnection(edges=edges))
+
+
+# ── Mutation ───────────────────────────────────────────────────────────────────
+
+
+@strawberry.type
+class Mutation:
+    @strawberry.mutation
+    def create_general_task(
+        self, info: strawberry.types.Info, input: CreateGeneralTaskInput
+    ) -> CreateGeneralTaskPayload:
+        return CreateGeneralTaskPayload(general_task=mutate_create_general_task(info, input))
+
+    @strawberry.mutation
+    def update_general_task(
+        self, info: strawberry.types.Info, input: UpdateGeneralTaskInput
+    ) -> UpdateGeneralTaskPayload:
+        return UpdateGeneralTaskPayload(general_task=mutate_update_general_task(info, input))
+
+    @strawberry.mutation
+    def create_rupture_set(self, info: strawberry.types.Info, input: CreateRuptureSetInput) -> CreateRuptureSetPayload:
+        return CreateRuptureSetPayload(ok=True, rupture_set=mutate_create_rupture_set(info, input))
+
+    @strawberry.mutation
+    def create_file(self, info: strawberry.types.Info, input: CreateFileInput) -> CreateFilePayload:
+        return CreateFilePayload(ok=True, file_result=mutate_create_file(info, input))
+
+    @strawberry.mutation
+    def create_sms_file(self, info: strawberry.types.Info, input: CreateSmsFileInput) -> CreateSmsFilePayload:
+        return CreateSmsFilePayload(ok=True, file_result=mutate_create_sms_file(info, input))
+
+    @strawberry.mutation
+    def create_strong_motion_station(
+        self, info: strawberry.types.Info, input: CreateStrongMotionStationInput
+    ) -> CreateStrongMotionStationPayload:
+        return CreateStrongMotionStationPayload(strong_motion_station=mutate_create_strong_motion_station(info, input))
+
+    @strawberry.mutation
+    def create_automation_task(
+        self, info: strawberry.types.Info, input: CreateAutomationTaskInput
+    ) -> CreateAutomationTaskPayload:
+        return CreateAutomationTaskPayload(task_result=mutate_create_automation_task(info, input))
+
+    @strawberry.mutation
+    def create_rupture_generation_task(
+        self, info: strawberry.types.Info, input: CreateAutomationTaskInput
+    ) -> CreateRuptureGenerationTaskPayload:
+        return CreateRuptureGenerationTaskPayload(task_result=mutate_create_rupture_generation_task(info, input))
+
+    @strawberry.mutation
+    def update_rupture_generation_task(
+        self, info: strawberry.types.Info, input: UpdateAutomationTaskInput
+    ) -> UpdateRuptureGenerationTaskPayload:
+        return UpdateRuptureGenerationTaskPayload(task_result=mutate_update_rupture_generation_task(info, input))
+
+    @strawberry.mutation
+    def update_automation_task(
+        self, info: strawberry.types.Info, input: UpdateAutomationTaskInput
+    ) -> UpdateAutomationTaskPayload:
+        return UpdateAutomationTaskPayload(task_result=mutate_update_automation_task(info, input))
+
+    @strawberry.mutation
+    def create_inversion_solution(
+        self, info: strawberry.types.Info, input: CreateInversionSolutionInput
+    ) -> CreateInversionSolutionPayload:
+        return CreateInversionSolutionPayload(ok=True, inversion_solution=mutate_create_inversion_solution(info, input))
+
+    @strawberry.mutation
+    def create_table(self, info: strawberry.types.Info, input: CreateTableInput) -> CreateTablePayload:
+        return CreateTablePayload(ok=True, table=mutate_create_table(info, input))
+
+    @strawberry.mutation
+    def append_inversion_solution_tables(
+        self, info: strawberry.types.Info, input: AppendInversionSolutionTablesInput
+    ) -> AppendInversionSolutionTablesPayload:
+        return AppendInversionSolutionTablesPayload(
+            ok=True, inversion_solution=mutate_append_inversion_solution_tables(info, input)
+        )
+
+    @strawberry.mutation
+    def create_scaled_inversion_solution(
+        self, info: strawberry.types.Info, input: CreateScaledInversionSolutionInput
+    ) -> CreateScaledInversionSolutionPayload:
+        return CreateScaledInversionSolutionPayload(
+            ok=True, solution=mutate_create_scaled_inversion_solution(info, input)
+        )
+
+    @strawberry.mutation
+    def create_aggregate_inversion_solution(
+        self, info: strawberry.types.Info, input: CreateAggregateInversionSolutionInput
+    ) -> CreateAggregateInversionSolutionPayload:
+        return CreateAggregateInversionSolutionPayload(
+            ok=True, solution=mutate_create_aggregate_inversion_solution(info, input)
+        )
+
+    @strawberry.mutation
+    def create_time_dependent_inversion_solution(
+        self, info: strawberry.types.Info, input: CreateTimeDependentInversionSolutionInput
+    ) -> CreateTimeDependentInversionSolutionPayload:
+        return CreateTimeDependentInversionSolutionPayload(
+            ok=True, solution=mutate_create_time_dependent_inversion_solution(info, input)
+        )
+
+    @strawberry.mutation
+    def create_inversion_solution_nrml(
+        self, info: strawberry.types.Info, input: CreateInversionSolutionNrmlInput
+    ) -> CreateInversionSolutionNrmlPayload:
+        return CreateInversionSolutionNrmlPayload(
+            ok=True, inversion_solution_nrml=mutate_create_inversion_solution_nrml(info, input)
+        )
+
+    @strawberry.mutation
+    def create_openquake_hazard_config(
+        self, info: strawberry.types.Info, input: CreateOpenquakeHazardConfigInput
+    ) -> CreateOpenquakeHazardConfigPayload:
+        return CreateOpenquakeHazardConfigPayload(ok=True, config=mutate_create_openquake_hazard_config(info, input))
+
+    @strawberry.mutation
+    def create_openquake_hazard_solution(
+        self, info: strawberry.types.Info, input: CreateOpenquakeHazardSolutionInput
+    ) -> CreateOpenquakeHazardSolutionPayload:
+        return CreateOpenquakeHazardSolutionPayload(
+            ok=True, openquake_hazard_solution=mutate_create_openquake_hazard_solution(info, input)
+        )
+
+    @strawberry.mutation
+    def create_openquake_hazard_task(
+        self, info: strawberry.types.Info, input: CreateOpenquakeHazardTaskInput
+    ) -> CreateOpenquakeHazardTaskPayload:
+        return CreateOpenquakeHazardTaskPayload(ok=True, task_result=mutate_create_openquake_hazard_task(info, input))
+
+    @strawberry.mutation
+    def update_openquake_hazard_task(
+        self, info: strawberry.types.Info, input: UpdateOpenquakeHazardTaskInput
+    ) -> UpdateOpenquakeHazardTaskPayload:
+        return UpdateOpenquakeHazardTaskPayload(ok=True, task_result=mutate_update_openquake_hazard_task(info, input))
+
+    @strawberry.mutation
+    def create_file_relation(
+        self, info: strawberry.types.Info, input: CreateFileRelationInput
+    ) -> CreateFileRelationPayload:
+        mutate_create_file_relation(info, input)
+        return CreateFileRelationPayload(ok=True)
+
+    @strawberry.mutation
+    def create_task_relation(
+        self, info: strawberry.types.Info, input: CreateTaskRelationInput
+    ) -> CreateTaskRelationPayload:
+        relation = mutate_create_task_relation(info, input)
+        return CreateTaskRelationPayload(ok=True, thing_relation=relation)
+
+    @strawberry.mutation
+    def reindex(self, info: strawberry.types.Info, id_in: list[strawberry.ID]) -> ReindexPayload:
+        ctx = info.context
+        dynamodb = ctx["dynamodb"]
+        ep = ctx.get("es_endpoint", "")
+        idx = ctx.get("es_index", "toshi-index-mapped")
+        reindexed = []
+        for gid in id_in:
+            global_id = GlobalID.from_id(gid)
+            data = get_object(dynamodb, global_id.type_name, global_id.node_id)
+            if data:
+                key = es_key_for(global_id.type_name, global_id.node_id)
+                _data_search.index_document(key, data, endpoint=ep, index=idx)
+                reindexed.append(str(gid))
+        return ReindexPayload(ok=True, reindexed_ids=reindexed)
+
+
+schema = strawberry.Schema(
+    query=Query,
+    mutation=Mutation,
+    config=StrawberryConfig(auto_camel_case=False),
+)

--- a/spike/strawberry_poc/setup.cfg
+++ b/spike/strawberry_poc/setup.cfg
@@ -1,0 +1,19 @@
+[tox:tox]
+isolated_build = true
+envlist = py312
+
+[gh-actions]
+python =
+    3.12: py312
+
+[testenv]
+allowlist_externals = pytest
+dependency_groups = dev
+passenv = *
+setenv =
+    DEPLOYMENT_STAGE = TEST
+    AWS_DEFAULT_REGION = us-east-1
+    AWS_ACCESS_KEY_ID = testing
+    AWS_SECRET_ACCESS_KEY = testing
+commands =
+    pytest tests/ -v --junitxml=junit.xml {posargs}

--- a/spike/strawberry_poc/tests/conftest.py
+++ b/spike/strawberry_poc/tests/conftest.py
@@ -1,0 +1,129 @@
+"""
+Test fixtures using DynamoDB Local and Elasticsearch via testcontainers.
+
+Both services start once per session using the official Docker images:
+  - amazon/dynamodb-local  — real DynamoDB, supports transact_write_items
+  - elasticsearch:7.1.0    — same version as production
+
+DynamoDB tables are created fresh per test module (dropped on teardown) so
+modules remain isolated. Elasticsearch is shared across the session; search
+tests find whatever is indexed during their own module setup.
+"""
+
+import os
+
+import boto3
+import pytest
+import requests
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+STAGE = "TEST"
+REGION = "us-east-1"
+ES_INDEX = "toshi-index-mapped"
+
+os.environ.setdefault("DEPLOYMENT_STAGE", STAGE)
+os.environ.setdefault("AWS_DEFAULT_REGION", REGION)
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+os.environ.setdefault("AWS_SECURITY_TOKEN", "testing")
+os.environ.setdefault("AWS_SESSION_TOKEN", "testing")
+
+_TABLE_NAMES = [
+    f"ToshiThingObject-{STAGE}",
+    f"ToshiFileObject-{STAGE}",
+    f"ToshiTableObject-{STAGE}",
+]
+_IDENTITY_TABLE = f"ToshiIdentity-{STAGE}"
+
+
+def _create_tables(dynamodb):
+    for table_name in _TABLE_NAMES:
+        dynamodb.create_table(
+            TableName=table_name,
+            KeySchema=[{"AttributeName": "object_id", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "object_id", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+    dynamodb.create_table(
+        TableName=_IDENTITY_TABLE,
+        KeySchema=[{"AttributeName": "table_name", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "table_name", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+def _drop_tables(dynamodb):
+    for name in _TABLE_NAMES + [_IDENTITY_TABLE]:
+        try:
+            dynamodb.Table(name).delete()
+        except Exception:
+            pass
+
+
+@pytest.fixture(scope="session")
+def dynamo_endpoint():
+    """Start DynamoDB Local once for the entire test session."""
+    container = (
+        DockerContainer("amazon/dynamodb-local:latest")
+        .with_bind_ports(8000, None)
+        .with_command("-jar DynamoDBLocal.jar -inMemory -sharedDb")
+    )
+    with container as c:
+        wait_for_logs(c, "Initializing DynamoDB Local", timeout=30)
+        host = c.get_container_host_ip()
+        port = c.get_exposed_port(8000)
+        yield f"http://{host}:{port}"
+
+
+@pytest.fixture(scope="session")
+def es_endpoint():
+    """Start Elasticsearch 7.1.0 once for the entire test session."""
+    container = (
+        DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:7.1.0")
+        .with_bind_ports(9200, None)
+        .with_env("discovery.type", "single-node")
+        .with_env("ES_JAVA_OPTS", "-Xms256m -Xmx256m")
+    )
+    with container as c:
+        wait_for_logs(c, "started", timeout=60)
+        host = c.get_container_host_ip()
+        port = c.get_exposed_port(9200)
+        endpoint = f"http://{host}:{port}"
+        # wait for green/yellow status before yielding
+        for _ in range(30):
+            try:
+                resp = requests.get(f"{endpoint}/_cluster/health", timeout=2)
+                if resp.json().get("status") in ("green", "yellow"):
+                    break
+            except Exception:
+                pass
+            import time
+
+            time.sleep(1)
+        os.environ["ES_ENDPOINT"] = endpoint
+        yield endpoint
+
+
+@pytest.fixture(scope="module")
+def dynamodb(dynamo_endpoint):
+    """Module-scoped DynamoDB resource — fresh tables per test file."""
+    db = boto3.resource(
+        "dynamodb",
+        endpoint_url=dynamo_endpoint,
+        region_name=REGION,
+        aws_access_key_id="testing",
+        aws_secret_access_key="testing",
+    )
+    _create_tables(db)
+    yield db
+    _drop_tables(db)
+
+
+@pytest.fixture(scope="module")
+def gql_context(dynamodb, es_endpoint):
+    return {
+        "dynamodb": dynamodb,
+        "es_endpoint": es_endpoint,
+        "es_index": ES_INDEX,
+    }

--- a/spike/strawberry_poc/tests/test_aggregate_inversion_solution.py
+++ b/spike/strawberry_poc/tests/test_aggregate_inversion_solution.py
@@ -1,0 +1,242 @@
+"""
+Tests for AggregateInversionSolution — source_solutions array, common_rupture_set,
+aggregation_fn, produced_by, predecessors.
+"""
+
+import base64
+
+import pytest
+
+from schema import schema
+
+# ── GQL strings ───────────────────────────────────────────────────────────────
+
+CREATE_MUTATION = """
+mutation CreateAggregate($input: CreateAggregateInversionSolutionInput!) {
+    create_aggregate_inversion_solution(input: $input) {
+        ok
+        solution {
+            id
+            file_name
+            md5_digest
+            file_size
+            created
+            aggregation_fn
+            produced_by {
+                ... on AutomationTask { id }
+                ... on RuptureGenerationTask { id }
+            }
+            source_solutions {
+                ... on InversionSolution { id }
+                ... on ScaledInversionSolution { id }
+            }
+            common_rupture_set { id }
+            predecessors {
+                id
+                depth
+                typename
+                relationship
+            }
+        }
+    }
+}
+"""
+
+NODE_QUERY = """
+query GetNode($id: ID!) {
+    node(id: $id) {
+        id
+        ... on AggregateInversionSolution {
+            file_name
+            aggregation_fn
+            produced_by {
+                ... on AutomationTask { id }
+                ... on RuptureGenerationTask { id }
+            }
+            source_solutions {
+                ... on InversionSolution { id }
+            }
+            common_rupture_set { id }
+        }
+    }
+}
+"""
+
+
+# ── Seed helpers ──────────────────────────────────────────────────────────────
+
+
+def _seed_rgt(gql_context) -> str:
+    from data.dynamo import create_thing
+
+    data = create_thing(
+        gql_context["dynamodb"],
+        "RuptureGenerationTask",
+        {"state": "done", "result": "success", "created": "2024-01-01T00:00:00Z"},
+    )
+    return base64.b64encode(f"RuptureGenerationTask:{data['object_id']}".encode()).decode()
+
+
+def _seed_automation_task(gql_context) -> str:
+    from data.dynamo import create_thing
+
+    data = create_thing(
+        gql_context["dynamodb"],
+        "AutomationTask",
+        {"state": "done", "result": "success", "task_type": "aggregate_solution", "created": "2024-01-01T00:00:00Z"},
+    )
+    return base64.b64encode(f"AutomationTask:{data['object_id']}".encode()).decode()
+
+
+def _seed_inversion_solution(gql_context, rgt_id: str, label: str = "upstream.zip") -> str:
+    result = schema.execute_sync(
+        """
+        mutation($input: CreateInversionSolutionInput!) {
+            create_inversion_solution(input: $input) {
+                ok
+                inversion_solution { id }
+            }
+        }
+        """,
+        variable_values={
+            "input": {
+                "file_name": label,
+                "produced_by": rgt_id,
+                "md5_digest": "aabbccdd",
+                "file_size": 1024,
+                "created": "2024-01-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_inversion_solution"]["inversion_solution"]["id"]
+
+
+def _seed_rupture_set(gql_context, label: str = "rupture_set.zip") -> str:
+    from data.dynamo import create_file
+
+    data = create_file(gql_context["dynamodb"], "RuptureSet", {"file_name": label})
+    return base64.b64encode(f"RuptureSet:{data['object_id']}".encode()).decode()
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def rgt_id(gql_context):
+    return _seed_rgt(gql_context)
+
+
+@pytest.fixture(scope="module")
+def automation_task_id(gql_context):
+    return _seed_automation_task(gql_context)
+
+
+@pytest.fixture(scope="module")
+def source_solution_ids(gql_context, rgt_id):
+    """Two upstream InversionSolutions to aggregate."""
+    id1 = _seed_inversion_solution(gql_context, rgt_id, "upstream_a.zip")
+    id2 = _seed_inversion_solution(gql_context, rgt_id, "upstream_b.zip")
+    return [id1, id2]
+
+
+@pytest.fixture(scope="module")
+def common_rupture_set_id(gql_context):
+    return _seed_rupture_set(gql_context, "common_rupture_set.zip")
+
+
+@pytest.fixture(scope="module")
+def created_aggregate(gql_context, automation_task_id, source_solution_ids, common_rupture_set_id):
+    result = schema.execute_sync(
+        CREATE_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "aggregate_v1.zip",
+                "source_solutions": source_solution_ids,
+                "common_rupture_set": common_rupture_set_id,
+                "aggregation_fn": "MEAN",
+                "produced_by": automation_task_id,
+                "md5_digest": "deadbeef",
+                "file_size": 4096,
+                "created": "2024-05-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_aggregate_inversion_solution"]["solution"]
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+def test_create_returns_id(created_aggregate):
+    gid = created_aggregate["id"]
+    decoded = base64.b64decode(gid).decode()
+    assert decoded.startswith("AggregateInversionSolution:"), decoded
+
+
+def test_fields(created_aggregate):
+    s = created_aggregate
+    assert s["file_name"] == "aggregate_v1.zip"
+    assert s["md5_digest"] == "deadbeef"
+    assert s["file_size"] == 4096
+    assert s["created"] == "2024-05-01T00:00:00Z"
+    assert s["aggregation_fn"] == "MEAN"
+
+
+def test_source_solutions(created_aggregate, source_solution_ids):
+    returned_ids = {ss["id"] for ss in created_aggregate["source_solutions"]}
+    for sid in source_solution_ids:
+        assert sid in returned_ids, f"{sid} not in source_solutions"
+
+
+def test_common_rupture_set(created_aggregate, common_rupture_set_id):
+    crs = created_aggregate["common_rupture_set"]
+    assert crs is not None
+    assert crs["id"] == common_rupture_set_id
+
+
+def test_produced_by(created_aggregate, automation_task_id):
+    pb = created_aggregate["produced_by"]
+    assert pb is not None
+    assert pb["id"] == automation_task_id
+
+
+def test_node_lookup(created_aggregate, gql_context, automation_task_id, source_solution_ids, common_rupture_set_id):
+    result = schema.execute_sync(NODE_QUERY, variable_values={"id": created_aggregate["id"]}, context_value=gql_context)
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["file_name"] == "aggregate_v1.zip"
+    assert node["aggregation_fn"] == "MEAN"
+    assert node["produced_by"]["id"] == automation_task_id
+    assert node["common_rupture_set"]["id"] == common_rupture_set_id
+    returned_ids = {ss["id"] for ss in node["source_solutions"]}
+    for sid in source_solution_ids:
+        assert sid in returned_ids
+
+
+def test_with_predecessors(gql_context, automation_task_id, source_solution_ids, common_rupture_set_id):
+    result = schema.execute_sync(
+        CREATE_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "aggregate_with_pred.zip",
+                "source_solutions": source_solution_ids,
+                "common_rupture_set": common_rupture_set_id,
+                "aggregation_fn": "MEAN",
+                "produced_by": automation_task_id,
+                "md5_digest": "cafecafe",
+                "file_size": 2048,
+                "created": "2024-05-02T00:00:00Z",
+                "predecessors": [{"id": source_solution_ids[0], "depth": -1}],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    preds = result.data["create_aggregate_inversion_solution"]["solution"]["predecessors"]
+    assert len(preds) == 1
+    assert preds[0]["id"] == source_solution_ids[0]
+    assert preds[0]["relationship"] == "parent"

--- a/spike/strawberry_poc/tests/test_automation_task.py
+++ b/spike/strawberry_poc/tests/test_automation_task.py
@@ -1,0 +1,179 @@
+"""
+Tests for AutomationTask — create, node lookup, update mutation, ES re-index.
+
+Covers COVERAGE_GAPS.md gaps 1 (update_automation_task) and 10 (ES re-index on update).
+The update_automation_task mutation was wired in Phase A1.
+"""
+
+import base64
+
+import pytest
+
+from schema import schema
+
+CREATE_MUTATION = """
+mutation CreateTask($input: CreateAutomationTaskInput!) {
+    create_automation_task(input: $input) {
+        task_result {
+            id
+            state
+            result
+            task_type
+            created
+            duration
+            arguments { k v }
+            environment { k v }
+            metrics { k v }
+        }
+    }
+}
+"""
+
+UPDATE_MUTATION = """
+mutation UpdateTask($input: UpdateAutomationTaskInput!) {
+    update_automation_task(input: $input) {
+        task_result {
+            id
+            state
+            result
+            duration
+            metrics { k v }
+        }
+    }
+}
+"""
+
+NODE_QUERY = """
+query GetNode($id: ID!) {
+    node(id: $id) {
+        id
+        ... on AutomationTask {
+            state
+            result
+            duration
+            metrics { k v }
+        }
+    }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def created_task(gql_context):
+    result = schema.execute_sync(
+        CREATE_MUTATION,
+        variable_values={
+            "input": {
+                "state": "SCHEDULED",
+                "result": "UNDEFINED",
+                "task_type": "INVERSION",
+                "created": "2024-01-01T00:00:00Z",
+                "duration": 0.0,
+                "arguments": [{"k": "alpha", "v": "0.1"}],
+                "environment": [{"k": "host", "v": "ci"}],
+                "metrics": [{"k": "iters", "v": "10"}],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_automation_task"]["task_result"]
+
+
+def test_create_returns_id(created_task):
+    assert created_task["id"]
+    decoded = base64.b64decode(created_task["id"]).decode()
+    assert decoded.startswith("AutomationTask:")
+
+
+def test_create_fields(created_task):
+    assert created_task["state"] == "SCHEDULED"
+    assert created_task["result"] == "UNDEFINED"
+    assert created_task["task_type"] == "INVERSION"
+    assert created_task["created"] == "2024-01-01T00:00:00Z"
+    assert created_task["arguments"] == [{"k": "alpha", "v": "0.1"}]
+    assert created_task["environment"] == [{"k": "host", "v": "ci"}]
+    assert created_task["metrics"] == [{"k": "iters", "v": "10"}]
+
+
+def test_update_state_and_result(gql_context, created_task):
+    result = schema.execute_sync(
+        UPDATE_MUTATION,
+        variable_values={
+            "input": {
+                "task_id": created_task["id"],
+                "state": "DONE",
+                "result": "SUCCESS",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    updated = result.data["update_automation_task"]["task_result"]
+    assert updated["state"] == "DONE"
+    assert updated["result"] == "SUCCESS"
+
+    node_result = schema.execute_sync(
+        NODE_QUERY, variable_values={"id": created_task["id"]}, context_value=gql_context
+    )
+    assert node_result.errors is None, node_result.errors
+    assert node_result.data["node"]["state"] == "DONE"
+    assert node_result.data["node"]["result"] == "SUCCESS"
+
+
+def test_update_duration_and_metrics(gql_context, created_task):
+    result = schema.execute_sync(
+        UPDATE_MUTATION,
+        variable_values={
+            "input": {
+                "task_id": created_task["id"],
+                "duration": 123.45,
+                "metrics": [{"k": "iters", "v": "100"}, {"k": "rmse", "v": "0.02"}],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    updated = result.data["update_automation_task"]["task_result"]
+    assert updated["duration"] == 123.45
+    assert {"k": "rmse", "v": "0.02"} in updated["metrics"]
+
+
+def test_update_preserves_id(gql_context, created_task):
+    result = schema.execute_sync(
+        UPDATE_MUTATION,
+        variable_values={"input": {"task_id": created_task["id"], "duration": 999.0}},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    assert result.data["update_automation_task"]["task_result"]["id"] == created_task["id"]
+
+
+def test_update_triggers_es_reindex(gql_context, created_task, monkeypatch):
+    """Updating an AutomationTask must trigger ES re-indexing (gap 10)."""
+    from data import dynamo as dynamo_mod
+
+    calls = []
+
+    def fake_index(doc_id, body):
+        calls.append((doc_id, body))
+
+    monkeypatch.setattr(dynamo_mod, "index_document", fake_index)
+
+    result = schema.execute_sync(
+        UPDATE_MUTATION,
+        variable_values={
+            "input": {
+                "task_id": created_task["id"],
+                "state": "STARTED",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+
+    raw_id = base64.b64decode(created_task["id"]).decode().split(":")[1]
+    expected_doc_id = f"ThingData_{raw_id}"
+    matching = [c for c in calls if c[0] == expected_doc_id]
+    assert matching, f"index_document was not called with {expected_doc_id}; calls: {calls}"
+    assert matching[0][1].get("state") == "started"

--- a/spike/strawberry_poc/tests/test_create_file_validation.py
+++ b/spike/strawberry_poc/tests/test_create_file_validation.py
@@ -1,0 +1,116 @@
+"""
+Tests for create_file file_size type coercion / validation.
+
+Covers COVERAGE_GAPS.md gap 8 (mirrors legacy test_create_file_bugfix_159.py
+which exercised file_size as BigInt, float, int, string).
+
+file_size uses the custom BigInt scalar (see models/common.py) so values
+exceeding GraphQL's 32-bit Int limit (>2GB) round-trip correctly.
+"""
+
+from schema import schema
+
+MAX_INT32 = 2**31 - 1  # 2_147_483_647
+
+CREATE_FILE_MUTATION = """
+mutation($input: CreateFileInput!) {
+    create_file(input: $input) {
+        ok
+        file_result {
+            id
+            file_name
+            file_size
+        }
+    }
+}
+"""
+
+
+def test_create_file_with_int_file_size(gql_context):
+    """Standard small file_size as int — round-trips correctly."""
+    result = schema.execute_sync(
+        CREATE_FILE_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "small.zip",
+                "md5_digest": "00",
+                "file_size": 1024,
+                "created": "2024-05-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    assert result.data["create_file"]["file_result"]["file_size"] == 1024
+
+
+def test_create_file_with_max_int32_file_size(gql_context):
+    """file_size up to MAX_INT32 (~2GB) round-trips through GraphQL Int."""
+    result = schema.execute_sync(
+        CREATE_FILE_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "near_max.zip",
+                "md5_digest": "01a",
+                "file_size": MAX_INT32,
+                "created": "2024-05-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    assert result.data["create_file"]["file_result"]["file_size"] == MAX_INT32
+
+
+def test_create_file_with_large_file_size_bigint(gql_context):
+    """5GB file_size (> 32-bit int) round-trips correctly via the BigInt scalar."""
+    big = 5_000_000_000
+    result = schema.execute_sync(
+        CREATE_FILE_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "big.zip",
+                "md5_digest": "01",
+                "file_size": big,
+                "created": "2024-05-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    assert result.data["create_file"]["file_result"]["file_size"] == big
+
+
+def test_create_file_rejects_string_file_size(gql_context):
+    """Non-numeric string for file_size must surface as a GraphQL validation error."""
+    result = schema.execute_sync(
+        CREATE_FILE_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "bad.zip",
+                "md5_digest": "02",
+                "file_size": "not-a-number",
+                "created": "2024-05-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is not None
+    assert any("file_size" in str(e).lower() or "int" in str(e).lower() for e in result.errors)
+
+
+def test_create_file_with_null_file_size(gql_context):
+    """file_size omitted (null) is acceptable; the field is optional."""
+    result = schema.execute_sync(
+        CREATE_FILE_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "nofsize.zip",
+                "md5_digest": "03",
+                "created": "2024-05-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    assert result.data["create_file"]["file_result"]["file_size"] is None

--- a/spike/strawberry_poc/tests/test_file_relation.py
+++ b/spike/strawberry_poc/tests/test_file_relation.py
@@ -1,0 +1,130 @@
+"""Tests for file relations — linking ToshiFiles to tasks."""
+
+
+import pytest
+
+from schema import schema
+
+# ── GQL strings ───────────────────────────────────────────────────────────────
+
+CREATE_AUTOMATION_TASK_MUTATION = """
+mutation CreateTask($input: CreateAutomationTaskInput!) {
+    create_automation_task(input: $input) {
+        task_result {
+            id
+        }
+    }
+}
+"""
+
+CREATE_FILE_MUTATION = """
+mutation CreateFile($input: CreateFileInput!) {
+    create_file(input: $input) {
+        ok
+        file_result { id }
+    }
+}
+"""
+
+CREATE_FILE_RELATION_MUTATION = """
+mutation CreateFileRelation($input: CreateFileRelationInput!) {
+    create_file_relation(input: $input) {
+        ok
+    }
+}
+"""
+
+TASK_FILES_QUERY = """
+query GetTask($id: ID!) {
+    node(id: $id) {
+        id
+        ... on AutomationTask {
+            files {
+                edges {
+                    node {
+                        role
+                        file {
+                            ... on ToshiFile { id }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def task_id(gql_context):
+    result = schema.execute_sync(
+        CREATE_AUTOMATION_TASK_MUTATION,
+        variable_values={
+            "input": {
+                "state": "UNDEFINED",
+                "result": "UNDEFINED",
+                "task_type": "INVERSION",
+                "created": "2024-08-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_automation_task"]["task_result"]["id"]
+
+
+@pytest.fixture(scope="module")
+def file_id(gql_context):
+    result = schema.execute_sync(
+        CREATE_FILE_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "output_data.zip",
+                "md5_digest": "99aabbcc",
+                "file_size": 2048,
+                "created": "2024-08-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_file"]["file_result"]["id"]
+
+
+@pytest.fixture(scope="module")
+def created_relation(gql_context, task_id, file_id):
+    result = schema.execute_sync(
+        CREATE_FILE_RELATION_MUTATION,
+        variable_values={"input": {"thing_id": task_id, "file_id": file_id, "role": "READ"}},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_file_relation"]
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+def test_create_file_relation_ok(created_relation):
+    assert created_relation["ok"] is True
+
+
+def test_file_appears_in_task_files(gql_context, task_id, file_id, created_relation):
+    result = schema.execute_sync(TASK_FILES_QUERY, variable_values={"id": task_id}, context_value=gql_context)
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    edges = node["files"]["edges"]
+    assert len(edges) >= 1
+    linked_ids = [e["node"]["file"]["id"] for e in edges if e["node"]["file"]]
+    assert file_id in linked_ids, f"{file_id} not in {linked_ids}"
+
+
+def test_file_relation_role(gql_context, task_id, created_relation):
+    result = schema.execute_sync(TASK_FILES_QUERY, variable_values={"id": task_id}, context_value=gql_context)
+    assert result.errors is None, result.errors
+    edges = result.data["node"]["files"]["edges"]
+    roles = [e["node"]["role"] for e in edges]
+    assert "READ" in roles

--- a/spike/strawberry_poc/tests/test_general_task.py
+++ b/spike/strawberry_poc/tests/test_general_task.py
@@ -1,0 +1,283 @@
+"""
+Tests for GeneralTask — create, list, node lookup, update.
+
+Runs schema.execute_sync() directly against a moto-backed DynamoDB.
+All tests in this module share the module-scoped fixture, so created
+objects accumulate across tests (same behaviour as existing test suite).
+
+Field and mutation names use snake_case (auto_camel_case=False on schema).
+Mutations return payload wrapper types matching the Graphene API shape.
+"""
+
+import base64
+
+import pytest
+
+from schema import schema
+
+CREATE_MUTATION = """
+mutation CreateTask($input: CreateGeneralTaskInput!) {
+    create_general_task(input: $input) {
+        general_task {
+            id
+            title
+            description
+            agent_name
+            created
+            notes
+            subtask_count
+            subtask_type
+            subtask_result
+            model_type
+            meta { k v }
+            argument_lists { k v }
+            swept_arguments
+        }
+    }
+}
+"""
+
+UPDATE_MUTATION = """
+mutation UpdateTask($input: UpdateGeneralTaskInput!) {
+    update_general_task(input: $input) {
+        general_task {
+            id
+            title
+            notes
+            updated
+            subtask_count
+        }
+    }
+}
+"""
+
+LIST_QUERY = """
+query {
+    general_tasks {
+        edges {
+            node {
+                id
+                title
+            }
+        }
+    }
+}
+"""
+
+NODE_QUERY = """
+query GetNode($id: ID!) {
+    node(id: $id) {
+        id
+        ... on GeneralTask {
+            title
+            description
+            agent_name
+            subtask_result
+            children { total_count }
+        }
+    }
+}
+"""
+
+CREATE_AUTOMATION_TASK_MUTATION = """
+mutation CreateTask($input: CreateAutomationTaskInput!) {
+    create_automation_task(input: $input) {
+        task_result { id }
+    }
+}
+"""
+
+CREATE_TASK_RELATION_MUTATION = """
+mutation CreateRelation($input: CreateTaskRelationInput!) {
+    create_task_relation(input: $input) {
+        ok
+    }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def created_task(gql_context):
+    """Create one GeneralTask and return the result dict — shared across tests."""
+    result = schema.execute_sync(
+        CREATE_MUTATION,
+        variable_values={
+            "input": {
+                "title": "Test task",
+                "description": "A test general task",
+                "agent_name": "pytest",
+                "created": "2024-01-01T00:00:00Z",
+                "notes": "initial notes",
+                "subtask_count": 3,
+                "subtask_type": "INVERSION",
+                "subtask_result": "SUCCESS",
+                "model_type": "CRUSTAL",
+                "meta": [{"k": "env", "v": "ci"}],
+                "argument_lists": [
+                    {"k": "alpha", "v": ["0.1", "0.2", "0.3"]},
+                    {"k": "beta", "v": ["1.0"]},
+                ],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_general_task"]["general_task"]
+
+
+def test_create_returns_id(created_task):
+    assert created_task["id"]
+    # Relay global IDs are base64("TypeName:raw_id")
+    decoded = base64.b64decode(created_task["id"]).decode()
+    assert decoded.startswith("GeneralTask:")
+
+
+def test_create_fields(created_task):
+    assert created_task["title"] == "Test task"
+    assert created_task["description"] == "A test general task"
+    assert created_task["agent_name"] == "pytest"
+    assert created_task["created"] == "2024-01-01T00:00:00Z"
+    assert created_task["notes"] == "initial notes"
+    assert created_task["subtask_count"] == 3
+    assert created_task["subtask_type"] == "INVERSION"
+    assert created_task["model_type"] == "CRUSTAL"
+    assert created_task["meta"] == [{"k": "env", "v": "ci"}]
+
+
+def test_swept_arguments(created_task):
+    # alpha has 3 values → swept; beta has 1 → not swept
+    assert created_task["swept_arguments"] == ["alpha"]
+
+
+def test_list_general_tasks(gql_context, created_task):
+    result = schema.execute_sync(LIST_QUERY, context_value=gql_context)
+    assert result.errors is None, result.errors
+
+    edges = result.data["general_tasks"]["edges"]
+    assert len(edges) >= 1
+    ids = [e["node"]["id"] for e in edges]
+    assert created_task["id"] in ids
+
+
+def test_node_lookup(gql_context, created_task):
+    result = schema.execute_sync(
+        NODE_QUERY,
+        variable_values={"id": created_task["id"]},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+
+    node = result.data["node"]
+    assert node["id"] == created_task["id"]
+    assert node["title"] == "Test task"
+    assert node["description"] == "A test general task"
+    assert node["agent_name"] == "pytest"
+
+
+def test_update_general_task(gql_context, created_task):
+    result = schema.execute_sync(
+        UPDATE_MUTATION,
+        variable_values={
+            "input": {
+                "task_id": created_task["id"],
+                "title": "Updated title",
+                "notes": "updated notes",
+                "updated": "2024-06-01T00:00:00Z",
+                "subtask_count": 5,
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+
+    updated = result.data["update_general_task"]["general_task"]
+    assert updated["id"] == created_task["id"]
+    assert updated["title"] == "Updated title"
+    assert updated["notes"] == "updated notes"
+    assert updated["updated"] == "2024-06-01T00:00:00Z"
+    assert updated["subtask_count"] == 5
+
+
+def test_update_preserves_id(gql_context, created_task):
+    """Update must not change the relay global ID."""
+    result = schema.execute_sync(
+        UPDATE_MUTATION,
+        variable_values={
+            "input": {
+                "task_id": created_task["id"],
+                "notes": "another update",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    assert result.data["update_general_task"]["general_task"]["id"] == created_task["id"]
+
+
+def test_subtask_result_field(created_task):
+    """subtask_result is stored and returned as an EventResult enum value."""
+    assert created_task["subtask_result"] == "SUCCESS"
+
+
+def test_children_total_count_zero(gql_context, created_task):
+    """children.total_count is 0 when no child tasks have been linked."""
+    result = schema.execute_sync(
+        NODE_QUERY, variable_values={"id": created_task["id"]}, context_value=gql_context
+    )
+    assert result.errors is None, result.errors
+    assert result.data["node"]["children"]["total_count"] == 0
+
+
+def test_children_total_count_after_relation(gql_context, created_task):
+    """children.total_count increments after a task relation is created."""
+    child_result = schema.execute_sync(
+        CREATE_AUTOMATION_TASK_MUTATION,
+        variable_values={
+            "input": {
+                "state": "DONE",
+                "result": "SUCCESS",
+                "task_type": "INVERSION",
+                "created": "2024-01-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert child_result.errors is None, child_result.errors
+    child_id = child_result.data["create_automation_task"]["task_result"]["id"]
+
+    rel_result = schema.execute_sync(
+        CREATE_TASK_RELATION_MUTATION,
+        variable_values={"input": {"parent_id": created_task["id"], "child_id": child_id}},
+        context_value=gql_context,
+    )
+    assert rel_result.errors is None, rel_result.errors
+
+    result = schema.execute_sync(
+        NODE_QUERY, variable_values={"id": created_task["id"]}, context_value=gql_context
+    )
+    assert result.errors is None, result.errors
+    assert result.data["node"]["children"]["total_count"] == 1
+
+
+def test_unknown_enum_value_does_not_crash(gql_context):
+    """from_dict must survive unknown enum values in production data (returns None, not an error)."""
+    from data.dynamo import create_thing
+
+    raw = create_thing(
+        gql_context["dynamodb"],
+        "GeneralTask",
+        {
+            "title": "enum resilience test",
+            "subtask_type": "future_unknown_type",
+            "subtask_result": "future_unknown_result",
+            "model_type": "future_unknown_model",
+        },
+    )
+    import base64
+
+    gid = base64.b64encode(f"GeneralTask:{raw['object_id']}".encode()).decode()
+    result = schema.execute_sync(NODE_QUERY, variable_values={"id": gid}, context_value=gql_context)
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["title"] == "enum resilience test"
+    assert node["subtask_result"] is None

--- a/spike/strawberry_poc/tests/test_inversion_solution.py
+++ b/spike/strawberry_poc/tests/test_inversion_solution.py
@@ -1,0 +1,305 @@
+"""
+Tests for InversionSolution, ScaledInversionSolution, and the append-tables mutation.
+
+Key feasibility signals:
+  1. InversionSolution.produced_by — resolves AutomationTaskUnion (RuptureGenerationTask)
+  2. LabelledTableRelation — inline embedded type round-trips through DynamoDB
+  3. append_inversion_solution_tables — mutation appends tables to existing record
+  4. ScaledInversionSolution.source_solution — resolves SourceSolutionUnion (InversionSolution)
+  5. Predecessors — inline embedded type with computed typename/relationship
+"""
+
+import base64
+
+import pytest
+
+from schema import schema
+
+# ── Mutation / query strings ──────────────────────────────────────────────────
+
+CREATE_INVERSION_SOLUTION_MUTATION = """
+mutation CreateInversionSolution($input: CreateInversionSolutionInput!) {
+    create_inversion_solution(input: $input) {
+        ok
+        inversion_solution {
+            id
+            file_name
+            md5_digest
+            file_size
+            created
+            meta { k v }
+            metrics { k v }
+            tables {
+                table_id
+                table_type
+                label
+            }
+            produced_by {
+                ... on RuptureGenerationTask {
+                    id
+                    state
+                    result
+                }
+            }
+            predecessors {
+                id
+                depth
+                relationship
+            }
+        }
+    }
+}
+"""
+
+APPEND_TABLES_MUTATION = """
+mutation AppendTables($input: AppendInversionSolutionTablesInput!) {
+    append_inversion_solution_tables(input: $input) {
+        ok
+        inversion_solution {
+            id
+            tables {
+                table_id
+                table_type
+                label
+            }
+        }
+    }
+}
+"""
+
+CREATE_SCALED_MUTATION = """
+mutation CreateScaled($input: CreateScaledInversionSolutionInput!) {
+    create_scaled_inversion_solution(input: $input) {
+        ok
+        solution {
+            id
+            file_name
+            source_solution {
+                ... on InversionSolution {
+                    id
+                    file_name
+                }
+            }
+            predecessors {
+                id
+                depth
+                typename
+                relationship
+            }
+        }
+    }
+}
+"""
+
+NODE_QUERY = """
+query GetNode($id: ID!) {
+    node(id: $id) {
+        id
+        ... on InversionSolution {
+            file_name
+            tables {
+                table_id
+                table_type
+            }
+        }
+    }
+}
+"""
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _seed_rupture_gen_task(gql_context):
+    from data.dynamo import create_thing
+
+    data = create_thing(
+        gql_context["dynamodb"],
+        "RuptureGenerationTask",
+        {"state": "done", "result": "success", "created": "2024-01-01T00:00:00Z"},
+    )
+    raw_id = data["object_id"]
+    return base64.b64encode(f"RuptureGenerationTask:{raw_id}".encode()).decode()
+
+
+def _seed_toshi_file(gql_context, label="table.hdf5"):
+    """Seed a plain ToshiFile to act as a table target."""
+    from data.dynamo import create_file
+
+    data = create_file(
+        gql_context["dynamodb"],
+        "ToshiFile",
+        {"file_name": label},
+    )
+    raw_id = data["object_id"]
+    return base64.b64encode(f"ToshiFile:{raw_id}".encode()).decode()
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def rgt_id(gql_context):
+    return _seed_rupture_gen_task(gql_context)
+
+
+@pytest.fixture(scope="module")
+def table_file_id(gql_context):
+    return _seed_toshi_file(gql_context)
+
+
+@pytest.fixture(scope="module")
+def created_inversion_solution(gql_context, rgt_id, table_file_id):
+    result = schema.execute_sync(
+        CREATE_INVERSION_SOLUTION_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "inversion_solution_v1.zip",
+                "produced_by": rgt_id,
+                "md5_digest": "deadbeef",
+                "file_size": 2097152,
+                "created": "2024-03-01T00:00:00Z",
+                "meta": [{"k": "region", "v": "NZ"}],
+                "metrics": [{"k": "total_rate_weighting", "v": "1.0"}],
+                "tables": [
+                    {
+                        "table_id": table_file_id,
+                        "table_type": "MFD_CURVES",
+                        "label": "initial",
+                    }
+                ],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_inversion_solution"]["inversion_solution"]
+
+
+# ── InversionSolution tests ───────────────────────────────────────────────────
+
+
+def test_inversion_solution_id_encoding(created_inversion_solution):
+    gid = created_inversion_solution["id"]
+    decoded = base64.b64decode(gid).decode()
+    assert decoded.startswith("InversionSolution:"), f"Unexpected ID: {decoded}"
+
+
+def test_inversion_solution_fields(created_inversion_solution):
+    is_ = created_inversion_solution
+    assert is_["file_name"] == "inversion_solution_v1.zip"
+    assert is_["md5_digest"] == "deadbeef"
+    assert is_["file_size"] == 2097152
+    assert is_["created"] == "2024-03-01T00:00:00Z"
+    assert is_["meta"] == [{"k": "region", "v": "NZ"}]
+    assert is_["metrics"] == [{"k": "total_rate_weighting", "v": "1.0"}]
+
+
+def test_inversion_solution_table(created_inversion_solution, table_file_id):
+    tables = created_inversion_solution["tables"]
+    assert tables is not None
+    assert len(tables) == 1
+    t = tables[0]
+    assert t["table_id"] == table_file_id
+    assert t["table_type"] == "MFD_CURVES"
+    assert t["label"] == "initial"
+
+
+def test_inversion_solution_produced_by(created_inversion_solution, rgt_id):
+    pb = created_inversion_solution["produced_by"]
+    assert pb is not None
+    assert pb["id"] == rgt_id
+    assert pb["state"] == "DONE"
+    assert pb["result"] == "SUCCESS"
+
+
+def test_inversion_solution_no_predecessors_by_default(created_inversion_solution):
+    assert created_inversion_solution["predecessors"] is None
+
+
+def test_node_lookup(gql_context, created_inversion_solution, table_file_id):
+    result = schema.execute_sync(
+        NODE_QUERY,
+        variable_values={"id": created_inversion_solution["id"]},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["id"] == created_inversion_solution["id"]
+    assert node["file_name"] == "inversion_solution_v1.zip"
+    assert node["tables"][0]["table_id"] == table_file_id
+
+
+# ── Append tables mutation ────────────────────────────────────────────────────
+
+
+def test_append_inversion_solution_tables(gql_context, created_inversion_solution, table_file_id):
+    """append_inversion_solution_tables must add a new table without removing existing ones."""
+    extra_file_id = _seed_toshi_file(gql_context, "hazard.hdf5")
+    result = schema.execute_sync(
+        APPEND_TABLES_MUTATION,
+        variable_values={
+            "input": {
+                "id": created_inversion_solution["id"],
+                "tables": [
+                    {
+                        "table_id": extra_file_id,
+                        "table_type": "HAZARD_GRIDDED",
+                        "label": "appended",
+                    }
+                ],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    tables = result.data["append_inversion_solution_tables"]["inversion_solution"]["tables"]
+    assert len(tables) == 2, f"Expected 2 tables, got {len(tables)}"
+    types = {t["table_type"] for t in tables}
+    assert "MFD_CURVES" in types
+    assert "HAZARD_GRIDDED" in types
+
+
+# ── ScaledInversionSolution tests ─────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def created_scaled(gql_context, created_inversion_solution):
+    """Create a ScaledInversionSolution whose source_solution points to the InversionSolution."""
+    is_id = created_inversion_solution["id"]
+    result = schema.execute_sync(
+        CREATE_SCALED_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "scaled_v1.zip",
+                "source_solution": is_id,
+                "created": "2024-04-01T00:00:00Z",
+                "predecessors": [{"id": is_id, "depth": -1}],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_scaled_inversion_solution"]["solution"]
+
+
+def test_scaled_id_encoding(created_scaled):
+    decoded = base64.b64decode(created_scaled["id"]).decode()
+    assert decoded.startswith("ScaledInversionSolution:")
+
+
+def test_scaled_source_solution_resolves(created_scaled, created_inversion_solution):
+    ss = created_scaled["source_solution"]
+    assert ss is not None
+    assert ss["id"] == created_inversion_solution["id"]
+    assert ss["file_name"] == "inversion_solution_v1.zip"
+
+
+def test_scaled_predecessor_relationship(created_scaled, created_inversion_solution):
+    preds = created_scaled["predecessors"]
+    assert preds is not None and len(preds) == 1
+    p = preds[0]
+    assert p["id"] == created_inversion_solution["id"]
+    assert p["depth"] == -1
+    assert p["typename"] == "InversionSolution"
+    assert p["relationship"] == "parent"

--- a/spike/strawberry_poc/tests/test_inversion_solution_interface.py
+++ b/spike/strawberry_poc/tests/test_inversion_solution_interface.py
@@ -1,0 +1,306 @@
+"""
+Tests for InversionSolutionInterface fragment queries.
+
+Exercises the `... on InversionSolutionInterface { ... }` pattern used by
+weka clients, verifying that mfd_table_id, mfd_table, hazard_table_id,
+relations { total_count }, tables, file_name, and created all resolve
+correctly through the interface fragment on InversionSolution and
+ScaledInversionSolution nodes.
+"""
+
+import base64
+
+import pytest
+
+from schema import schema
+
+# ── GQL strings ───────────────────────────────────────────────────────────────
+
+# Mirrors the weka query pattern that was broken before InversionSolutionInterface
+# was added to the Strawberry POC schema.
+INTERFACE_NODE_QUERY = """
+query GetNodeViaInterface($id: ID!) {
+    node(id: $id) {
+        id
+        __typename
+        ... on InversionSolutionInterface {
+            file_name
+            created
+            mfd_table_id
+            mfd_table { id }
+            hazard_table_id
+            tables {
+                table_id
+                table_type
+            }
+            relations {
+                total_count
+            }
+            produced_by {
+                ... on RuptureGenerationTask { id }
+                ... on AutomationTask { id }
+            }
+        }
+    }
+}
+"""
+
+CREATE_TABLE_MUTATION = """
+mutation CreateTable($input: CreateTableInput!) {
+    create_table(input: $input) {
+        ok
+        table { id }
+    }
+}
+"""
+
+CREATE_IS_MUTATION = """
+mutation CreateIS($input: CreateInversionSolutionInput!) {
+    create_inversion_solution(input: $input) {
+        ok
+        inversion_solution { id }
+    }
+}
+"""
+
+CREATE_SIS_MUTATION = """
+mutation CreateSIS($input: CreateScaledInversionSolutionInput!) {
+    create_scaled_inversion_solution(input: $input) {
+        ok
+        solution { id }
+    }
+}
+"""
+
+CREATE_FILE_RELATION_MUTATION = """
+mutation CreateFileRelation($input: CreateFileRelationInput!) {
+    create_file_relation(input: $input) {
+        ok
+    }
+}
+"""
+
+CREATE_AUTOMATION_TASK_MUTATION = """
+mutation CreateTask($input: CreateAutomationTaskInput!) {
+    create_automation_task(input: $input) {
+        task_result { id }
+    }
+}
+"""
+
+
+# ── Seed helpers ──────────────────────────────────────────────────────────────
+
+
+def _seed_rgt(gql_context) -> str:
+    from data.dynamo import create_thing
+
+    data = create_thing(
+        gql_context["dynamodb"],
+        "RuptureGenerationTask",
+        {"state": "done", "result": "success", "created": "2024-01-01T00:00:00Z"},
+    )
+    return base64.b64encode(f"RuptureGenerationTask:{data['object_id']}".encode()).decode()
+
+
+def _seed_mfd_table(gql_context, rgt_id: str) -> str:
+    result = schema.execute_sync(
+        CREATE_TABLE_MUTATION,
+        variable_values={
+            "input": {
+                "object_id": rgt_id,
+                "table_type": "MFD_CURVES_V2",
+                "created": "2024-01-01T00:00:00Z",
+                "column_headers": ["mag", "rate"],
+                "column_types": ["float", "float"],
+                "rows": [["7.0", "1e-5"], ["7.5", "5e-6"]],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_table"]["table"]["id"]
+
+
+def _seed_automation_task(gql_context) -> str:
+    result = schema.execute_sync(
+        CREATE_AUTOMATION_TASK_MUTATION,
+        variable_values={
+            "input": {
+                "state": "DONE",
+                "result": "SUCCESS",
+                "task_type": "INVERSION",
+                "created": "2024-01-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_automation_task"]["task_result"]["id"]
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def rgt_id(gql_context):
+    return _seed_rgt(gql_context)
+
+
+@pytest.fixture(scope="module")
+def mfd_table_id(gql_context, rgt_id):
+    return _seed_mfd_table(gql_context, rgt_id)
+
+
+@pytest.fixture(scope="module")
+def is_with_mfd_table(gql_context, rgt_id, mfd_table_id):
+    """InversionSolution that has one MFD_CURVES_V2 table entry."""
+    result = schema.execute_sync(
+        CREATE_IS_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "is_with_mfd.zip",
+                "produced_by": rgt_id,
+                "md5_digest": "aabbccdd",
+                "file_size": 1024,
+                "created": "2024-06-01T00:00:00Z",
+                "tables": [
+                    {"table_id": mfd_table_id, "table_type": "MFD_CURVES_V2", "label": "mfd"}
+                ],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_inversion_solution"]["inversion_solution"]["id"]
+
+
+@pytest.fixture(scope="module")
+def sis_with_mfd_table(gql_context, is_with_mfd_table):
+    """ScaledInversionSolution pointing to is_with_mfd_table."""
+    result = schema.execute_sync(
+        CREATE_SIS_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "sis_iface_test.zip",
+                "source_solution": is_with_mfd_table,
+                "md5_digest": "eeff0011",
+                "file_size": 512,
+                "created": "2024-06-02T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_scaled_inversion_solution"]["solution"]["id"]
+
+
+# ── Tests: InversionSolution via interface fragment ───────────────────────────
+
+
+def test_interface_fragment_resolves_file_name(gql_context, is_with_mfd_table):
+    result = schema.execute_sync(
+        INTERFACE_NODE_QUERY, variable_values={"id": is_with_mfd_table}, context_value=gql_context
+    )
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["__typename"] == "InversionSolution"
+    assert node["file_name"] == "is_with_mfd.zip"
+    assert node["created"] == "2024-06-01T00:00:00Z"
+
+
+def test_mfd_table_id_resolves(gql_context, is_with_mfd_table, mfd_table_id):
+    result = schema.execute_sync(
+        INTERFACE_NODE_QUERY, variable_values={"id": is_with_mfd_table}, context_value=gql_context
+    )
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["mfd_table_id"] == mfd_table_id
+
+
+def test_mfd_table_resolves(gql_context, is_with_mfd_table, mfd_table_id):
+    result = schema.execute_sync(
+        INTERFACE_NODE_QUERY, variable_values={"id": is_with_mfd_table}, context_value=gql_context
+    )
+    assert result.errors is None, result.errors
+    assert result.data["node"]["mfd_table"]["id"] == mfd_table_id
+
+
+def test_hazard_table_id_null_when_no_hazard_table(gql_context, is_with_mfd_table):
+    result = schema.execute_sync(
+        INTERFACE_NODE_QUERY, variable_values={"id": is_with_mfd_table}, context_value=gql_context
+    )
+    assert result.errors is None, result.errors
+    assert result.data["node"]["hazard_table_id"] is None
+
+
+def test_tables_via_interface_fragment(gql_context, is_with_mfd_table, mfd_table_id):
+    result = schema.execute_sync(
+        INTERFACE_NODE_QUERY, variable_values={"id": is_with_mfd_table}, context_value=gql_context
+    )
+    assert result.errors is None, result.errors
+    tables = result.data["node"]["tables"]
+    assert len(tables) == 1
+    assert tables[0]["table_id"] == mfd_table_id
+    assert tables[0]["table_type"] == "MFD_CURVES_V2"
+
+
+def test_produced_by_via_interface_fragment(gql_context, is_with_mfd_table, rgt_id):
+    result = schema.execute_sync(
+        INTERFACE_NODE_QUERY, variable_values={"id": is_with_mfd_table}, context_value=gql_context
+    )
+    assert result.errors is None, result.errors
+    pb = result.data["node"]["produced_by"]
+    assert pb is not None
+    assert pb["id"] == rgt_id
+
+
+def test_relations_total_count_zero_when_no_relations(gql_context, is_with_mfd_table):
+    result = schema.execute_sync(
+        INTERFACE_NODE_QUERY, variable_values={"id": is_with_mfd_table}, context_value=gql_context
+    )
+    assert result.errors is None, result.errors
+    rels = result.data["node"]["relations"]
+    assert rels is not None
+    assert rels["total_count"] == 0
+
+
+def test_relations_total_count_after_create_file_relation(gql_context, is_with_mfd_table):
+    task_id = _seed_automation_task(gql_context)
+    rel_result = schema.execute_sync(
+        CREATE_FILE_RELATION_MUTATION,
+        variable_values={"input": {"thing_id": task_id, "file_id": is_with_mfd_table, "role": "READ"}},
+        context_value=gql_context,
+    )
+    assert rel_result.errors is None, rel_result.errors
+    assert rel_result.data["create_file_relation"]["ok"] is True
+
+    result = schema.execute_sync(
+        INTERFACE_NODE_QUERY, variable_values={"id": is_with_mfd_table}, context_value=gql_context
+    )
+    assert result.errors is None, result.errors
+    assert result.data["node"]["relations"]["total_count"] == 1
+
+
+# ── Tests: ScaledInversionSolution via interface fragment ─────────────────────
+
+
+def test_scaled_typename_via_interface_fragment(gql_context, sis_with_mfd_table):
+    result = schema.execute_sync(
+        INTERFACE_NODE_QUERY, variable_values={"id": sis_with_mfd_table}, context_value=gql_context
+    )
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["__typename"] == "ScaledInversionSolution"
+    assert node["file_name"] == "sis_iface_test.zip"
+
+
+def test_scaled_mfd_table_null_when_no_tables(gql_context, sis_with_mfd_table):
+    """ScaledInversionSolution created without tables → mfd_table_id is null."""
+    result = schema.execute_sync(
+        INTERFACE_NODE_QUERY, variable_values={"id": sis_with_mfd_table}, context_value=gql_context
+    )
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["mfd_table_id"] is None
+    assert node["mfd_table"] is None

--- a/spike/strawberry_poc/tests/test_inversion_solution_nrml.py
+++ b/spike/strawberry_poc/tests/test_inversion_solution_nrml.py
@@ -1,0 +1,241 @@
+"""
+Tests for InversionSolutionNrml — file type with a SourceSolutionUnion source.
+
+Mirrors legacy hazard/test_openquake_sources_nrml_solution.py. Covers
+COVERAGE_GAPS.md gap 2 (NRML had zero POC tests previously).
+"""
+
+import base64
+
+import pytest
+
+from schema import schema
+
+# ── GQL strings ───────────────────────────────────────────────────────────────
+
+CREATE_NRML_MUTATION = """
+mutation CreateNrml($input: CreateInversionSolutionNrmlInput!) {
+    create_inversion_solution_nrml(input: $input) {
+        ok
+        inversion_solution_nrml {
+            id
+            file_name
+            md5_digest
+            file_size
+            created
+            source_solution {
+                __typename
+                ... on InversionSolution { id }
+                ... on ScaledInversionSolution { id }
+                ... on TimeDependentInversionSolution { id }
+            }
+            predecessors { id depth relationship typename }
+        }
+    }
+}
+"""
+
+NODE_QUERY = """
+query GetNode($id: ID!) {
+    node(id: $id) {
+        id
+        __typename
+        ... on InversionSolutionNrml {
+            file_name
+            source_solution {
+                __typename
+                ... on InversionSolution { id }
+                ... on ScaledInversionSolution { id }
+                ... on TimeDependentInversionSolution { id }
+            }
+            predecessors { id depth relationship }
+        }
+    }
+}
+"""
+
+CREATE_IS_MUTATION = """
+mutation($input: CreateInversionSolutionInput!) {
+    create_inversion_solution(input: $input) { inversion_solution { id } }
+}
+"""
+
+CREATE_SIS_MUTATION = """
+mutation($input: CreateScaledInversionSolutionInput!) {
+    create_scaled_inversion_solution(input: $input) { solution { id } }
+}
+"""
+
+CREATE_TDIS_MUTATION = """
+mutation($input: CreateTimeDependentInversionSolutionInput!) {
+    create_time_dependent_inversion_solution(input: $input) { solution { id } }
+}
+"""
+
+
+# ── Seed helpers ──────────────────────────────────────────────────────────────
+
+
+def _seed_rgt(gql_context) -> str:
+    from data.dynamo import create_thing
+
+    data = create_thing(
+        gql_context["dynamodb"],
+        "RuptureGenerationTask",
+        {"state": "done", "result": "success", "created": "2024-01-01T00:00:00Z"},
+    )
+    return base64.b64encode(f"RuptureGenerationTask:{data['object_id']}".encode()).decode()
+
+
+def _seed_is(gql_context, rgt_id: str) -> str:
+    result = schema.execute_sync(
+        CREATE_IS_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "nrml_is.zip",
+                "produced_by": rgt_id,
+                "md5_digest": "aaaa",
+                "file_size": 100,
+                "created": "2024-02-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_inversion_solution"]["inversion_solution"]["id"]
+
+
+def _seed_sis(gql_context, source_is_id: str) -> str:
+    result = schema.execute_sync(
+        CREATE_SIS_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "nrml_sis.zip",
+                "source_solution": source_is_id,
+                "md5_digest": "bbbb",
+                "file_size": 200,
+                "created": "2024-02-02T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_scaled_inversion_solution"]["solution"]["id"]
+
+
+def _seed_tdis(gql_context, source_is_id: str) -> str:
+    result = schema.execute_sync(
+        CREATE_TDIS_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "nrml_tdis.zip",
+                "source_solution": source_is_id,
+                "md5_digest": "cccc",
+                "file_size": 300,
+                "created": "2024-02-03T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_time_dependent_inversion_solution"]["solution"]["id"]
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def rgt_id(gql_context):
+    return _seed_rgt(gql_context)
+
+
+@pytest.fixture(scope="module")
+def is_id(gql_context, rgt_id):
+    return _seed_is(gql_context, rgt_id)
+
+
+@pytest.fixture(scope="module")
+def sis_id(gql_context, is_id):
+    return _seed_sis(gql_context, is_id)
+
+
+@pytest.fixture(scope="module")
+def tdis_id(gql_context, is_id):
+    return _seed_tdis(gql_context, is_id)
+
+
+def _create_nrml(gql_context, source_id: str, file_name: str, predecessors=None):
+    payload = {
+        "file_name": file_name,
+        "source_solution": source_id,
+        "md5_digest": "deadbeef",
+        "file_size": 2048,
+        "created": "2024-03-01T00:00:00Z",
+    }
+    if predecessors is not None:
+        payload["predecessors"] = predecessors
+    result = schema.execute_sync(
+        CREATE_NRML_MUTATION, variable_values={"input": payload}, context_value=gql_context
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_inversion_solution_nrml"]["inversion_solution_nrml"]
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+def test_create_nrml_from_inversion_solution(gql_context, is_id):
+    nrml = _create_nrml(gql_context, is_id, "nrml_from_is.xml")
+    decoded = base64.b64decode(nrml["id"]).decode()
+    assert decoded.startswith("InversionSolutionNrml:")
+    assert nrml["file_name"] == "nrml_from_is.xml"
+    assert nrml["md5_digest"] == "deadbeef"
+    assert nrml["file_size"] == 2048
+    assert nrml["created"] == "2024-03-01T00:00:00Z"
+
+
+def test_create_nrml_from_scaled_solution(gql_context, sis_id):
+    nrml = _create_nrml(gql_context, sis_id, "nrml_from_sis.xml")
+    assert nrml["source_solution"]["__typename"] == "ScaledInversionSolution"
+    assert nrml["source_solution"]["id"] == sis_id
+
+
+def test_create_nrml_from_time_dependent_solution(gql_context, tdis_id):
+    nrml = _create_nrml(gql_context, tdis_id, "nrml_from_tdis.xml")
+    assert nrml["source_solution"]["__typename"] == "TimeDependentInversionSolution"
+    assert nrml["source_solution"]["id"] == tdis_id
+
+
+def test_source_solution_union_dispatch(gql_context, is_id):
+    """source_solution must dispatch to the correct type based on clazz_name."""
+    nrml = _create_nrml(gql_context, is_id, "dispatch_check.xml")
+    assert nrml["source_solution"]["__typename"] == "InversionSolution"
+    assert nrml["source_solution"]["id"] == is_id
+
+
+def test_nrml_with_predecessors(gql_context, is_id):
+    nrml = _create_nrml(
+        gql_context,
+        is_id,
+        "nrml_with_preds.xml",
+        predecessors=[{"id": is_id, "depth": -1}],
+    )
+    preds = nrml["predecessors"]
+    assert preds is not None
+    assert len(preds) == 1
+    assert preds[0]["id"] == is_id
+    assert preds[0]["depth"] == -1
+    assert preds[0]["relationship"].lower() == "parent"
+
+
+def test_nrml_node_lookup(gql_context, is_id):
+    nrml = _create_nrml(gql_context, is_id, "node_lookup.xml")
+    result = schema.execute_sync(
+        NODE_QUERY, variable_values={"id": nrml["id"]}, context_value=gql_context
+    )
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["__typename"] == "InversionSolutionNrml"
+    assert node["file_name"] == "node_lookup.xml"
+    assert node["source_solution"]["__typename"] == "InversionSolution"
+    assert node["source_solution"]["id"] == is_id

--- a/spike/strawberry_poc/tests/test_nodes_query.py
+++ b/spike/strawberry_poc/tests/test_nodes_query.py
@@ -1,0 +1,275 @@
+"""
+Tests for the `nodes(id_in: [...])` batch-fetch query.
+
+Mirrors legacy test_nodes_bugfix_220.py, which exercises the primary
+weka client query pattern: fetch a ScaledInversionSolution by id,
+expand its source_solution and produced_by, then traverse produced_by →
+parents → GeneralTask in a single round-trip.
+
+Note: legacy schema had an `AutomationTaskInterface`; the POC uses the
+concrete `AutomationTask` type. The traversal pattern is otherwise identical.
+
+Covers COVERAGE_GAPS.md gap 3.
+"""
+
+import base64
+
+import pytest
+
+from schema import schema
+
+# ── GQL strings ───────────────────────────────────────────────────────────────
+
+NODES_BASIC_QUERY = """
+query NodesBasic($ids: [ID!]!) {
+    nodes(id_in: $ids) {
+        ok
+        result {
+            edges {
+                node {
+                    __typename
+                    ... on ScaledInversionSolution { id }
+                    ... on InversionSolution { id }
+                    ... on AutomationTask { id }
+                }
+            }
+        }
+    }
+}
+"""
+
+NODES_INTERFACE_QUERY = """
+query NodesInterface($ids: [ID!]!) {
+    nodes(id_in: $ids) {
+        result {
+            edges {
+                node {
+                    __typename
+                    ... on InversionSolutionInterface {
+                        file_name
+                        mfd_table_id
+                        tables { table_id table_type }
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+NODES_DEEP_QUERY = """
+query NodesDeep($ids: [ID!]!) {
+    nodes(id_in: $ids) {
+        result {
+            edges {
+                node {
+                    __typename
+                    ... on ScaledInversionSolution {
+                        id
+                        file_name
+                        source_solution {
+                            __typename
+                            ... on InversionSolution { id file_name }
+                        }
+                        produced_by {
+                            __typename
+                            ... on AutomationTask {
+                                id
+                                task_type
+                                parents {
+                                    edges {
+                                        node {
+                                            parent {
+                                                __typename
+                                                ... on GeneralTask { id title }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+CREATE_GT_MUTATION = """
+mutation($input: CreateGeneralTaskInput!) {
+    create_general_task(input: $input) { general_task { id } }
+}
+"""
+
+CREATE_AT_MUTATION = """
+mutation($input: CreateAutomationTaskInput!) {
+    create_automation_task(input: $input) { task_result { id } }
+}
+"""
+
+CREATE_IS_MUTATION = """
+mutation($input: CreateInversionSolutionInput!) {
+    create_inversion_solution(input: $input) { inversion_solution { id } }
+}
+"""
+
+CREATE_SIS_MUTATION = """
+mutation($input: CreateScaledInversionSolutionInput!) {
+    create_scaled_inversion_solution(input: $input) { solution { id } }
+}
+"""
+
+CREATE_TASK_RELATION_MUTATION = """
+mutation($input: CreateTaskRelationInput!) {
+    create_task_relation(input: $input) { ok }
+}
+"""
+
+
+# ── Seeds ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def chain(gql_context):
+    """Seed GT → AT (linked as child of GT) → IS (produced by AT) → SIS (produced by AT, source = IS)."""
+    gt_result = schema.execute_sync(
+        CREATE_GT_MUTATION,
+        variable_values={"input": {"title": "weka-pattern parent GT", "agent_name": "pytest"}},
+        context_value=gql_context,
+    )
+    assert gt_result.errors is None, gt_result.errors
+    gt_id = gt_result.data["create_general_task"]["general_task"]["id"]
+
+    at_result = schema.execute_sync(
+        CREATE_AT_MUTATION,
+        variable_values={
+            "input": {
+                "state": "DONE",
+                "result": "SUCCESS",
+                "task_type": "INVERSION",
+                "created": "2024-01-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert at_result.errors is None, at_result.errors
+    at_id = at_result.data["create_automation_task"]["task_result"]["id"]
+
+    rel_result = schema.execute_sync(
+        CREATE_TASK_RELATION_MUTATION,
+        variable_values={"input": {"parent_id": gt_id, "child_id": at_id}},
+        context_value=gql_context,
+    )
+    assert rel_result.errors is None, rel_result.errors
+
+    is_result = schema.execute_sync(
+        CREATE_IS_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "weka_pattern.zip",
+                "produced_by": at_id,
+                "md5_digest": "1111",
+                "file_size": 1024,
+                "created": "2024-02-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert is_result.errors is None, is_result.errors
+    is_id = is_result.data["create_inversion_solution"]["inversion_solution"]["id"]
+
+    sis_result = schema.execute_sync(
+        CREATE_SIS_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "weka_pattern_scaled.zip",
+                "source_solution": is_id,
+                "produced_by": at_id,
+                "md5_digest": "2222",
+                "file_size": 2048,
+                "created": "2024-02-02T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert sis_result.errors is None, sis_result.errors
+    sis_id = sis_result.data["create_scaled_inversion_solution"]["solution"]["id"]
+
+    return {"gt_id": gt_id, "at_id": at_id, "is_id": is_id, "sis_id": sis_id}
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+def test_nodes_basic_returns_typename_and_id(gql_context, chain):
+    """nodes(id_in: [mixed]) returns matching __typename and id for each."""
+    ids = [chain["sis_id"], chain["is_id"], chain["at_id"]]
+    result = schema.execute_sync(
+        NODES_BASIC_QUERY, variable_values={"ids": ids}, context_value=gql_context
+    )
+    assert result.errors is None, result.errors
+    edges = result.data["nodes"]["result"]["edges"]
+    nodes = [e["node"] for e in edges]
+    typenames = {n["__typename"] for n in nodes}
+    assert typenames == {"ScaledInversionSolution", "InversionSolution", "AutomationTask"}
+    returned_ids = {n["id"] for n in nodes}
+    assert returned_ids == set(ids)
+
+
+def test_nodes_with_unknown_id_skips_silently(gql_context, chain):
+    """An invalid/unknown global ID should be skipped, not error."""
+    fake_id = base64.b64encode(b"NoSuchType:00000nope").decode()
+    result = schema.execute_sync(
+        NODES_BASIC_QUERY,
+        variable_values={"ids": [chain["sis_id"], fake_id]},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    edges = result.data["nodes"]["result"]["edges"]
+    assert len(edges) == 1
+    assert edges[0]["node"]["id"] == chain["sis_id"]
+
+
+def test_nodes_expand_inversion_solution_interface(gql_context, chain):
+    """Expand `... on InversionSolutionInterface` on a ScaledInversionSolution
+    via the nodes query — this is the weka fragment pattern."""
+    result = schema.execute_sync(
+        NODES_INTERFACE_QUERY,
+        variable_values={"ids": [chain["sis_id"]]},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    node = result.data["nodes"]["result"]["edges"][0]["node"]
+    assert node["__typename"] == "ScaledInversionSolution"
+    assert node["file_name"] == "weka_pattern_scaled.zip"
+    # ScaledIS without tables → mfd_table_id is null
+    assert node["mfd_table_id"] is None
+
+
+def test_nodes_deep_parent_traversal(gql_context, chain):
+    """Canonical weka pattern: fetch ScaledIS → expand produced_by AutomationTask
+    → traverse parents to retrieve the parent GeneralTask in one request."""
+    result = schema.execute_sync(
+        NODES_DEEP_QUERY,
+        variable_values={"ids": [chain["sis_id"]]},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    node = result.data["nodes"]["result"]["edges"][0]["node"]
+    assert node["__typename"] == "ScaledInversionSolution"
+    assert node["id"] == chain["sis_id"]
+    assert node["source_solution"]["__typename"] == "InversionSolution"
+    assert node["source_solution"]["id"] == chain["is_id"]
+
+    produced_by = node["produced_by"]
+    assert produced_by["__typename"] == "AutomationTask"
+    assert produced_by["id"] == chain["at_id"]
+    assert produced_by["task_type"] == "INVERSION"
+
+    parent_edges = produced_by["parents"]["edges"]
+    assert len(parent_edges) == 1
+    parent = parent_edges[0]["node"]["parent"]
+    assert parent["__typename"] == "GeneralTask"
+    assert parent["id"] == chain["gt_id"]
+    assert parent["title"] == "weka-pattern parent GT"

--- a/spike/strawberry_poc/tests/test_openquake.py
+++ b/spike/strawberry_poc/tests/test_openquake.py
@@ -1,0 +1,533 @@
+"""
+Tests for OpenquakeHazardTask, OpenquakeHazardSolution, and OpenquakeHazardConfig.
+
+Key feasibility signals:
+  1. OpenquakeHazardSolution.produced_by → resolves back to the creating OpenquakeHazardTask
+  2. update_openquake_hazard_task → links hazard_solution onto an existing task
+  3. task.hazard_solution → resolves OpenquakeHazardSolution (bidirectional link)
+  4. OpenquakeHazardConfig.template_archive → resolves ToshiFile
+  5. OpenquakeHazardConfig.source_models → resolves OpenquakeNrmlUnion (ToshiFile case)
+"""
+
+import base64
+
+import pytest
+
+from schema import schema
+
+# ── Mutation / query strings ──────────────────────────────────────────────────
+
+CREATE_OQ_TASK_MUTATION = """
+mutation CreateOQTask($input: CreateOpenquakeHazardTaskInput!) {
+    create_openquake_hazard_task(input: $input) {
+        ok
+        task_result {
+            id
+            state
+            result
+            task_type
+            created
+            executor
+            arguments { k v }
+        }
+    }
+}
+"""
+
+CREATE_OQ_SOLUTION_MUTATION = """
+mutation CreateOQSolution($input: CreateOpenquakeHazardSolutionInput!) {
+    create_openquake_hazard_solution(input: $input) {
+        ok
+        openquake_hazard_solution {
+            id
+            created
+            task_type
+            metrics { k v }
+            produced_by {
+                id
+                state
+                result
+            }
+        }
+    }
+}
+"""
+
+UPDATE_OQ_TASK_MUTATION = """
+mutation UpdateOQTask($input: UpdateOpenquakeHazardTaskInput!) {
+    update_openquake_hazard_task(input: $input) {
+        ok
+        task_result {
+            id
+            state
+            result
+            hazard_solution {
+                id
+                task_type
+            }
+        }
+    }
+}
+"""
+
+CREATE_OQ_CONFIG_MUTATION = """
+mutation CreateOQConfig($input: CreateOpenquakeHazardConfigInput!) {
+    create_openquake_hazard_config(input: $input) {
+        ok
+        config {
+            id
+            created
+            template_archive {
+                id
+                file_name
+            }
+            source_models {
+                ... on ToshiFile {
+                    id
+                    file_name
+                }
+            }
+        }
+    }
+}
+"""
+
+NODE_QUERY = """
+query GetNode($id: ID!) {
+    node(id: $id) {
+        id
+        ... on OpenquakeHazardSolution {
+            task_type
+            produced_by {
+                id
+            }
+        }
+        ... on OpenquakeHazardTask {
+            state
+            hazard_solution {
+                id
+            }
+        }
+        ... on OpenquakeHazardConfig {
+            created
+            template_archive {
+                id
+            }
+        }
+    }
+}
+"""
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _seed_toshi_file(gql_context, name="archive.zip"):
+    from data.dynamo import create_file
+
+    data = create_file(gql_context["dynamodb"], "ToshiFile", {"file_name": name})
+    raw_id = data["object_id"]
+    return base64.b64encode(f"ToshiFile:{raw_id}".encode()).decode()
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def created_oq_task(gql_context):
+    result = schema.execute_sync(
+        CREATE_OQ_TASK_MUTATION,
+        variable_values={
+            "input": {
+                "state": "STARTED",
+                "result": "UNDEFINED",
+                "created": "2024-05-01T00:00:00Z",
+                "task_type": "HAZARD",
+                "executor": "openquake-3.16",
+                "arguments": [{"k": "max_sites_disagg", "v": "10"}],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_openquake_hazard_task"]["task_result"]
+
+
+@pytest.fixture(scope="module")
+def created_oq_solution(gql_context, created_oq_task):
+    result = schema.execute_sync(
+        CREATE_OQ_SOLUTION_MUTATION,
+        variable_values={
+            "input": {
+                "produced_by": created_oq_task["id"],
+                "task_type": "HAZARD",
+                "created": "2024-05-01T06:00:00Z",
+                "metrics": [{"k": "num_sites", "v": "42"}],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_openquake_hazard_solution"]["openquake_hazard_solution"]
+
+
+# ── OpenquakeHazardTask tests ─────────────────────────────────────────────────
+
+
+def test_oq_task_id_encoding(created_oq_task):
+    decoded = base64.b64decode(created_oq_task["id"]).decode()
+    assert decoded.startswith("OpenquakeHazardTask:"), f"Unexpected ID: {decoded}"
+
+
+def test_oq_task_fields(created_oq_task):
+    t = created_oq_task
+    assert t["state"] == "STARTED"
+    assert t["result"] == "UNDEFINED"
+    assert t["task_type"] == "HAZARD"
+    assert t["executor"] == "openquake-3.16"
+    assert t["arguments"] == [{"k": "max_sites_disagg", "v": "10"}]
+
+
+# ── OpenquakeHazardSolution tests ─────────────────────────────────────────────
+
+
+def test_oq_solution_id_encoding(created_oq_solution):
+    decoded = base64.b64decode(created_oq_solution["id"]).decode()
+    assert decoded.startswith("OpenquakeHazardSolution:")
+
+
+def test_oq_solution_fields(created_oq_solution):
+    s = created_oq_solution
+    assert s["task_type"] == "HAZARD"
+    assert s["created"] == "2024-05-01T06:00:00Z"
+    assert s["metrics"] == [{"k": "num_sites", "v": "42"}]
+
+
+def test_oq_solution_produced_by(created_oq_solution, created_oq_task):
+    pb = created_oq_solution["produced_by"]
+    assert pb is not None
+    assert pb["id"] == created_oq_task["id"]
+    assert pb["state"] == "STARTED"
+
+
+def test_oq_solution_node_lookup(gql_context, created_oq_solution, created_oq_task):
+    result = schema.execute_sync(
+        NODE_QUERY,
+        variable_values={"id": created_oq_solution["id"]},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["id"] == created_oq_solution["id"]
+    assert node["task_type"] == "HAZARD"
+    assert node["produced_by"]["id"] == created_oq_task["id"]
+
+
+# ── update_openquake_hazard_task tests ────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def updated_oq_task(gql_context, created_oq_task, created_oq_solution):
+    result = schema.execute_sync(
+        UPDATE_OQ_TASK_MUTATION,
+        variable_values={
+            "input": {
+                "task_id": created_oq_task["id"],
+                "state": "DONE",
+                "result": "SUCCESS",
+                "hazard_solution": created_oq_solution["id"],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["update_openquake_hazard_task"]["task_result"]
+
+
+def test_update_oq_task_state(updated_oq_task):
+    assert updated_oq_task["state"] == "DONE"
+    assert updated_oq_task["result"] == "SUCCESS"
+
+
+def test_update_oq_task_hazard_solution(updated_oq_task, created_oq_solution):
+    hs = updated_oq_task["hazard_solution"]
+    assert hs is not None
+    assert hs["id"] == created_oq_solution["id"]
+    assert hs["task_type"] == "HAZARD"
+
+
+def test_updated_task_node_lookup(gql_context, updated_oq_task, created_oq_solution):
+    result = schema.execute_sync(
+        NODE_QUERY,
+        variable_values={"id": updated_oq_task["id"]},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["state"] == "DONE"
+    assert node["hazard_solution"]["id"] == created_oq_solution["id"]
+
+
+# ── OpenquakeHazardConfig tests ───────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def template_archive_id(gql_context):
+    return _seed_toshi_file(gql_context, "config_template.zip")
+
+
+@pytest.fixture(scope="module")
+def source_model_id(gql_context):
+    return _seed_toshi_file(gql_context, "source_model.xml")
+
+
+@pytest.fixture(scope="module")
+def created_oq_config(gql_context, template_archive_id, source_model_id):
+    result = schema.execute_sync(
+        CREATE_OQ_CONFIG_MUTATION,
+        variable_values={
+            "input": {
+                "template_archive": template_archive_id,
+                "source_models": [source_model_id],
+                "created": "2024-04-15T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_openquake_hazard_config"]["config"]
+
+
+def test_oq_config_id_encoding(created_oq_config):
+    decoded = base64.b64decode(created_oq_config["id"]).decode()
+    assert decoded.startswith("OpenquakeHazardConfig:")
+
+
+def test_oq_config_created(created_oq_config):
+    assert created_oq_config["created"] == "2024-04-15T00:00:00Z"
+
+
+def test_oq_config_template_archive(created_oq_config, template_archive_id):
+    ta = created_oq_config["template_archive"]
+    assert ta is not None
+    assert ta["id"] == template_archive_id
+    assert ta["file_name"] == "config_template.zip"
+
+
+def test_oq_config_source_models(created_oq_config, source_model_id):
+    sm = created_oq_config["source_models"]
+    assert sm is not None and len(sm) == 1
+    assert sm[0]["id"] == source_model_id
+    assert sm[0]["file_name"] == "source_model.xml"
+
+
+def test_oq_config_node_lookup(gql_context, created_oq_config, template_archive_id):
+    result = schema.execute_sync(
+        NODE_QUERY,
+        variable_values={"id": created_oq_config["id"]},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["created"] == "2024-04-15T00:00:00Z"
+    assert node["template_archive"]["id"] == template_archive_id
+
+
+# ── DISAGG variant (COVERAGE_GAPS.md gap 4) ───────────────────────────────────
+
+CREATE_OQ_TASK_DISAGG_MUTATION = """
+mutation CreateDisaggTask($input: CreateOpenquakeHazardTaskInput!) {
+    create_openquake_hazard_task(input: $input) {
+        ok
+        task_result { id task_type state result }
+    }
+}
+"""
+
+NODE_TASK_TASK_TYPE_QUERY = """
+query GetNode($id: ID!) {
+    node(id: $id) {
+        id
+        ... on OpenquakeHazardTask { task_type state }
+    }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def disagg_oq_task(gql_context):
+    result = schema.execute_sync(
+        CREATE_OQ_TASK_DISAGG_MUTATION,
+        variable_values={
+            "input": {
+                "state": "DONE",
+                "result": "SUCCESS",
+                "created": "2024-06-01T00:00:00Z",
+                "task_type": "DISAGG",
+                "executor": "openquake-3.16",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_openquake_hazard_task"]["task_result"]
+
+
+def test_create_disagg_oq_task(disagg_oq_task):
+    """task_type DISAGG round-trips through create mutation."""
+    assert disagg_oq_task["task_type"] == "DISAGG"
+    assert disagg_oq_task["state"] == "DONE"
+
+
+def test_disagg_oq_task_node_lookup(gql_context, disagg_oq_task):
+    result = schema.execute_sync(
+        NODE_TASK_TASK_TYPE_QUERY,
+        variable_values={"id": disagg_oq_task["id"]},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    assert result.data["node"]["task_type"] == "DISAGG"
+
+
+# ── JSON tree fields (COVERAGE_GAPS.md gap 5) ─────────────────────────────────
+
+CREATE_OQ_TASK_WITH_TREES_MUTATION = """
+mutation CreateTaskTrees($input: CreateOpenquakeHazardTaskInput!) {
+    create_openquake_hazard_task(input: $input) {
+        ok
+        task_result {
+            id
+            task_type
+            model_type
+            srm_logic_tree
+            gmcm_logic_tree
+            openquake_config
+        }
+    }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def oq_task_with_trees(gql_context):
+    import json
+
+    result = schema.execute_sync(
+        CREATE_OQ_TASK_WITH_TREES_MUTATION,
+        variable_values={
+            "input": {
+                "state": "DONE",
+                "result": "SUCCESS",
+                "created": "2024-06-02T00:00:00Z",
+                "task_type": "HAZARD",
+                "model_type": "CRUSTAL",
+                "srm_logic_tree": json.dumps({"srm": "tree"}),
+                "gmcm_logic_tree": json.dumps({"gmcm": "tree"}),
+                "openquake_config": json.dumps({"calc": "config"}),
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_openquake_hazard_task"]["task_result"]
+
+
+def test_oq_task_srm_logic_tree_round_trip(oq_task_with_trees):
+    import json
+
+    assert json.loads(oq_task_with_trees["srm_logic_tree"]) == {"srm": "tree"}
+
+
+def test_oq_task_gmcm_logic_tree_round_trip(oq_task_with_trees):
+    import json
+
+    assert json.loads(oq_task_with_trees["gmcm_logic_tree"]) == {"gmcm": "tree"}
+
+
+def test_oq_task_openquake_config_round_trip(oq_task_with_trees):
+    import json
+
+    assert json.loads(oq_task_with_trees["openquake_config"]) == {"calc": "config"}
+
+
+def test_oq_task_model_type(oq_task_with_trees):
+    assert oq_task_with_trees["model_type"] == "CRUSTAL"
+
+
+# ── OpenquakeHazardSolution archive fields (COVERAGE_GAPS.md gap 6) ───────────
+
+CREATE_OQ_SOLUTION_FULL_MUTATION = """
+mutation CreateSolutionFull($input: CreateOpenquakeHazardSolutionInput!) {
+    create_openquake_hazard_solution(input: $input) {
+        ok
+        openquake_hazard_solution {
+            id
+            task_type
+            csv_archive { ... on ToshiFile { id file_name } }
+            hdf5_archive { ... on ToshiFile { id file_name } }
+            task_args { ... on ToshiFile { id file_name } }
+            predecessors { id depth relationship }
+        }
+    }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def csv_archive_id(gql_context):
+    return _seed_toshi_file(gql_context, "results.csv")
+
+
+@pytest.fixture(scope="module")
+def hdf5_archive_id(gql_context):
+    return _seed_toshi_file(gql_context, "results.hdf5")
+
+
+@pytest.fixture(scope="module")
+def task_args_id(gql_context):
+    return _seed_toshi_file(gql_context, "args.json")
+
+
+@pytest.fixture(scope="module")
+def oq_solution_with_archives(
+    gql_context, created_oq_task, csv_archive_id, hdf5_archive_id, task_args_id
+):
+    result = schema.execute_sync(
+        CREATE_OQ_SOLUTION_FULL_MUTATION,
+        variable_values={
+            "input": {
+                "produced_by": created_oq_task["id"],
+                "task_type": "HAZARD",
+                "created": "2024-06-03T00:00:00Z",
+                "csv_archive": csv_archive_id,
+                "hdf5_archive": hdf5_archive_id,
+                "task_args": task_args_id,
+                "predecessors": [{"id": csv_archive_id, "depth": -1}],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_openquake_hazard_solution"]["openquake_hazard_solution"]
+
+
+def test_oq_solution_csv_archive_resolves(oq_solution_with_archives, csv_archive_id):
+    assert oq_solution_with_archives["csv_archive"]["id"] == csv_archive_id
+    assert oq_solution_with_archives["csv_archive"]["file_name"] == "results.csv"
+
+
+def test_oq_solution_hdf5_archive_resolves(oq_solution_with_archives, hdf5_archive_id):
+    assert oq_solution_with_archives["hdf5_archive"]["id"] == hdf5_archive_id
+
+
+def test_oq_solution_task_args_resolves(oq_solution_with_archives, task_args_id):
+    assert oq_solution_with_archives["task_args"]["id"] == task_args_id
+
+
+def test_oq_solution_predecessors(oq_solution_with_archives, csv_archive_id):
+    preds = oq_solution_with_archives["predecessors"]
+    assert preds is not None
+    assert len(preds) == 1
+    assert preds[0]["id"] == csv_archive_id
+    assert preds[0]["depth"] == -1
+    assert preds[0]["relationship"].lower() == "parent"

--- a/spike/strawberry_poc/tests/test_pagination.py
+++ b/spike/strawberry_poc/tests/test_pagination.py
@@ -1,0 +1,122 @@
+"""
+Relay cursor pagination tests.
+
+Verifies that Strawberry's relay.ListConnection correctly handles
+first/after/page_info for top-level connection fields.
+
+No production code changes needed — the mechanism is built into
+@relay.connection(relay.ListConnection[T]) and works in-memory over
+the list returned by each resolver.
+
+Run with:
+    uv run --extra dev pytest tests/test_pagination.py -v
+"""
+
+import pytest
+
+from schema import schema
+
+PAGINATED_QUERY = """
+query Paginated($first: Int, $after: String) {
+    general_tasks(first: $first, after: $after) {
+        page_info {
+            has_next_page
+            has_previous_page
+            start_cursor
+            end_cursor
+        }
+        edges {
+            cursor
+            node { id title }
+        }
+    }
+}
+"""
+
+CREATE_GT = """
+mutation CreateGT($title: String!) {
+    create_general_task(input: { title: $title, created: "2024-01-01T00:00Z" }) {
+        general_task { id title }
+    }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def paginated_tasks(gql_context):
+    """Create 4 GeneralTasks and return their IDs in creation order."""
+    ids = []
+    for i in range(4):
+        result = schema.execute_sync(
+            CREATE_GT,
+            context_value=gql_context,
+            variable_values={"title": f"Pagination Task {i}"},
+        )
+        assert result.errors is None, result.errors
+        ids.append(result.data["create_general_task"]["general_task"]["id"])
+    return ids
+
+
+def _query(gql_context, first=None, after=None):
+    vars = {}
+    if first is not None:
+        vars["first"] = first
+    if after is not None:
+        vars["after"] = after
+    result = schema.execute_sync(PAGINATED_QUERY, context_value=gql_context, variable_values=vars)
+    assert result.errors is None, result.errors
+    return result.data["general_tasks"]
+
+
+def test_first_returns_subset(paginated_tasks, gql_context):
+    """first: 2 returns exactly 2 edges."""
+    conn = _query(gql_context, first=2)
+    assert len(conn["edges"]) == 2
+
+
+def test_pageinfo_has_next_page(paginated_tasks, gql_context):
+    """first: 2 with 4 total → has_next_page True, end_cursor set."""
+    conn = _query(gql_context, first=2)
+    assert conn["page_info"]["has_next_page"] is True
+    assert conn["page_info"]["end_cursor"]
+
+
+def test_pageinfo_no_next_page_on_last_page(paginated_tasks, gql_context):
+    """Fetching page 2 of 2 → has_next_page False."""
+    page1 = _query(gql_context, first=2)
+    cursor = page1["page_info"]["end_cursor"]
+    page2 = _query(gql_context, first=2, after=cursor)
+    assert page2["page_info"]["has_next_page"] is False
+
+
+def test_cursor_advances_correctly(paginated_tasks, gql_context):
+    """Page 1 and page 2 IDs are disjoint; together they cover all 4 tasks."""
+    page1 = _query(gql_context, first=2)
+    cursor = page1["page_info"]["end_cursor"]
+    page2 = _query(gql_context, first=2, after=cursor)
+
+    ids_p1 = {e["node"]["id"] for e in page1["edges"]}
+    ids_p2 = {e["node"]["id"] for e in page2["edges"]}
+
+    assert ids_p1.isdisjoint(ids_p2), "Pages overlap — cursor not advancing"
+    assert len(ids_p1 | ids_p2) == 4, "Pages don't cover all 4 tasks"
+    # All created IDs are present across both pages
+    for task_id in paginated_tasks:
+        assert task_id in (ids_p1 | ids_p2)
+
+
+def test_first_exceeding_total(paginated_tasks, gql_context):
+    """first: 100 with only 4 tasks → all returned, has_next_page False."""
+    conn = _query(gql_context, first=100)
+    assert conn["page_info"]["has_next_page"] is False
+    returned_ids = {e["node"]["id"] for e in conn["edges"]}
+    for task_id in paginated_tasks:
+        assert task_id in returned_ids
+
+
+def test_no_args_returns_all(paginated_tasks, gql_context):
+    """No pagination args → all 4 tasks present (default behaviour unchanged)."""
+    conn = _query(gql_context)
+    returned_ids = {e["node"]["id"] for e in conn["edges"]}
+    for task_id in paginated_tasks:
+        assert task_id in returned_ids

--- a/spike/strawberry_poc/tests/test_reindex.py
+++ b/spike/strawberry_poc/tests/test_reindex.py
@@ -1,0 +1,139 @@
+"""
+Tests for the reindex mutation.
+
+reindex(id_in: [ID!]!) re-pushes each object to Elasticsearch by:
+  1. Decoding the relay global ID → (type_name, raw_id)
+  2. Fetching the current object from DynamoDB
+  3. Calling index_document with the correct ThingData_/FileData_ key prefix
+
+Unit tests mock index_document so no live ES is required.
+Integration test verifies the document actually lands in ES.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from schema import schema
+
+CREATE_GT = """
+mutation { create_general_task(input: { title: "Reindex Me", created: "2024-01-01T00:00Z" }) {
+    general_task { id }
+} }
+"""
+
+CREATE_FILE = """
+mutation { create_file(input: { file_name: "reindex.txt", file_size: 1, md5_digest: "abc" }) {
+    file_result { id }
+} }
+"""
+
+REINDEX_MUTATION = """
+mutation Reindex($ids: [ID!]!) {
+    reindex(id_in: $ids) {
+        ok
+        reindexed_ids
+    }
+}
+"""
+
+
+def run(query, gql_context, variables=None):
+    result = schema.execute_sync(query, context_value=gql_context, variable_values=variables or {})
+    assert result.errors is None, result.errors
+    return result.data
+
+
+# ── Unit tests (no ES required) ───────────────────────────────────────────────
+
+
+def test_reindex_thing_calls_index_document(gql_context):
+    """reindex on a GeneralTask calls index_document with ThingData_ prefix."""
+    gt_id = run(CREATE_GT, gql_context)["create_general_task"]["general_task"]["id"]
+
+    with patch("data.search.index_document") as mock_index:
+        result = run(REINDEX_MUTATION, gql_context, {"ids": [gt_id]})
+
+    assert result["reindex"]["ok"] is True
+    assert gt_id in result["reindex"]["reindexed_ids"]
+    assert mock_index.called
+    key = mock_index.call_args[0][0]
+    assert key.startswith("ThingData_")
+
+
+def test_reindex_file_calls_index_document(gql_context):
+    """reindex on a ToshiFile calls index_document with FileData_ prefix."""
+    file_id = run(CREATE_FILE, gql_context)["create_file"]["file_result"]["id"]
+
+    with patch("data.search.index_document") as mock_index:
+        result = run(REINDEX_MUTATION, gql_context, {"ids": [file_id]})
+
+    assert result["reindex"]["ok"] is True
+    assert file_id in result["reindex"]["reindexed_ids"]
+    key = mock_index.call_args[0][0]
+    assert key.startswith("FileData_")
+
+
+def test_reindex_multiple_ids(gql_context):
+    """reindex accepts a batch of IDs and returns all of them."""
+    gt_id = run(CREATE_GT, gql_context)["create_general_task"]["general_task"]["id"]
+    file_id = run(CREATE_FILE, gql_context)["create_file"]["file_result"]["id"]
+
+    with patch("data.search.index_document"):
+        result = run(REINDEX_MUTATION, gql_context, {"ids": [gt_id, file_id]})
+
+    assert result["reindex"]["ok"] is True
+    assert set(result["reindex"]["reindexed_ids"]) == {gt_id, file_id}
+
+
+def test_reindex_unknown_id_skipped(gql_context):
+    """An ID that doesn't exist in DynamoDB is silently skipped."""
+    from strawberry.relay import GlobalID
+
+    fake_id = str(GlobalID("GeneralTask", "999999zzzzz"))
+
+    with patch("data.search.index_document") as mock_index:
+        result = run(REINDEX_MUTATION, gql_context, {"ids": [fake_id]})
+
+    assert result["reindex"]["ok"] is True
+    assert result["reindex"]["reindexed_ids"] == []
+    mock_index.assert_not_called()
+
+
+def test_reindex_empty_list(gql_context):
+    """Empty id_in returns ok with empty reindexed_ids."""
+    result = run(REINDEX_MUTATION, gql_context, {"ids": []})
+    assert result["reindex"]["ok"] is True
+    assert result["reindex"]["reindexed_ids"] == []
+
+
+# ── Integration test — requires live ES ──────────────────────────────────────
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not __import__("os").environ.get("ES_ENDPOINT"), reason="requires ES_ENDPOINT")
+def test_reindex_document_lands_in_es(gql_context):
+    """After reindex, the document is queryable from ES."""
+    import time
+
+    import requests as _req
+
+    gt_id = run(CREATE_GT, gql_context)["create_general_task"]["general_task"]["id"]
+    ep = gql_context.get("es_endpoint", "")
+    idx = gql_context.get("es_index", "toshi-index-mapped")
+
+    # Delete and re-index to confirm reindex actually writes
+    from strawberry.relay import GlobalID
+
+    gid = GlobalID.from_id(gt_id)
+    key = f"ThingData_{gid.node_id}"
+    _req.delete(f"{ep}/{idx}/_doc/{key}", timeout=5)
+    time.sleep(0.5)
+
+    result = run(REINDEX_MUTATION, gql_context, {"ids": [gt_id]})
+    assert result["reindex"]["ok"] is True
+    time.sleep(1)
+
+    resp = _req.get(f"{ep}/{idx}/_doc/{key}", timeout=5).json()
+    assert resp.get("found") is True
+    assert resp["_source"]["clazz_name"] == "GeneralTask"

--- a/spike/strawberry_poc/tests/test_rupture_set.py
+++ b/spike/strawberry_poc/tests/test_rupture_set.py
@@ -1,0 +1,188 @@
+"""
+Tests for RuptureSet — relay ID encoding, produced_by union resolution.
+
+Key feasibility signals tested here:
+  1. relay.GlobalID round-trip: base64("TypeName:id") matches Graphene format
+  2. Union type (produced_by): resolves correctly to RuptureGenerationTask
+  3. File table separate from Thing table: create + list work independently
+
+Field and mutation names use snake_case (auto_camel_case=False on schema).
+Mutations return payload wrapper types matching the Graphene API shape.
+"""
+
+import base64
+
+import pytest
+
+from schema import schema
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+CREATE_RUPTURE_SET_MUTATION = """
+mutation CreateRuptureSet($input: CreateRuptureSetInput!) {
+    create_rupture_set(input: $input) {
+        rupture_set {
+            id
+            file_name
+            md5_digest
+            file_size
+            created
+            fault_models
+            metrics { k v }
+            produced_by {
+                id
+                state
+                result
+            }
+        }
+    }
+}
+"""
+
+LIST_RUPTURE_SETS_QUERY = """
+query {
+    rupture_sets {
+        edges {
+            node {
+                id
+                file_name
+                produced_by {
+                    id
+                }
+            }
+        }
+    }
+}
+"""
+
+NODE_QUERY = """
+query GetNode($id: ID!) {
+    node(id: $id) {
+        id
+        ... on RuptureSet {
+            file_name
+            md5_digest
+            produced_by {
+                id
+                state
+            }
+        }
+    }
+}
+"""
+
+
+def _make_rupture_generation_task(gql_context):
+    """Seed a RuptureGenerationTask directly via the data layer."""
+    from data.dynamo import create_thing
+
+    data = create_thing(
+        gql_context["dynamodb"],
+        "RuptureGenerationTask",
+        {"state": "done", "result": "success", "created": "2024-01-01T00:00:00Z"},
+    )
+    raw_id = data["object_id"]
+    encoded = base64.b64encode(f"RuptureGenerationTask:{raw_id}".encode()).decode()
+    return encoded, raw_id
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def rupture_gen_task_id(gql_context):
+    """Returns the relay GlobalID string for a seeded RuptureGenerationTask."""
+    encoded, _ = _make_rupture_generation_task(gql_context)
+    return encoded
+
+
+@pytest.fixture(scope="module")
+def created_rupture_set(gql_context, rupture_gen_task_id):
+    """Creates a RuptureSet and returns the result dict."""
+    result = schema.execute_sync(
+        CREATE_RUPTURE_SET_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "rupture_set_v1.zip",
+                "produced_by": rupture_gen_task_id,
+                "md5_digest": "abc123",
+                "file_size": 1048576,
+                "created": "2024-02-01T00:00:00Z",
+                "fault_models": ["CFM_0_9_SANSTVZ_D90"],
+                "metrics": [{"k": "num_ruptures", "v": "200000"}],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_rupture_set"]["rupture_set"]
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+
+def test_rupture_set_id_encoding(created_rupture_set):
+    """Relay global ID must be base64('RuptureSet:<raw_id>')."""
+    gid = created_rupture_set["id"]
+    decoded = base64.b64decode(gid).decode()
+    assert decoded.startswith("RuptureSet:"), f"Unexpected ID format: {decoded}"
+
+
+def test_rupture_gen_task_id_encoding(rupture_gen_task_id):
+    """Seeded RuptureGenerationTask ID must be base64('RuptureGenerationTask:<raw_id>')."""
+    decoded = base64.b64decode(rupture_gen_task_id).decode()
+    assert decoded.startswith("RuptureGenerationTask:")
+
+
+def test_rupture_set_fields(created_rupture_set):
+    assert created_rupture_set["file_name"] == "rupture_set_v1.zip"
+    assert created_rupture_set["md5_digest"] == "abc123"
+    assert created_rupture_set["file_size"] == 1048576
+    assert created_rupture_set["created"] == "2024-02-01T00:00:00Z"
+    assert created_rupture_set["fault_models"] == ["CFM_0_9_SANSTVZ_D90"]
+    assert created_rupture_set["metrics"] == [{"k": "num_ruptures", "v": "200000"}]
+
+
+def test_produced_by_resolved(created_rupture_set, rupture_gen_task_id):
+    """produced_by must resolve to the correct RuptureGenerationTask."""
+    produced_by = created_rupture_set["produced_by"]
+    assert produced_by is not None
+    assert produced_by["id"] == rupture_gen_task_id
+    assert produced_by["state"] == "DONE"
+    assert produced_by["result"] == "SUCCESS"
+
+
+def test_list_rupture_sets(gql_context, created_rupture_set):
+    result = schema.execute_sync(LIST_RUPTURE_SETS_QUERY, context_value=gql_context)
+    assert result.errors is None, result.errors
+
+    edges = result.data["rupture_sets"]["edges"]
+    assert len(edges) >= 1
+    ids = [e["node"]["id"] for e in edges]
+    assert created_rupture_set["id"] in ids
+
+
+def test_node_lookup(gql_context, created_rupture_set, rupture_gen_task_id):
+    """Node interface lookup must return the correct RuptureSet with produced_by."""
+    result = schema.execute_sync(
+        NODE_QUERY,
+        variable_values={"id": created_rupture_set["id"]},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+
+    node = result.data["node"]
+    assert node["id"] == created_rupture_set["id"]
+    assert node["file_name"] == "rupture_set_v1.zip"
+    assert node["md5_digest"] == "abc123"
+    assert node["produced_by"]["id"] == rupture_gen_task_id
+    assert node["produced_by"]["state"] == "DONE"
+
+
+def test_relay_ids_are_different_types(created_rupture_set, rupture_gen_task_id):
+    """File and Thing objects have different type prefixes in their global IDs."""
+    rs_type = base64.b64decode(created_rupture_set["id"]).decode().split(":")[0]
+    rgt_type = base64.b64decode(rupture_gen_task_id).decode().split(":")[0]
+    assert rs_type == "RuptureSet"
+    assert rgt_type == "RuptureGenerationTask"
+    assert rs_type != rgt_type

--- a/spike/strawberry_poc/tests/test_rupture_set_upload.py
+++ b/spike/strawberry_poc/tests/test_rupture_set_upload.py
@@ -1,0 +1,127 @@
+"""
+Tests for RuptureSet upload URL fields (post_url, post_url_v2, file_url).
+
+Covers COVERAGE_GAPS.md gap 9 — guards the schema-level contract that
+weka relies on for upload/download URL generation. In the POC, these
+resolvers are stubs returning None (S3 is not exercised); the tests
+confirm the fields are queryable without error and have the correct
+nullable String types.
+"""
+
+import pytest
+
+from schema import schema
+
+CREATE_RS_MUTATION = """
+mutation($input: CreateRuptureSetInput!) {
+    create_rupture_set(input: $input) {
+        ok
+        rupture_set {
+            id
+            file_name
+            file_url
+            post_url
+            post_url_v2
+            post_data_v2
+        }
+    }
+}
+"""
+
+NODE_QUERY = """
+query GetNode($id: ID!) {
+    node(id: $id) {
+        id
+        ... on RuptureSet {
+            file_name
+            file_url
+            post_url
+            post_url_v2
+            post_data_v2
+        }
+    }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def rgt_id(gql_context):
+    import base64
+
+    from data.dynamo import create_thing
+
+    data = create_thing(
+        gql_context["dynamodb"],
+        "RuptureGenerationTask",
+        {"state": "done", "result": "success", "created": "2024-01-01T00:00:00Z"},
+    )
+    return base64.b64encode(f"RuptureGenerationTask:{data['object_id']}".encode()).decode()
+
+
+@pytest.fixture(scope="module")
+def created_rupture_set(gql_context, rgt_id):
+    result = schema.execute_sync(
+        CREATE_RS_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "upload_test.zip",
+                "produced_by": rgt_id,
+                "md5_digest": "feedface",
+                "file_size": 1_048_576,
+                "created": "2024-04-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_rupture_set"]["rupture_set"]
+
+
+def test_post_url_fields_queryable_on_create(created_rupture_set):
+    """All upload URL fields resolve without error on the create payload."""
+    rs = created_rupture_set
+    assert rs["file_name"] == "upload_test.zip"
+    # In POC: stubs return null; the schema-level contract is what's tested
+    assert rs["post_url"] is None
+    assert rs["post_url_v2"] is None
+    assert rs["post_data_v2"] is None
+
+
+def test_file_url_resolves_without_error(created_rupture_set):
+    """file_url calls presigned_download_url; returns None when S3 not configured."""
+    rs = created_rupture_set
+    assert "file_url" in rs
+
+
+def test_post_url_fields_queryable_via_node(gql_context, created_rupture_set):
+    """Same upload URL fields resolve via the node(id:) query."""
+    result = schema.execute_sync(
+        NODE_QUERY, variable_values={"id": created_rupture_set["id"]}, context_value=gql_context
+    )
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["file_name"] == "upload_test.zip"
+    assert node["post_url"] is None
+    assert node["post_url_v2"] is None
+    assert node["post_data_v2"] is None
+
+
+def test_file_url_uses_presigned_download_url(gql_context, created_rupture_set, monkeypatch):
+    """file_url must delegate to presigned_download_url with (pk, file_name)."""
+    from models import file_interface as fi
+
+    captured = {}
+
+    def fake_presigner(object_id, file_name):
+        captured["object_id"] = object_id
+        captured["file_name"] = file_name
+        return f"https://fake-bucket.s3/{object_id}/{file_name}"
+
+    monkeypatch.setattr(fi, "presigned_download_url", fake_presigner)
+
+    result = schema.execute_sync(
+        NODE_QUERY, variable_values={"id": created_rupture_set["id"]}, context_value=gql_context
+    )
+    assert result.errors is None, result.errors
+    assert result.data["node"]["file_url"] == f"https://fake-bucket.s3/{captured['object_id']}/upload_test.zip"
+    assert captured["file_name"] == "upload_test.zip"

--- a/spike/strawberry_poc/tests/test_scaled_inversion_solution.py
+++ b/spike/strawberry_poc/tests/test_scaled_inversion_solution.py
@@ -1,0 +1,212 @@
+"""
+Tests for ScaledInversionSolution — produced_by, source_solution, predecessors.
+"""
+
+import base64
+
+import pytest
+
+from schema import schema
+
+# ── GQL strings ───────────────────────────────────────────────────────────────
+
+CREATE_MUTATION = """
+mutation CreateScaled($input: CreateScaledInversionSolutionInput!) {
+    create_scaled_inversion_solution(input: $input) {
+        ok
+        solution {
+            id
+            file_name
+            md5_digest
+            file_size
+            created
+            produced_by {
+                ... on AutomationTask { id }
+                ... on RuptureGenerationTask { id }
+            }
+            source_solution {
+                ... on InversionSolution { id }
+            }
+            predecessors {
+                id
+                depth
+                typename
+                relationship
+            }
+        }
+    }
+}
+"""
+
+NODE_QUERY = """
+query GetNode($id: ID!) {
+    node(id: $id) {
+        id
+        ... on ScaledInversionSolution {
+            file_name
+            produced_by {
+                ... on AutomationTask { id }
+                ... on RuptureGenerationTask { id }
+            }
+            source_solution {
+                ... on InversionSolution { id }
+            }
+            predecessors {
+                id
+                depth
+                relationship
+            }
+        }
+    }
+}
+"""
+
+
+# ── Seed helpers ──────────────────────────────────────────────────────────────
+
+
+def _seed_rgt(gql_context) -> str:
+    from data.dynamo import create_thing
+
+    data = create_thing(
+        gql_context["dynamodb"],
+        "RuptureGenerationTask",
+        {"state": "done", "result": "success", "created": "2024-01-01T00:00:00Z"},
+    )
+    return base64.b64encode(f"RuptureGenerationTask:{data['object_id']}".encode()).decode()
+
+
+def _seed_automation_task(gql_context) -> str:
+    from data.dynamo import create_thing
+
+    data = create_thing(
+        gql_context["dynamodb"],
+        "AutomationTask",
+        {"state": "done", "result": "success", "task_type": "scale_solution", "created": "2024-01-01T00:00:00Z"},
+    )
+    return base64.b64encode(f"AutomationTask:{data['object_id']}".encode()).decode()
+
+
+def _seed_inversion_solution(gql_context, rgt_id: str) -> str:
+    result = schema.execute_sync(
+        """
+        mutation($input: CreateInversionSolutionInput!) {
+            create_inversion_solution(input: $input) {
+                ok
+                inversion_solution { id }
+            }
+        }
+        """,
+        variable_values={
+            "input": {
+                "file_name": "upstream.zip",
+                "produced_by": rgt_id,
+                "md5_digest": "aabbccdd",
+                "file_size": 1024,
+                "created": "2024-01-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_inversion_solution"]["inversion_solution"]["id"]
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def rgt_id(gql_context):
+    return _seed_rgt(gql_context)
+
+
+@pytest.fixture(scope="module")
+def automation_task_id(gql_context):
+    return _seed_automation_task(gql_context)
+
+
+@pytest.fixture(scope="module")
+def source_solution_id(gql_context, rgt_id):
+    return _seed_inversion_solution(gql_context, rgt_id)
+
+
+@pytest.fixture(scope="module")
+def created_scaled(gql_context, automation_task_id, source_solution_id):
+    result = schema.execute_sync(
+        CREATE_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "scaled_v1.zip",
+                "source_solution": source_solution_id,
+                "produced_by": automation_task_id,
+                "md5_digest": "deadbeef",
+                "file_size": 512,
+                "created": "2024-03-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_scaled_inversion_solution"]["solution"]
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+def test_create_returns_id(created_scaled):
+    gid = created_scaled["id"]
+    decoded = base64.b64decode(gid).decode()
+    assert decoded.startswith("ScaledInversionSolution:"), decoded
+
+
+def test_fields(created_scaled):
+    s = created_scaled
+    assert s["file_name"] == "scaled_v1.zip"
+    assert s["md5_digest"] == "deadbeef"
+    assert s["file_size"] == 512
+    assert s["created"] == "2024-03-01T00:00:00Z"
+
+
+def test_produced_by(created_scaled, automation_task_id):
+    pb = created_scaled["produced_by"]
+    assert pb is not None
+    assert pb["id"] == automation_task_id
+
+
+def test_source_solution(created_scaled, source_solution_id):
+    ss = created_scaled["source_solution"]
+    assert ss is not None
+    assert ss["id"] == source_solution_id
+
+
+def test_node_lookup(created_scaled, gql_context, automation_task_id, source_solution_id):
+    result = schema.execute_sync(NODE_QUERY, variable_values={"id": created_scaled["id"]}, context_value=gql_context)
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["file_name"] == "scaled_v1.zip"
+    assert node["produced_by"]["id"] == automation_task_id
+    assert node["source_solution"]["id"] == source_solution_id
+
+
+def test_with_predecessors(gql_context, automation_task_id, source_solution_id):
+    result = schema.execute_sync(
+        CREATE_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "scaled_with_pred.zip",
+                "source_solution": source_solution_id,
+                "produced_by": automation_task_id,
+                "md5_digest": "cafebabe",
+                "file_size": 256,
+                "created": "2024-03-02T00:00:00Z",
+                "predecessors": [{"id": source_solution_id, "depth": -1}],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    preds = result.data["create_scaled_inversion_solution"]["solution"]["predecessors"]
+    assert len(preds) == 1
+    assert preds[0]["id"] == source_solution_id
+    assert preds[0]["depth"] == -1
+    assert preds[0]["relationship"] == "parent"

--- a/spike/strawberry_poc/tests/test_smoketest_ab.py
+++ b/spike/strawberry_poc/tests/test_smoketest_ab.py
@@ -1,0 +1,863 @@
+"""
+A/B smoketest — mirrors graphql_api/tests/smoketests.py setup sequence.
+
+Mutation strings are intentionally kept as close as possible to the originals
+in smoketests.py so this file can serve as a diff to document any remaining
+API surface differences.
+
+Key differences from the original smoketest:
+  - No search() queries (no Elasticsearch in POC)
+  - IDs captured from mutation responses rather than hardcoded
+    (no TOSHI_FIX_RANDOM_SEED dependency)
+  - Verification via node() and list queries instead of search()
+"""
+
+import pytest
+
+from schema import schema
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def ids(gql_context):
+    """
+    Run the full setup mutation sequence and collect returned IDs.
+    Mutation strings mirror graphql_api/tests/smoketests.py test_setup.
+    """
+    import requests as _requests
+
+    ep = gql_context.get("es_endpoint", "")
+    idx = gql_context.get("es_index", "toshi-index-mapped")
+    if ep:
+        # Wipe any stale data from previous runs so search results only
+        # contain objects created by this fixture.
+        _requests.delete(f"{ep}/{idx}", timeout=5)
+
+    collected = {}
+
+    def run(query, variables=None):
+        result = schema.execute_sync(query, context_value=gql_context, variable_values=variables or {})
+        assert result.errors is None, result.errors
+        return result.data
+
+    # 1. StrongMotionStation — mirrors smoketests.py "new_sms"
+    data = run("""
+        mutation new_sms {
+            create_strong_motion_station(input: {
+                site_code: "ABCD"
+                created: "2020-10-10T23:00Z"
+                site_class_basis: SPT
+                Vs30_mean: [200.0]
+                site_class: B
+            }) {
+                strong_motion_station { id }
+            }
+        }
+    """)
+    collected["sms_id"] = data["create_strong_motion_station"]["strong_motion_station"]["id"]
+
+    # 2. First RuptureGenerationTask — mirrors "new_ruptgen_task"
+    data = run("""
+        mutation new_ruptgen_task {
+            create_rupture_generation_task(input: {
+                created: "2020-10-10T23:00Z"
+                state: SCHEDULED
+                result: UNDEFINED
+                task_type: RUPTURE_SET
+            }) {
+                task_result { id created }
+            }
+        }
+    """)
+    collected["rgt1_id"] = data["create_rupture_generation_task"]["task_result"]["id"]
+
+    # 3. Update RuptureGenerationTask — mirrors "update_ruptgen_task"
+    data = run(
+        """
+        mutation update_ruptgen_task($task_id: ID!) {
+            update_rupture_generation_task(input: {
+                task_id: $task_id
+                result: SUCCESS
+                state: DONE
+            }) {
+                task_result { id }
+            }
+        }
+    """,
+        {"task_id": collected["rgt1_id"]},
+    )
+    assert data["update_rupture_generation_task"]["task_result"]["id"] == collected["rgt1_id"]
+
+    # 4. File — mirrors "new_rupt_file"
+    data = run("""
+        mutation new_rupt_file {
+            create_file(input: {
+                file_name: "myfile2.txt"
+                file_size: 2000
+                md5_digest: "abc123"
+                meta: [{ k: "encoding", v: "utf8" }]
+            }) {
+                file_result { id meta { k v } }
+            }
+        }
+    """)
+    collected["file_id"] = data["create_file"]["file_result"]["id"]
+
+    # 5. File → RuptureGenerationTask relation — mirrors "new_rupt_file_relation"
+    data = run(
+        """
+        mutation new_rupt_file_relation($file_id: ID!, $thing_id: ID!) {
+            create_file_relation(input: {
+                file_id: $file_id
+                thing_id: $thing_id
+                role: WRITE
+            }) { ok }
+        }
+    """,
+        {"file_id": collected["file_id"], "thing_id": collected["rgt1_id"]},
+    )
+    assert data["create_file_relation"]["ok"] is True
+
+    # 6. SmsFile — mirrors "new_sms_file"
+    data = run("""
+        mutation new_sms_file {
+            create_sms_file(input: {
+                file_name: "my_sms_File2.txt"
+                file_size: 2000
+                file_type: CPT
+                md5_digest: "def456"
+            }) {
+                file_result { id file_type }
+            }
+        }
+    """)
+    collected["sms_file_id"] = data["create_sms_file"]["file_result"]["id"]
+
+    # 7. SmsFile → StrongMotionStation relation — mirrors "new_sms_file_relation"
+    data = run(
+        """
+        mutation new_sms_file_relation($file_id: ID!, $thing_id: ID!) {
+            create_file_relation(input: {
+                file_id: $file_id
+                thing_id: $thing_id
+                role: UNDEFINED
+            }) { ok }
+        }
+    """,
+        {"file_id": collected["sms_file_id"], "thing_id": collected["sms_id"]},
+    )
+    assert data["create_file_relation"]["ok"] is True
+
+    # 8. GeneralTask — mirrors "new_general_task"
+    data = run("""
+        mutation new_general_task {
+            create_general_task(input: {
+                created: "2020-10-10T23:00:00+00:00"
+                title: "My First Manual task"
+                description: "##Some notes go here"
+                agent_name: "chrisbc"
+            }) {
+                general_task { id created }
+            }
+        }
+    """)
+    collected["gt_id"] = data["create_general_task"]["general_task"]["id"]
+
+    # 9. File → GeneralTask relation — mirrors "new_gt_file_relation"
+    data = run(
+        """
+        mutation new_gt_file_relation($file_id: ID!, $thing_id: ID!) {
+            create_file_relation(input: {
+                file_id: $file_id
+                thing_id: $thing_id
+                role: READ
+            }) { ok }
+        }
+    """,
+        {"file_id": collected["file_id"], "thing_id": collected["gt_id"]},
+    )
+    assert data["create_file_relation"]["ok"] is True
+
+    # 10. SmsFile → GeneralTask relation — mirrors "new_gt_smsfile_relation"
+    data = run(
+        """
+        mutation new_gt_smsfile_relation($file_id: ID!, $thing_id: ID!) {
+            create_file_relation(input: {
+                file_id: $file_id
+                thing_id: $thing_id
+                role: UNDEFINED
+            }) { ok }
+        }
+    """,
+        {"file_id": collected["sms_file_id"], "thing_id": collected["gt_id"]},
+    )
+    assert data["create_file_relation"]["ok"] is True
+
+    # 11. GeneralTask → RuptureGenerationTask — mirrors "new_task_subtask_relation"
+    data = run(
+        """
+        mutation new_task_subtask_relation($child_id: ID!, $parent_id: ID!) {
+            create_task_relation(input: {
+                child_id: $child_id
+                parent_id: $parent_id
+            }) {
+                thing_relation {
+                    parent { ... on GeneralTask { id } }
+                    child  { ... on RuptureGenerationTask { id } }
+                }
+            }
+        }
+    """,
+        {"child_id": collected["rgt1_id"], "parent_id": collected["gt_id"]},
+    )
+    rel = data["create_task_relation"]["thing_relation"]
+    assert rel["parent"]["id"] == collected["gt_id"]
+    assert rel["child"]["id"] == collected["rgt1_id"]
+
+    # 12. AutomationTask — mirrors "new_inversion"
+    data = run("""
+        mutation new_inversion {
+            create_automation_task(input: {
+                task_type: INVERSION
+                result: UNDEFINED
+                state: UNDEFINED
+                created: "2020-10-10T23:00Z"
+                arguments: [{ k: "max_jump_distance", v: "55.5" }]
+                environment: [
+                    { k: "gitref_opensha_ucerf3", v: "ABC" }
+                    { k: "JAVA", v: "-Xmx24G" }
+                ]
+            }) {
+                task_result { id created arguments { k v } }
+            }
+        }
+    """)
+    collected["at_id"] = data["create_automation_task"]["task_result"]["id"]
+
+    # 13. Second RuptureGenerationTask with full args — mirrors "new_ruptgen_new_task"
+    data = run("""
+        mutation new_ruptgen_new_task {
+            create_rupture_generation_task(input: {
+                state: UNDEFINED
+                result: UNDEFINED
+                task_type: RUPTURE_SET
+                created: "2020-10-10T23:00Z"
+                duration: 600.0
+                arguments: [
+                    { k: "max_jump_distance", v: "55.5" }
+                    { k: "max_sub_section_length", v: "2" }
+                    { k: "max_cumulative_azimuth", v: "590" }
+                    { k: "min_sub_sections_per_parent", v: "2" }
+                    { k: "permutation_strategy", v: "DOWNDIP" }
+                ]
+                environment: [
+                    { k: "gitref_opensha_ucerf3", v: "ABC" }
+                    { k: "host", v: "tryharder-ubuntu" }
+                    { k: "JAVA", v: "-Xmx24G" }
+                ]
+                metrics: [
+                    { k: "subsection_count", v: "3600" }
+                    { k: "total_energy", v: "3280.2333" }
+                ]
+            }) {
+                task_result { id created duration arguments { k v } }
+            }
+        }
+    """)
+    collected["rgt2_id"] = data["create_rupture_generation_task"]["task_result"]["id"]
+
+    return collected
+
+
+# ── Verification tests ────────────────────────────────────────────────────────
+
+
+def test_setup_returns_all_ids(ids):
+    assert all(k in ids for k in ["sms_id", "rgt1_id", "file_id", "sms_file_id", "gt_id", "at_id", "rgt2_id"])
+    for key, val in ids.items():
+        assert val and len(val) > 4, f"{key} has empty ID"
+
+
+def test_node_strong_motion_station(ids, gql_context):
+    result = schema.execute_sync(
+        """
+        query GetSMS($id: ID!) {
+            node(id: $id) {
+                __typename
+                ... on StrongMotionStation {
+                    id
+                    site_code
+                    site_class
+                    site_class_basis
+                    Vs30_mean
+                }
+            }
+        }
+    """,
+        context_value=gql_context,
+        variable_values={"id": ids["sms_id"]},
+    )
+    assert result.errors is None
+    node = result.data["node"]
+    assert node["__typename"] == "StrongMotionStation"
+    assert node["site_code"] == "ABCD"
+    assert node["site_class"] == "B"
+    assert node["site_class_basis"] == "SPT"
+    assert node["Vs30_mean"] == [200.0]
+
+
+def test_node_rgt_after_update(ids, gql_context):
+    result = schema.execute_sync(
+        """
+        query GetRGT($id: ID!) {
+            node(id: $id) {
+                __typename
+                ... on RuptureGenerationTask {
+                    id
+                    created
+                    state
+                    result
+                    duration
+                }
+            }
+        }
+    """,
+        context_value=gql_context,
+        variable_values={"id": ids["rgt1_id"]},
+    )
+    assert result.errors is None
+    node = result.data["node"]
+    assert node["__typename"] == "RuptureGenerationTask"
+    assert node["state"] == "DONE"
+    assert node["result"] == "SUCCESS"
+    assert node["duration"] is None
+
+
+def test_node_file_with_relations(ids, gql_context):
+    result = schema.execute_sync(
+        """
+        query GetFile($id: ID!) {
+            node(id: $id) {
+                ... on ToshiFile {
+                    file_name
+                    file_size
+                    meta { k v }
+                    relations {
+                        edges {
+                            node {
+                                ... on FileRelation {
+                                    role
+                                    thing { __typename }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    """,
+        context_value=gql_context,
+        variable_values={"id": ids["file_id"]},
+    )
+    assert result.errors is None
+    node = result.data["node"]
+    assert node["file_name"] == "myfile2.txt"
+    assert node["file_size"] == 2000
+    assert node["meta"] == [{"k": "encoding", "v": "utf8"}]
+    typenames = {e["node"]["thing"]["__typename"] for e in node["relations"]["edges"]}
+    assert "RuptureGenerationTask" in typenames
+    assert "GeneralTask" in typenames
+
+
+def test_node_sms_file_with_relation(ids, gql_context):
+    result = schema.execute_sync(
+        """
+        query GetSmsFile($id: ID!) {
+            node(id: $id) {
+                ... on SmsFile {
+                    file_name
+                    file_type
+                    relations {
+                        edges {
+                            node {
+                                ... on FileRelation {
+                                    role
+                                    thing {
+                                        __typename
+                                        ... on StrongMotionStation { site_code }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    """,
+        context_value=gql_context,
+        variable_values={"id": ids["sms_file_id"]},
+    )
+    assert result.errors is None
+    node = result.data["node"]
+    assert node["file_name"] == "my_sms_File2.txt"
+    assert node["file_type"] == "CPT"
+    things = [e["node"]["thing"] for e in node["relations"]["edges"]]
+    sms = next(t for t in things if t["__typename"] == "StrongMotionStation")
+    assert sms["site_code"] == "ABCD"
+
+
+def test_node_general_task_children_and_files(ids, gql_context):
+    result = schema.execute_sync(
+        """
+        query GetGT($id: ID!) {
+            node(id: $id) {
+                ... on GeneralTask {
+                    id
+                    title
+                    description
+                    agent_name
+                    created
+                    children {
+                        edges {
+                            node {
+                                child {
+                                    __typename
+                                    ... on RuptureGenerationTask {
+                                        id
+                                        state
+                                        result
+                                        created
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    files {
+                        edges {
+                            node {
+                                ... on FileRelation {
+                                    role
+                                    file {
+                                        __typename
+                                        ... on ToshiFile { file_name file_size }
+                                        ... on SmsFile { file_name file_size file_type }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    """,
+        context_value=gql_context,
+        variable_values={"id": ids["gt_id"]},
+    )
+    assert result.errors is None
+    node = result.data["node"]
+    assert node["title"] == "My First Manual task"
+    assert node["agent_name"] == "chrisbc"
+
+    children = node["children"]["edges"]
+    assert len(children) == 1
+    child = children[0]["node"]["child"]
+    assert child["__typename"] == "RuptureGenerationTask"
+    assert child["id"] == ids["rgt1_id"]
+    assert child["state"] == "DONE"
+    assert child["result"] == "SUCCESS"
+
+    file_edges = node["files"]["edges"]
+    assert len(file_edges) == 2
+    roles = {e["node"]["role"] for e in file_edges}
+    assert "READ" in roles
+    assert "UNDEFINED" in roles
+    typenames = {e["node"]["file"]["__typename"] for e in file_edges}
+    assert "ToshiFile" in typenames
+    assert "SmsFile" in typenames
+
+
+def test_node_rgt_files_and_parents(ids, gql_context):
+    result = schema.execute_sync(
+        """
+        query GetRGT($id: ID!) {
+            node(id: $id) {
+                ... on RuptureGenerationTask {
+                    state
+                    result
+                    files {
+                        edges {
+                            node {
+                                ... on FileRelation {
+                                    role
+                                    file { ... on ToshiFile { file_name } }
+                                }
+                            }
+                        }
+                    }
+                    parents {
+                        edges {
+                            node {
+                                parent {
+                                    ... on GeneralTask { title description }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    """,
+        context_value=gql_context,
+        variable_values={"id": ids["rgt1_id"]},
+    )
+    assert result.errors is None
+    node = result.data["node"]
+    assert node["state"] == "DONE"
+    assert node["files"]["edges"][0]["node"]["file"]["file_name"] == "myfile2.txt"
+    assert node["parents"]["edges"][0]["node"]["parent"]["title"] == "My First Manual task"
+
+
+def test_node_automation_task(ids, gql_context):
+    result = schema.execute_sync(
+        """
+        query GetAT($id: ID!) {
+            node(id: $id) {
+                __typename
+                ... on AutomationTask {
+                    id
+                    created
+                    task_type
+                    arguments { k v }
+                }
+            }
+        }
+    """,
+        context_value=gql_context,
+        variable_values={"id": ids["at_id"]},
+    )
+    assert result.errors is None
+    node = result.data["node"]
+    assert node["__typename"] == "AutomationTask"
+    assert node["task_type"] == "INVERSION"
+    assert node["arguments"] == [{"k": "max_jump_distance", "v": "55.5"}]
+
+
+def test_node_rgt2_arguments_and_metrics(ids, gql_context):
+    result = schema.execute_sync(
+        """
+        query GetRGT2($id: ID!) {
+            node(id: $id) {
+                __typename
+                ... on RuptureGenerationTask {
+                    id
+                    created
+                    duration
+                    arguments { k v }
+                    metrics { k v }
+                }
+            }
+        }
+    """,
+        context_value=gql_context,
+        variable_values={"id": ids["rgt2_id"]},
+    )
+    assert result.errors is None
+    node = result.data["node"]
+    assert node["__typename"] == "RuptureGenerationTask"
+    assert node["duration"] == 600.0
+    assert len(node["arguments"]) == 5
+    assert len(node["metrics"]) == 2
+
+
+def test_list_general_tasks(ids, gql_context):
+    result = schema.execute_sync(
+        """
+        query { general_tasks { edges { node { id title agent_name } } } }
+    """,
+        context_value=gql_context,
+    )
+    assert result.errors is None
+    nodes = [e["node"] for e in result.data["general_tasks"]["edges"]]
+    assert any(n["id"] == ids["gt_id"] and n["title"] == "My First Manual task" for n in nodes)
+
+
+def test_list_rupture_generation_tasks(ids, gql_context):
+    result = schema.execute_sync(
+        """
+        query { rupture_generation_tasks { edges { node { id state result } } } }
+    """,
+        context_value=gql_context,
+    )
+    assert result.errors is None
+    nodes = [e["node"] for e in result.data["rupture_generation_tasks"]["edges"]]
+    found = {n["id"] for n in nodes}
+    assert ids["rgt1_id"] in found
+    assert ids["rgt2_id"] in found
+    rgt1 = next(n for n in nodes if n["id"] == ids["rgt1_id"])
+    assert rgt1["state"] == "DONE"
+    assert rgt1["result"] == "SUCCESS"
+
+
+def test_list_strong_motion_stations(ids, gql_context):
+    result = schema.execute_sync(
+        """
+        query { strong_motion_stations { edges { node { id site_code site_class } } } }
+    """,
+        context_value=gql_context,
+    )
+    assert result.errors is None
+    nodes = [e["node"] for e in result.data["strong_motion_stations"]["edges"]]
+    assert any(n["id"] == ids["sms_id"] and n["site_code"] == "ABCD" for n in nodes)
+
+
+def test_list_sms_files(ids, gql_context):
+    result = schema.execute_sync(
+        """
+        query { sms_files { edges { node { id file_name file_type } } } }
+    """,
+        context_value=gql_context,
+    )
+    assert result.errors is None
+    nodes = [e["node"] for e in result.data["sms_files"]["edges"]]
+    assert any(n["id"] == ids["sms_file_id"] and n["file_type"] == "CPT" for n in nodes)
+
+
+def test_list_automation_tasks(ids, gql_context):
+    result = schema.execute_sync(
+        """
+        query { automation_tasks { edges { node { id task_type } } } }
+    """,
+        context_value=gql_context,
+    )
+    assert result.errors is None
+    nodes = [e["node"] for e in result.data["automation_tasks"]["edges"]]
+    assert any(n["id"] == ids["at_id"] and n["task_type"] == "INVERSION" for n in nodes)
+
+
+# ── Integration tests — require live ES (ES_ENDPOINT env var) ─────────────────
+# Run with: ES_ENDPOINT=http://localhost:9200 uv run --extra dev pytest tests/ -m integration -v
+
+SEARCH_FRAGMENT = """
+fragment sr on SearchResult {
+    __typename
+    ... on ToshiFile {
+        id
+        file_name
+        relations {
+            edges {
+                node {
+                    ... on FileRelation {
+                        role
+                        thing {
+                            __typename
+                            ... on RuptureGenerationTask { created }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    ... on SmsFile {
+        id
+        file_name
+        file_type
+        relations {
+            edges {
+                node {
+                    ... on FileRelation {
+                        role
+                        thing {
+                            __typename
+                            ... on StrongMotionStation { site_code }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    ... on RuptureGenerationTask {
+        id
+        result
+        state
+        arguments { k v }
+        files {
+            edges {
+                node {
+                    ... on FileRelation {
+                        role
+                        file {
+                            ... on ToshiFile { id file_name file_size }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    ... on StrongMotionStation {
+        id
+        created
+        site_code
+        site_class
+        site_class_basis
+        liquefiable
+        Vs30_mean
+        files {
+            edges {
+                node {
+                    ... on FileRelation {
+                        role
+                        file {
+                            ... on SmsFile { file_name file_size }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    ... on GeneralTask {
+        id
+        created
+        updated
+        title
+        description
+        agent_name
+        children {
+            edges {
+                node {
+                    child {
+                        __typename
+                        ... on RuptureGenerationTask {
+                            id
+                            state
+                            result
+                            created
+                        }
+                    }
+                }
+            }
+        }
+        files {
+            edges {
+                node {
+                    ... on FileRelation {
+                        role
+                        file {
+                            __typename
+                            ... on ToshiFile { file_name file_size }
+                            ... on SmsFile { file_name file_size file_type }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    ... on AutomationTask {
+        id
+        created
+        task_type
+        arguments { k v }
+    }
+}
+"""
+
+SEARCH_QUERY = (
+    SEARCH_FRAGMENT
+    + """
+query Search($term: String!) {
+    search(search_term: $term) {
+        search_result {
+            edges {
+                node { ...sr }
+            }
+        }
+    }
+}
+"""
+)
+
+
+def _search(gql_context, term):
+    result = schema.execute_sync(SEARCH_QUERY, context_value=gql_context, variable_values={"term": term})
+    assert result.errors is None, result.errors
+    return result.data["search"]["search_result"]["edges"]
+
+
+@pytest.mark.integration
+def test_search_sms_by_site_class_basis(ids, gql_context):
+    """Mirrors smoketests.py search_sms query."""
+    import time
+
+    time.sleep(1)  # allow ES to index
+    edges = _search(gql_context, "site_class_basis:SPT")
+    nodes = [e["node"] for e in edges]
+    sms = next((n for n in nodes if n["__typename"] == "StrongMotionStation"), None)
+    assert sms is not None
+    assert sms["id"] == ids["sms_id"]
+    assert sms["site_code"] == "ABCD"
+    assert sms["site_class"] == "B"
+    assert sms["site_class_basis"] == "SPT"
+    assert sms["Vs30_mean"] == [200.0]
+    # File relation to SmsFile
+    file_nodes = [e["node"]["file"] for e in sms["files"]["edges"]]
+    assert any(f and f.get("file_name") == "my_sms_File2.txt" for f in file_nodes)
+
+
+@pytest.mark.integration
+def test_search_rupture_generation_task_by_result(ids, gql_context):
+    """Mirrors smoketests.py search_rupture query."""
+    edges = _search(gql_context, "result:SUCCESS")
+    nodes = [e["node"] for e in edges]
+    rgt = next((n for n in nodes if n["__typename"] == "RuptureGenerationTask"), None)
+    assert rgt is not None
+    assert rgt["id"] == ids["rgt1_id"]
+    assert rgt["result"] == "SUCCESS"
+    assert rgt["state"] == "DONE"
+    file_nodes = [e["node"] for e in rgt["files"]["edges"]]
+    assert any(e["role"] == "WRITE" and e["file"] and e["file"]["file_name"] == "myfile2.txt" for e in file_nodes)
+
+
+@pytest.mark.integration
+def test_search_sms_file_by_name(ids, gql_context):
+    """Mirrors smoketests.py search_file query."""
+    edges = _search(gql_context, "file_name:my_sms*")
+    nodes = [e["node"] for e in edges]
+    sms_file = next((n for n in nodes if n["__typename"] == "SmsFile"), None)
+    assert sms_file is not None
+    assert sms_file["id"] == ids["sms_file_id"]
+    assert sms_file["file_name"] == "my_sms_File2.txt"
+    assert sms_file["file_type"] == "CPT"
+    things = [e["node"]["thing"] for e in sms_file["relations"]["edges"]]
+    assert any(t["__typename"] == "StrongMotionStation" and t["site_code"] == "ABCD" for t in things)
+
+
+@pytest.mark.integration
+def test_search_general_task_by_agent(ids, gql_context):
+    """Mirrors smoketests.py search_general_task query."""
+    edges = _search(gql_context, "agent_name:chrisbc")
+    nodes = [e["node"] for e in edges]
+    gt = next((n for n in nodes if n["__typename"] == "GeneralTask"), None)
+    assert gt is not None
+    assert gt["id"] == ids["gt_id"]
+    assert gt["title"] == "My First Manual task"
+    assert gt["agent_name"] == "chrisbc"
+    # Child relation
+    children = [e["node"]["child"] for e in gt["children"]["edges"]]
+    assert any(c["__typename"] == "RuptureGenerationTask" and c["state"] == "DONE" for c in children)
+    # File relations
+    file_nodes = [e["node"] for e in gt["files"]["edges"]]
+    roles = {e["role"] for e in file_nodes}
+    assert "READ" in roles
+    assert "UNDEFINED" in roles
+
+
+@pytest.mark.integration
+def test_search_automation_task_by_task_type(ids, gql_context):
+    """Mirrors smoketests.py search_automation_task query."""
+    edges = _search(gql_context, "task_type:inversion")
+    nodes = [e["node"] for e in edges]
+    at = next((n for n in nodes if n["__typename"] == "AutomationTask"), None)
+    assert at is not None
+    assert at["id"] == ids["at_id"]
+    assert at["task_type"] == "INVERSION"
+    assert at["arguments"] == [{"k": "max_jump_distance", "v": "55.5"}]

--- a/spike/strawberry_poc/tests/test_sms_file.py
+++ b/spike/strawberry_poc/tests/test_sms_file.py
@@ -1,0 +1,101 @@
+"""Tests for SmsFile — create and node lookup."""
+
+import base64
+
+import pytest
+
+from schema import schema
+
+# ── GQL strings ───────────────────────────────────────────────────────────────
+
+CREATE_MUTATION = """
+mutation CreateSmsFile($input: CreateSmsFileInput!) {
+    create_sms_file(input: $input) {
+        ok
+        file_result {
+            id
+            file_name
+            file_size
+            md5_digest
+            created
+            file_type
+        }
+    }
+}
+"""
+
+NODE_QUERY = """
+query GetSmsFile($id: ID!) {
+    node(id: $id) {
+        id
+        ... on SmsFile {
+            file_name
+            file_type
+        }
+    }
+}
+"""
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def created_sms_file(gql_context):
+    result = schema.execute_sync(
+        CREATE_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "borehole_log.csv",
+                "file_type": "BH",
+                "md5_digest": "abcdef12",
+                "file_size": 8192,
+                "created": "2024-07-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_sms_file"]["file_result"]
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+def test_create_returns_id(created_sms_file):
+    gid = created_sms_file["id"]
+    decoded = base64.b64decode(gid).decode()
+    assert decoded.startswith("SmsFile:"), decoded
+
+
+def test_create_ok(gql_context):
+    result = schema.execute_sync(
+        CREATE_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "hvsr_data.csv",
+                "file_type": "HVSR",
+                "created": "2024-07-02T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    assert result.data["create_sms_file"]["ok"] is True
+
+
+def test_fields(created_sms_file):
+    f = created_sms_file
+    assert f["file_name"] == "borehole_log.csv"
+    assert f["file_type"] == "BH"
+    assert f["md5_digest"] == "abcdef12"
+    assert f["file_size"] == 8192
+    assert f["created"] == "2024-07-01T00:00:00Z"
+
+
+def test_node_lookup(created_sms_file, gql_context):
+    result = schema.execute_sync(NODE_QUERY, variable_values={"id": created_sms_file["id"]}, context_value=gql_context)
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["file_name"] == "borehole_log.csv"
+    assert node["file_type"] == "BH"

--- a/spike/strawberry_poc/tests/test_table.py
+++ b/spike/strawberry_poc/tests/test_table.py
@@ -1,0 +1,248 @@
+"""
+Tests for Table — create, node lookup, mfd_table resolver on InversionSolution.
+"""
+
+import base64
+
+import pytest
+
+from schema import schema
+
+# ── GQL strings ───────────────────────────────────────────────────────────────
+
+CREATE_TABLE_MUTATION = """
+mutation CreateTable($input: CreateTableInput!) {
+    create_table(input: $input) {
+        ok
+        table {
+            id
+            object_id
+            created
+            column_headers
+            column_types
+            rows
+            meta { k v }
+            dimensions { k v }
+            table_type
+        }
+    }
+}
+"""
+
+NODE_QUERY = """
+query GetTable($id: ID!) {
+    node(id: $id) {
+        id
+        ... on Table {
+            object_id
+            column_headers
+            column_types
+            rows
+            meta { k v }
+            dimensions { k v }
+            table_type
+        }
+    }
+}
+"""
+
+CREATE_IS_MUTATION = """
+mutation CreateIS($input: CreateInversionSolutionInput!) {
+    create_inversion_solution(input: $input) {
+        ok
+        inversion_solution {
+            id
+            mfd_table { id }
+        }
+    }
+}
+"""
+
+
+# ── Seed helpers ──────────────────────────────────────────────────────────────
+
+
+def _seed_rgt(gql_context) -> str:
+    from data.dynamo import create_thing
+
+    data = create_thing(
+        gql_context["dynamodb"],
+        "RuptureGenerationTask",
+        {"state": "done", "result": "success", "created": "2024-01-01T00:00:00Z"},
+    )
+    return base64.b64encode(f"RuptureGenerationTask:{data['object_id']}".encode()).decode()
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def task_id(gql_context):
+    """A RuptureGenerationTask ID to use as object_id for the table."""
+    return _seed_rgt(gql_context)
+
+
+@pytest.fixture(scope="module")
+def created_table(gql_context, task_id):
+    result = schema.execute_sync(
+        CREATE_TABLE_MUTATION,
+        variable_values={
+            "input": {
+                "object_id": task_id,
+                "created": "2024-06-01T00:00:00Z",
+                "column_headers": ["mag", "rate"],
+                "column_types": ["double", "double"],
+                "rows": [["6.0", "0.01"], ["7.0", "0.001"]],
+                "meta": [{"k": "source", "v": "opensha"}],
+                "table_type": "MFD_CURVES_V2",
+                "dimensions": [{"k": "iml_periods", "v": ["0", "0.1", "0.2"]}],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_table"]["table"]
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+def test_create_returns_id(created_table):
+    gid = created_table["id"]
+    decoded = base64.b64decode(gid).decode()
+    assert decoded.startswith("Table:"), decoded
+
+
+def test_create_ok(gql_context, task_id):
+    result = schema.execute_sync(
+        CREATE_TABLE_MUTATION,
+        variable_values={
+            "input": {
+                "object_id": task_id,
+                "column_headers": ["a"],
+                "rows": [["1"]],
+                "table_type": "HAZARD_GRIDDED",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    assert result.data["create_table"]["ok"] is True
+
+
+def test_fields(created_table):
+    t = created_table
+    assert t["column_headers"] == ["mag", "rate"]
+    assert t["column_types"] == ["double", "double"]
+    assert t["rows"] == [["6.0", "0.01"], ["7.0", "0.001"]]
+    assert t["meta"] == [{"k": "source", "v": "opensha"}]
+    assert t["table_type"] == "MFD_CURVES_V2"
+
+
+def test_dimensions(created_table):
+    dims = created_table["dimensions"]
+    assert len(dims) == 1
+    assert dims[0]["k"] == "iml_periods"
+    assert dims[0]["v"] == ["0", "0.1", "0.2"]
+
+
+def test_node_lookup(created_table, gql_context):
+    result = schema.execute_sync(NODE_QUERY, variable_values={"id": created_table["id"]}, context_value=gql_context)
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["column_headers"] == ["mag", "rate"]
+    assert node["rows"] == [["6.0", "0.01"], ["7.0", "0.001"]]
+    assert node["table_type"] == "MFD_CURVES_V2"
+    assert node["dimensions"][0]["k"] == "iml_periods"
+
+
+# ── name field (COVERAGE_GAPS.md gap 7) ───────────────────────────────────────
+
+CREATE_TABLE_WITH_NAME_MUTATION = """
+mutation CreateTable($input: CreateTableInput!) {
+    create_table(input: $input) {
+        ok
+        table { id name table_type }
+    }
+}
+"""
+
+NODE_NAME_QUERY = """
+query GetTable($id: ID!) {
+    node(id: $id) {
+        id
+        ... on Table { name table_type }
+    }
+}
+"""
+
+
+def test_create_table_with_name(gql_context, task_id):
+    """The name input field round-trips to Table.name."""
+    result = schema.execute_sync(
+        CREATE_TABLE_WITH_NAME_MUTATION,
+        variable_values={
+            "input": {
+                "object_id": task_id,
+                "name": "MFD Curves v2",
+                "table_type": "MFD_CURVES_V2",
+                "column_headers": ["mag"],
+                "rows": [["7.0"]],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    table = result.data["create_table"]["table"]
+    assert table["name"] == "MFD Curves v2"
+
+
+def test_table_node_lookup_returns_name(gql_context, task_id):
+    create_result = schema.execute_sync(
+        CREATE_TABLE_WITH_NAME_MUTATION,
+        variable_values={
+            "input": {
+                "object_id": task_id,
+                "name": "Hazard Sites Grid",
+                "table_type": "HAZARD_SITES",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert create_result.errors is None, create_result.errors
+    table_id = create_result.data["create_table"]["table"]["id"]
+
+    result = schema.execute_sync(
+        NODE_NAME_QUERY, variable_values={"id": table_id}, context_value=gql_context
+    )
+    assert result.errors is None, result.errors
+    assert result.data["node"]["name"] == "Hazard Sites Grid"
+
+
+def test_mfd_table_on_inversion_solution(gql_context, created_table):
+    """InversionSolution.mfd_table resolves when a MFD_CURVES_V2 table entry is linked."""
+    rgt_id = _seed_rgt(gql_context)
+    result = schema.execute_sync(
+        CREATE_IS_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "is_with_mfd.zip",
+                "produced_by": rgt_id,
+                "md5_digest": "12345678",
+                "file_size": 512,
+                "created": "2024-06-01T00:00:00Z",
+                "tables": [
+                    {
+                        "table_id": created_table["id"],
+                        "table_type": "MFD_CURVES_V2",
+                        "label": "mfd",
+                    }
+                ],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    is_ = result.data["create_inversion_solution"]["inversion_solution"]
+    assert is_["mfd_table"] is not None
+    assert is_["mfd_table"]["id"] == created_table["id"]

--- a/spike/strawberry_poc/tests/test_time_dependent_inversion_solution.py
+++ b/spike/strawberry_poc/tests/test_time_dependent_inversion_solution.py
@@ -1,0 +1,217 @@
+"""
+Tests for TimeDependentInversionSolution — produced_by, source_solution, predecessors.
+"""
+
+import base64
+
+import pytest
+
+from schema import schema
+
+# ── GQL strings ───────────────────────────────────────────────────────────────
+
+CREATE_MUTATION = """
+mutation CreateTimeDependent($input: CreateTimeDependentInversionSolutionInput!) {
+    create_time_dependent_inversion_solution(input: $input) {
+        ok
+        solution {
+            id
+            file_name
+            md5_digest
+            file_size
+            created
+            produced_by {
+                ... on AutomationTask { id }
+                ... on RuptureGenerationTask { id }
+            }
+            source_solution {
+                ... on InversionSolution { id }
+            }
+            predecessors {
+                id
+                depth
+                typename
+                relationship
+            }
+        }
+    }
+}
+"""
+
+NODE_QUERY = """
+query GetNode($id: ID!) {
+    node(id: $id) {
+        id
+        ... on TimeDependentInversionSolution {
+            file_name
+            produced_by {
+                ... on AutomationTask { id }
+                ... on RuptureGenerationTask { id }
+            }
+            source_solution {
+                ... on InversionSolution { id }
+            }
+            predecessors {
+                id
+                depth
+                relationship
+            }
+        }
+    }
+}
+"""
+
+
+# ── Seed helpers ──────────────────────────────────────────────────────────────
+
+
+def _seed_rgt(gql_context) -> str:
+    from data.dynamo import create_thing
+
+    data = create_thing(
+        gql_context["dynamodb"],
+        "RuptureGenerationTask",
+        {"state": "done", "result": "success", "created": "2024-01-01T00:00:00Z"},
+    )
+    return base64.b64encode(f"RuptureGenerationTask:{data['object_id']}".encode()).decode()
+
+
+def _seed_automation_task(gql_context) -> str:
+    from data.dynamo import create_thing
+
+    data = create_thing(
+        gql_context["dynamodb"],
+        "AutomationTask",
+        {
+                "state": "done",
+                "result": "success",
+                "task_type": "time_dependent_solution",
+                "created": "2024-01-01T00:00:00Z",
+            },
+    )
+    return base64.b64encode(f"AutomationTask:{data['object_id']}".encode()).decode()
+
+
+def _seed_inversion_solution(gql_context, rgt_id: str) -> str:
+    result = schema.execute_sync(
+        """
+        mutation($input: CreateInversionSolutionInput!) {
+            create_inversion_solution(input: $input) {
+                ok
+                inversion_solution { id }
+            }
+        }
+        """,
+        variable_values={
+            "input": {
+                "file_name": "upstream_td.zip",
+                "produced_by": rgt_id,
+                "md5_digest": "11223344",
+                "file_size": 2048,
+                "created": "2024-01-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_inversion_solution"]["inversion_solution"]["id"]
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def rgt_id(gql_context):
+    return _seed_rgt(gql_context)
+
+
+@pytest.fixture(scope="module")
+def automation_task_id(gql_context):
+    return _seed_automation_task(gql_context)
+
+
+@pytest.fixture(scope="module")
+def source_solution_id(gql_context, rgt_id):
+    return _seed_inversion_solution(gql_context, rgt_id)
+
+
+@pytest.fixture(scope="module")
+def created_td(gql_context, automation_task_id, source_solution_id):
+    result = schema.execute_sync(
+        CREATE_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "time_dependent_v1.zip",
+                "source_solution": source_solution_id,
+                "produced_by": automation_task_id,
+                "md5_digest": "feedface",
+                "file_size": 1024,
+                "created": "2024-04-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_time_dependent_inversion_solution"]["solution"]
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+def test_create_returns_id(created_td):
+    gid = created_td["id"]
+    decoded = base64.b64decode(gid).decode()
+    assert decoded.startswith("TimeDependentInversionSolution:"), decoded
+
+
+def test_fields(created_td):
+    s = created_td
+    assert s["file_name"] == "time_dependent_v1.zip"
+    assert s["md5_digest"] == "feedface"
+    assert s["file_size"] == 1024
+    assert s["created"] == "2024-04-01T00:00:00Z"
+
+
+def test_produced_by(created_td, automation_task_id):
+    pb = created_td["produced_by"]
+    assert pb is not None
+    assert pb["id"] == automation_task_id
+
+
+def test_source_solution(created_td, source_solution_id):
+    ss = created_td["source_solution"]
+    assert ss is not None
+    assert ss["id"] == source_solution_id
+
+
+def test_node_lookup(created_td, gql_context, automation_task_id, source_solution_id):
+    result = schema.execute_sync(NODE_QUERY, variable_values={"id": created_td["id"]}, context_value=gql_context)
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["file_name"] == "time_dependent_v1.zip"
+    assert node["produced_by"]["id"] == automation_task_id
+    assert node["source_solution"]["id"] == source_solution_id
+
+
+def test_with_predecessors(gql_context, automation_task_id, source_solution_id):
+    result = schema.execute_sync(
+        CREATE_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "td_with_pred.zip",
+                "source_solution": source_solution_id,
+                "produced_by": automation_task_id,
+                "md5_digest": "beefdead",
+                "file_size": 512,
+                "created": "2024-04-02T00:00:00Z",
+                "predecessors": [{"id": source_solution_id, "depth": -1}],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    preds = result.data["create_time_dependent_inversion_solution"]["solution"]["predecessors"]
+    assert len(preds) == 1
+    assert preds[0]["id"] == source_solution_id
+    assert preds[0]["depth"] == -1
+    assert preds[0]["relationship"] == "parent"

--- a/spike/strawberry_poc/uv.lock
+++ b/spike/strawberry_poc/uv.lock
@@ -1,0 +1,1120 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "ast-serialize"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/9d/09e27731bd5864a9ce04e3244074e674bb8936bf62b45e0357248717adac/ast_serialize-0.5.0.tar.gz", hash = "sha256:5880091bfe6f4f986f22866375c2e884843e7a0b6343ae41aeea659613d879b6", size = 61157, upload-time = "2026-05-17T17:48:29.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/9a/13dde51ba9e15f8b97957ab7cb0120d0e381524d651c6bd630b9c359227f/ast_serialize-0.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8f5c14f169eb0972c0c21bada5358b23d6047c76583b005234f865b11f1fa00a", size = 1183520, upload-time = "2026-05-17T17:47:30.831Z" },
+    { url = "https://files.pythonhosted.org/packages/37/de/5a7f0a9fe68944f536632a5af84676739c7d2582be42deb082634bf3a754/ast_serialize-0.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7d1a2de9de5be04652f0ed60738356ef94f66db37924a9499fffe98dc491aa0b", size = 1175779, upload-time = "2026-05-17T17:47:32.551Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/81/0bb853e76e4f6e9a1855d569003c59e19ffac45f7079d91505d1bb212f92/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be5173fb66f9b49026d9d5a2ff0fc7c7009077107c0eb285b2d60fdf1fe10bd1", size = 1233750, upload-time = "2026-05-17T17:47:34.731Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d3/4cf705beeccc08754d0bbda99aefff26110e209b9a07ac8a6b60eec48531/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f8015cd071ac1339924ee2b8098c93e00e155f30a16f40ec9816fcf84f4753f6", size = 1235942, upload-time = "2026-05-17T17:47:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c8/ee097e437ea27dd2b8b227865c875492b585650a5802a22d82b304c8201b/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5499e8797edff2a9186aa313ed382c6b422e798e9332d9953badcee6e69a88f2", size = 1442517, upload-time = "2026-05-17T17:47:38.17Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/bd/68063442838f1ba68ec72b5436430bc75b3bb17a1a3c3063f09b0c05ae2b/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6848f2a093fb5548751a9a09bff8fcd229e2bbeb0e3331f391b6ae6d26cd9903", size = 1254081, upload-time = "2026-05-17T17:47:39.826Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e2/1e520793bc6a4e4524a6ab022391e827825eaa0c3811828bfdc6852eca26/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:832d4c998e0b091fd60a6d6bceee535483c4d490de9ba85003af835225719261", size = 1259910, upload-time = "2026-05-17T17:47:41.369Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e1/49b60f467979979cfe6913b43948ff25bca971ad0591d181812f163a988e/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:16db7c62ec0b8efe1d7afd283a388d8f74f2605d56032e5a37747d2de8dba027", size = 1250678, upload-time = "2026-05-17T17:47:43.702Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ba/66ab9555de6275677566f6574e5ef6c29cb185ea866f643bc06f8280a8ee/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:baf5eb061eb5bccade4128ad42da33787d72f6013809cd1b590376ece8b3c937", size = 1301603, upload-time = "2026-05-17T17:47:46.256Z" },
+    { url = "https://files.pythonhosted.org/packages/66/42/6aca9b9abc710014b2be9059689e5dd1679339e78f567ffb4d255a9e2050/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:104e4a35bd7c124173c41760ef9aaea17ddb3f86c65cb643671d59afbe3ee94c", size = 1410332, upload-time = "2026-05-17T17:47:47.899Z" },
+    { url = "https://files.pythonhosted.org/packages/47/68/2f76594432a22581ecf878b5e75a9b8601c24b2241cf0bbeb1e21fcf370c/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:36be371028fc1675acb38a331bde160dbab7ff907fdf00b67eb6911aa106951b", size = 1509979, upload-time = "2026-05-17T17:47:50.942Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ac/a93c9b58292653f6c595752f677a08e608f903b710594909e9231a389b3b/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:061ee58bdb52341c8201a6df41182a977736bae3b7ded87ca7176ca25a8a47ab", size = 1505002, upload-time = "2026-05-17T17:47:54.093Z" },
+    { url = "https://files.pythonhosted.org/packages/14/2e/b278f68c497ee2f1d1576cbbef8db5281cd4a5f2db040537592ac9c8862e/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b15219e9cdc9f53f6f4cb51c009203507228226148c05c5e8fe451c28b435eb3", size = 1456231, upload-time = "2026-05-17T17:47:56.311Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/419be1c566a4c504cd8fd60ce2f84e790f295495c0f327cfaeadf3d51012/ast_serialize-0.5.0-cp314-cp314t-win32.whl", hash = "sha256:842d1c004bb466c7df036f95fabef789570541922b10976b12f5592a69cf0b38", size = 1058668, upload-time = "2026-05-17T17:47:58.305Z" },
+    { url = "https://files.pythonhosted.org/packages/03/6f/c9d4d549295ed05111aeb8853232d1afd9d0a179fddb01eeffbb3a4a6842/ast_serialize-0.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b0c06d760909b095cc466356dfccd05a1c7233a6ca191c020dca2c6a6f16c24c", size = 1101075, upload-time = "2026-05-17T17:48:00.35Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/8e/d00c5ab30c58222e07d62956fca86c59d91b9ad32997e633c38b526623a3/ast_serialize-0.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:787baedb0262cc49e8ce37cc15c00ae818e46a165a3b36f5e21ed174998104cb", size = 1075347, upload-time = "2026-05-17T17:48:01.753Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9e/dc2530acb3a60dc6e46d65abf27d1d9f86721694757906a148d90a6860de/ast_serialize-0.5.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:0668aa9459cfa8c9c49ddd2163ebcf43088ba045ef7492af6fe22e0098303101", size = 1191380, upload-time = "2026-05-17T17:48:03.738Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0a/bd3d18a582f273d6c843d16bb9e22e9e16365ff7991e92f18f798e9f1224/ast_serialize-0.5.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bf683d6363edf2b39eed6b6d4fe22d34b6203867a67e27134d9e2a2680c4bc4a", size = 1183879, upload-time = "2026-05-17T17:48:05.463Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/1f919100f8620887af58fcc381c61a1f218cdf89c6e155f87b213e61010a/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cc22cf0c9be65e71cf88fda130af60d61eb4a79370ad4cfe7900d48a4aa2211", size = 1244529, upload-time = "2026-05-17T17:48:07.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ca/6376559dcce707cdbc1d0d9a13c8d3baaaa501e949ce0ebdc4230cd881aa/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f66173891548c9f2726bf27957b41cabce12fa679dc6da505ddbde4d4b3b31cf", size = 1240560, upload-time = "2026-05-17T17:48:08.46Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b2/a620e206b5aeb7efbf2710336df57d457cffbb3991076bbcc1147ef9abd4/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e42d729ef2be96a14efbad355093284739e3670ece3e534f82cc8832790911d9", size = 1451172, upload-time = "2026-05-17T17:48:09.922Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/e0/4ad5c04c24a40481b2935ce9a0ccdb6023dc8b667167d06ae530cc3512f2/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b725026bafa801dbd7310eb13a75f0a2e370e7e51b2cb225f9d21fcfadf919ee", size = 1265072, upload-time = "2026-05-17T17:48:11.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/71/4d1d479aa56d0101c40e17720c3d6ac2af7269ea0487a80b18e7bfd1a5b7/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b54f60c1d78767a53b67eaa663f0dfac3afe606aa07f1301572f588b73d64809", size = 1270488, upload-time = "2026-05-17T17:48:13.575Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/4f/0de1bbe06f6edef9fde4ed12ca8e7b3ec7e6e2bd4e672c5af487f7957665/ast_serialize-0.5.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:27d51654fc240a1e87e742d353d98eb45b75f62f129086b3596ab53df2ac2a43", size = 1260702, upload-time = "2026-05-17T17:48:15.141Z" },
+    { url = "https://files.pythonhosted.org/packages/75/61/e00872439cfdddcc3c1b6cdaa6e5d904ba8e26a18807c67c4e14409d0ca8/ast_serialize-0.5.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c36237c46dd1674542f2109740ea5ea485a169bf1431939ada0434e17934", size = 1311182, upload-time = "2026-05-17T17:48:16.779Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8e/699a5b955f7926956c95e9e1d74132acad73c2fe7a426f94da89123c20aa/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1943db345233cc7194a470f13afa9c59772c0b123dea0c9414c4d4ca54369759", size = 1421410, upload-time = "2026-05-17T17:48:18.527Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ae/d5b7626874478997adc7a29ab28accf21e596fb590c944290401dfd0b29e/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:df1c00022cbbcb064bfaa505aa9c9295362443ce5dacb459d1331d3da353f887", size = 1516587, upload-time = "2026-05-17T17:48:20.133Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ce/b59e02a82d9c4244d64cde502e0b00e83e38816abe19155ceb5437402c7f/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:cae65289fc456fde04af979a2be09302ef5d8ab92ef23e596d6746dc267ada27", size = 1515171, upload-time = "2026-05-17T17:48:21.921Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/38/d8d90042747d05aa08d4efcf1c99035a5f670a6bf4c214d31644392afbca/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:239a4c354e8d676e9d94631d1d4a64edc6b266f86ff3a5a80aedd344f342c01d", size = 1464668, upload-time = "2026-05-17T17:48:23.544Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/51/5b840c4df7334104cecffa28f23904fe81ca89ca223d2450e288de39fd3c/ast_serialize-0.5.0-cp39-abi3-win32.whl", hash = "sha256:143a4ef63285a075871908fda3672dc21864b83a8ec3ee12304aa3e4c5387b9a", size = 1068311, upload-time = "2026-05-17T17:48:25.027Z" },
+    { url = "https://files.pythonhosted.org/packages/41/11/ca5672c7d491825bc4cd6702dea106a6b60d928707712ec257c7833ae476/ast_serialize-0.5.0-cp39-abi3-win_amd64.whl", hash = "sha256:cf25572c526add400f26a4750dc6ce0c3bb93fc1f75e7ae0cad4ce4f2cd5c590", size = 1108931, upload-time = "2026-05-17T17:48:26.591Z" },
+    { url = "https://files.pythonhosted.org/packages/45/19/cc8bd127d28a43da249aa955cfd164cf8fd534e79e42cea96c4854d72fd0/ast_serialize-0.5.0-cp39-abi3-win_arm64.whl", hash = "sha256:92a31c9c20d25a076edaeec76b128a3535d74a24f340b9a8a7e96c9b86dc9642", size = 1081181, upload-time = "2026-05-17T17:48:28.122Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.42.94"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/6a/95302333208830de932ad1d0b69599ee13e936349a44981fb72632507861/boto3-1.42.94.tar.gz", hash = "sha256:5b6056a661c19e974aaea3cb97690ddbe30d10c31e4f887df3bff06574f34510", size = 113211, upload-time = "2026-04-22T20:36:19.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/6f/4e175604f3168befcb413c95bf45eada67d12042f92f76a9305d6a817ea9/boto3-1.42.94-py3-none-any.whl", hash = "sha256:56d53bce75629cc7c78a32da8b62de74cee3e2a3d54a2b60ba1a65f9f1b129da", size = 140555, upload-time = "2026-04-22T20:36:16.182Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.94"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/90/1a4d0e81b325d38e37f81d907ceacac3b8f509ad38b495bb95086ecb609d/botocore-1.42.94.tar.gz", hash = "sha256:41c6b3b11b073221a41f52b222ba387be34459fb77cdc506e8b74cdaf24bdcce", size = 15260901, upload-time = "2026-04-22T20:36:00.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/313af9ee02ac0155247bcf3f04fcf54fcae2e33250bb437528c18aeefd81/botocore-1.42.94-py3-none-any.whl", hash = "sha256:a2143742132ed0f6cdb90204d667b89d0301068b1045e8bc099efa267bf1b348", size = 14942938, upload-time = "2026-04-22T20:35:55.663Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/b7/bdbb725ba02c5b42825b200c940f38b7a54fcad24627b7192f78f8110d76/coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c", size = 220022, upload-time = "2026-05-26T20:39:03.702Z" },
+    { url = "https://files.pythonhosted.org/packages/72/81/fdc0898a55c6219223291ec1a1fe89966ef212ce82276aa0899df84b5de0/coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c", size = 220379, upload-time = "2026-05-26T20:39:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/de/72/de048c4a25e13bce59ac6a339351c10bdf2515e07459afcdaf04dc3143a2/coverage-7.14.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:84b535f00655ecafe1d929d1fb00ed5d6fa3051ea643ab2c161a3887b86f294b", size = 251888, upload-time = "2026-05-26T20:39:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/28/30/300c343f68beb9d4cbb64ec81e58c5b6b80b56927f72d2b38654ac26e013/coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6", size = 254624, upload-time = "2026-05-26T20:39:09.037Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ed/7b25642496e8170b6bac14adce00537c6e5fa2d586159401a4de3e8b49e6/coverage-7.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:442cc9c952b2df400cda54bb04ab87330cf2cd08a8692cbbea36773531eb6f37", size = 255739, upload-time = "2026-05-26T20:39:10.889Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a2/abd210b8c4e29c24e4624916db97bb519097a91034aaeb767f937e7da794/coverage-7.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8270544c361ed405a27a060dbc9ed2c124b084d96dfdc2d9a2510482aef981ad", size = 257998, upload-time = "2026-05-26T20:39:12.722Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/24/7c50beed3792fe62f6ce0545c6686ce83379719e2c0276179333d97eae92/coverage-7.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:48b283b1dd6372e8de2a7a9a4c4d5dc06f4d4fd209b876f3c88a7a205a0c8f84", size = 252296, upload-time = "2026-05-26T20:39:14.259Z" },
+    { url = "https://files.pythonhosted.org/packages/15/05/0f874628ebcbfc77ead559ff210281ef06a97db08481832e7dd39274a135/coverage-7.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5b0c99ba93a07d56f6df340bb79be53202a082b2fdb81bfe6190b741a3470d54", size = 253658, upload-time = "2026-05-26T20:39:15.923Z" },
+    { url = "https://files.pythonhosted.org/packages/99/6f/ca6ad067364b337ef997802115e7ecad2abd2248b05471464b0dea02b4d4/coverage-7.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e471bc5769ff073b058cfadb0d736b56ce067c8560eabeb0da88462df98c23e7", size = 251803, upload-time = "2026-05-26T20:39:17.537Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/30/b9b4d377cd9f40baf228068f5a81faf8450c6228503011bd499708483a50/coverage-7.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f497a1ea81d4cd7c10ddcaa685135b9aabd291af3d55775a9ddf3cb7a364cdd9", size = 255873, upload-time = "2026-05-26T20:39:19.414Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/21/7c721a9e5e6bb88547d30a787aefb97512d3f54c1324c7488d9b3743f7f9/coverage-7.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2222be86d0b54f5dd5a38f45f17f315f737245e857bf0bdedc70734f84a13c02", size = 251372, upload-time = "2026-05-26T20:39:21.169Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f8ae5a2200130e1503cd7661a6cd3b2b7bacef98277fbf3571fb13f8b766/coverage-7.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:85e85586565842f6932abebd4c18bcb1074223dc0b3576e7d173ca710622813a", size = 253245, upload-time = "2026-05-26T20:39:23.097Z" },
+    { url = "https://files.pythonhosted.org/packages/34/62/70a9024672a5f6910517d9628c52c9afbdd3cf8f46426af52bb148a56fff/coverage-7.14.1-cp312-cp312-win32.whl", hash = "sha256:4a28fd227808366b196a75476dced2eb35b351d6766ba9c858dc93319e87f4f1", size = 222567, upload-time = "2026-05-26T20:39:24.868Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/8b7cd386839b039ebe1855733b9f9449a8dec5d79564018234f185a7fa70/coverage-7.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:54acdb6674a4661768d7bf7db32dfb9f46ab1d764f8aba6df75ce1a6a088724e", size = 223372, upload-time = "2026-05-26T20:39:26.603Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ba/b44d472022f620d289d95fa830143235c0c36461c6f2437ea8d51e5481ed/coverage-7.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:99cd41ff91afd94896fea3bc002706b6ae4ce95727d06e4a0f39c0a8d8bd8b1a", size = 221989, upload-time = "2026-05-26T20:39:28.242Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/9e/5f6d56327c62b185225d145191c607e07515294a0aa6338e58805cd4a5ac/coverage-7.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:be9f2c802dcfce3f71298303aa5dad0dce440a76c52f2f60dacd8656dab78793", size = 220044, upload-time = "2026-05-26T20:39:29.902Z" },
+    { url = "https://files.pythonhosted.org/packages/75/92/e82aca356744cbbc0f77a0b623e38918c1872361963413a3bab5d0340393/coverage-7.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6223a72fd0e4c7156353ec0f08a5f93623e1d3034d0e2683b9bb8ea674131b1d", size = 220412, upload-time = "2026-05-26T20:39:31.561Z" },
+    { url = "https://files.pythonhosted.org/packages/27/c9/385bde0bf7ed0f4bf3a7ee5367060a86b5d218718cfd6fb943c0f836b34f/coverage-7.14.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7279d2110a28cebc738b6459ecda2771735a4c18465fbbd36b3288fe5ed92247", size = 251412, upload-time = "2026-05-26T20:39:33.337Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/23faf6a2343a0d17f960a4bd56c43bc7eb4cf312f774dd6ceebd82c7d8fc/coverage-7.14.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9eeb3fcbc13ba40dfbdb22d01d196a28e9cef9ed4c29b60061a1e0e823a9929d", size = 254008, upload-time = "2026-05-26T20:39:35.009Z" },
+    { url = "https://files.pythonhosted.org/packages/42/06/36f4aa9ca8a815e6036156e80706a67828bb97bd826948244f6996dda957/coverage-7.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f0cfc27c539f07cf5c0a4cfe211d0b6cae039f8f40526dbaa71944e64b50a7b", size = 255241, upload-time = "2026-05-26T20:39:36.71Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/79/95266316352f90f6b1c6736bb413302edfde2453fb32422d3911642691b3/coverage-7.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:221c70f316241a78e77e607c227cefc8808d4e08f28d99c04f35694690e940be", size = 257373, upload-time = "2026-05-26T20:39:38.412Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/9c/58316d1f66c488b5fca8a0eb3e98348807813efa8a0d0833b9021be27488/coverage-7.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:da028256b04ec30e5e0114b6f76172938c313991f0a2d3d894271315cf5d5e43", size = 251635, upload-time = "2026-05-26T20:39:40.268Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5a/ca2398a568e16fed7bb713e84ba3603a7164fb65779abe645c565ec890d5/coverage-7.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76a085d7005236a767e3426148b2c407e53ad61695c562f8a81da2d373324901", size = 253373, upload-time = "2026-05-26T20:39:42.145Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2c/0396562c32deaebe7be51d865b3a41e9a87d7561acafe1a28f53b07e019a/coverage-7.14.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b553d04b5e778a8e56d57eb134aff42a92718ecba45e79c4764ecfa40efd92ff", size = 251341, upload-time = "2026-05-26T20:39:43.907Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/8f/a94f9221184c9cae1ee115820e3798e48b6b17777a9f19e46fb9a0c8dc74/coverage-7.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:46f714d2fb8ae2f4f29f23ada7f1e79b759fff5a70f94a1dac23af204c3ec9e4", size = 255497, upload-time = "2026-05-26T20:39:46.166Z" },
+    { url = "https://files.pythonhosted.org/packages/71/69/505d70e47db1eaebcd002c39759707621ef184cd6b1ae084d9f41293f323/coverage-7.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1896f5e19ff3f0431c7ce2172adc54890fd97f86b59ced8ca1649145d9ffe35d", size = 251159, upload-time = "2026-05-26T20:39:48.03Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/aa/58681c383aa33a9d2ed40a02d7a22fbf780d1fa4d575396365777828198c/coverage-7.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:62fd185ef9df3c33d1c8178c5af105f762afbad96038de9a4ae100aa6297ca33", size = 252934, upload-time = "2026-05-26T20:39:49.872Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/fd/11c928cd6bdffc7074bb5965c173d9ebf517fb00205e1da524b98d29ef92/coverage-7.14.1-cp313-cp313-win32.whl", hash = "sha256:ab4af6352741a604c431c6072fce5bee33bf0f20dc7a56618d6bf6bb89e9810c", size = 222584, upload-time = "2026-05-26T20:39:51.68Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/92/fb416fc26d340dcba19518c418d6048e913186e17243982c5e435e41fa7a/coverage-7.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:7af486dabe8954d03b087f0021540897afe084f04e16ff5579e08cc46f871416", size = 223394, upload-time = "2026-05-26T20:39:53.472Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c6/02d56e3867972f77d5036de924643f26c056e848f00452cafb4dbc3c29b4/coverage-7.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:2224f89ffd0c5605ccce1ed7a584da162bc7c55f601ab1c946bc9de31a486b42", size = 222015, upload-time = "2026-05-26T20:39:55.374Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9e/fcc77914050df73f7662fa1f00902774c79c075a8388ab334074574bf77e/coverage-7.14.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:de286598cc65d2b489411174b1faec2f5a7775fb3201fd925db2a76b4030f37d", size = 220733, upload-time = "2026-05-26T20:39:57.189Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/67/2963cbdaf5cbadec44efa3a1e39eaa1f02df4079585f05387607a221e126/coverage-7.14.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:042c46ded7c288aeb07cf14a28b6c1e10b78fcba40171c3fa1e939377eeef0b5", size = 221086, upload-time = "2026-05-26T20:39:59.019Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/8701645574e11881f2f47d8930f98bc48b5d43b25eb5b4430dfc4a2f9f48/coverage-7.14.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f4ddbe407477f04c45115d1a4e5bc480f753553b534d338d4c3358b1cdd0ea52", size = 262381, upload-time = "2026-05-26T20:40:00.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/28/7a64d73598263e0c5abd5084211a8474488d31b3c552ff531c719dfcff62/coverage-7.14.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d13e6725992e2d2fd7d81d4f5241952d13740121dfd501da09201be39b2c003a", size = 264458, upload-time = "2026-05-26T20:40:02.506Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/d8/4969179db9f7eb4df218e69540adf829d1c835f59452513d065d15446802/coverage-7.14.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f747dc8edcfe740130f28f32f3995e955494285717e86ee25af51db2219df08a", size = 266884, upload-time = "2026-05-26T20:40:04.421Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/78/a45d5794dbc9bafd97afc96a4377c86c7820d78b6cf51b89bc1d4e919275/coverage-7.14.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced2f09ef276fd58611a1ef502164ad266d2b75174e5a40cabbdb4033f9f6cf2", size = 268022, upload-time = "2026-05-26T20:40:06.298Z" },
+    { url = "https://files.pythonhosted.org/packages/21/cb/4f5e354e9e3e67af96bd4e57113e6db6b22298c7168b13eec408a549903d/coverage-7.14.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b84800013769a78ccb9ef4659402e26d06867e337b61ec365f77ad008adea80e", size = 261631, upload-time = "2026-05-26T20:40:08.226Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/49/eced49af4cb996d5d8b7e94e736175c513e4facd3398507b89892b4326d8/coverage-7.14.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ea8cd6ca0ee9f616aaef3afc6882e32c2cbf18b00d96313ffd76af650574034d", size = 264443, upload-time = "2026-05-26T20:40:10.137Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d8/5603a88a7c5913a6b54f6cb1a8c46f7b39cbb30f27cd3f492908da09b2d7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:aa5e304a873fabddc11e484e9b6b738bd38bd7bed17b09aa84eecf5332e8b8bb", size = 262069, upload-time = "2026-05-26T20:40:11.999Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/59/2ae3cb79da554a06c8619d6c88ea19dd1e4aed4b834b6a83bb1fa243bdc5/coverage-7.14.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5a1c5215be81035e629d5bc756650634d0bf31991038db7a0eccb90f025ce16d", size = 265780, upload-time = "2026-05-26T20:40:13.858Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5f/b130c1dc999031f2648bd25317fbce505ad8d5562079b4ed81e736a84967/coverage-7.14.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:79058c47dae6788504b5effb319961bcd72d7240551464b91d474bc0ed186d69", size = 260970, upload-time = "2026-05-26T20:40:16.142Z" },
+    { url = "https://files.pythonhosted.org/packages/87/d1/ec13ccddeb48ec963bdfa72a11224bac2584bd045ba13beca82f8113e9c7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:370c5afae3fa0658e11694a32b24c2778f6bc2d17718121f94ee185e69f26b54", size = 263157, upload-time = "2026-05-26T20:40:18.382Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c2/cd91ead503045161092d3845f7bb95ea2f25131ce96d3e314dd835d91b9c/coverage-7.14.1-cp313-cp313t-win32.whl", hash = "sha256:3758dd0a7f1fa57365ef2e781df0f0731d38b6e3772259d13dae4bd8a958d4b1", size = 223259, upload-time = "2026-05-26T20:40:20.381Z" },
+    { url = "https://files.pythonhosted.org/packages/71/9f/1e28d97e6bd2c76b07f38b7c02870f1371255ff6717f54eca578fcbbdd0e/coverage-7.14.1-cp313-cp313t-win_amd64.whl", hash = "sha256:6ff665fb023a77386fe11685190cee1f60a7d635994a30d9b0a061533d470fce", size = 224320, upload-time = "2026-05-26T20:40:22.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/e0/d936e908f0e1efa55e52b91e01b52f1055cef5e1ab2718493390ed8e2fb8/coverage-7.14.1-cp313-cp313t-win_arm64.whl", hash = "sha256:17a5a241e5997621a956a7f402a7433ef4221e5152809b785bec79e2323799f1", size = 222577, upload-time = "2026-05-26T20:40:24.894Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/34/fc2f101b151af3799a101f0550b0454aa008afdc0add677394ec4aa8ea10/coverage-7.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d5ed429d0b8edaac649e889b4ffcedb6c80b06629a3f93050e3dddfb99235bee", size = 220091, upload-time = "2026-05-26T20:40:27.249Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a7/1ebae2ab5b961b5c79bb09fe7b3ac99edb190d8be4a8c510b2cf66f46468/coverage-7.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8011224a62280e50dab346960c03cf47aca1a1e09e608c0fb33fd6e0cc8e9500", size = 220421, upload-time = "2026-05-26T20:40:30.084Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/90/92aca9cf0acc95123c96cd1eb1f08917897a7f5dee01e15738922971ec31/coverage-7.14.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c42ec1e14f553c4f817e989365982e646e27211f10a0f717855b94a79c8906", size = 251466, upload-time = "2026-05-26T20:40:32.542Z" },
+    { url = "https://files.pythonhosted.org/packages/26/2b/78048cbe3b999f6cbf9cc0d90abba6a88a3e0863a8c1c6cbc762f3f8802f/coverage-7.14.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:06144cd511cf2624873a035c5069cf297144f6e77a73ee3d7a55b605ec5efb42", size = 253973, upload-time = "2026-05-26T20:40:34.473Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/21/c2e33b29d1cfde484a19d437afc343c6cd30b08d78cbbf9f5aff14e57b2b/coverage-7.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a311d8e1da24be5c1ccf85cbfb06315dbaa1703d5a1eab3f6432c72b837917c8", size = 255318, upload-time = "2026-05-26T20:40:38.154Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ee/aad2f108d63b769121005302f16bf66db8625c88ceaba466942e09a2607e/coverage-7.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c79cead5b5bc584d9c71451cb984d0e3a84e0c0937379c8efcbf27c8d661b851", size = 257633, upload-time = "2026-05-26T20:40:40.164Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f8/11a2c29b4fd76d9849f81d0bb812ec0017a9396df3217214e38934a8c837/coverage-7.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dcbf65f1f66a26cdd88c35cf68fb4729c5d1cd2e88added72420541dfb212034", size = 251488, upload-time = "2026-05-26T20:40:42.631Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/9a5820de4b8ac2b71d85e3b5fb49108d7469c665f0e2ad0dd7569023e305/coverage-7.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fd86572566fb40189a8260446158235159bc7a82dfbc87a3b39cf4fb57fcec1c", size = 253329, upload-time = "2026-05-26T20:40:45.208Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ff/f33e4823667e27548e8fd8df44217515303f9808d0ff29817db56f87d990/coverage-7.14.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:7771b601718fdde84832c3a434ca9bbf4ae9adbc49d84198b4110700c3c77c36", size = 251291, upload-time = "2026-05-26T20:40:47.502Z" },
+    { url = "https://files.pythonhosted.org/packages/68/9b/489db0ebb209054766b90a9014a45f6d26eb724c02ec21311c3733b5a644/coverage-7.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:39b21e212c55af06fa375e3dbf90a8a8e38792f3a910c580066d23563830ddd5", size = 255564, upload-time = "2026-05-26T20:40:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b5/16bc2d4c2409b23c7737edb68c83bc89e345f378050549fe1d75ac7d34d5/coverage-7.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f2302660e32562a532b442480121aef8aa61a5bdb20b30bf0adab29f10a5a4b4", size = 251107, upload-time = "2026-05-26T20:40:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/0c/2629997469a00cd069d588a41c9dc887610f2775ae89d250c4791e65272a/coverage-7.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:03a6f93c1ec3b7f2e77b5dbcc5573a2c21f12529a5c6bbe0f16f72303cc2fa4d", size = 252764, upload-time = "2026-05-26T20:40:54.267Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ee/f78d63c8f079e0d7211c7e2401fa17e311514534ba61bae03e4b287ce4ab/coverage-7.14.1-cp314-cp314-win32.whl", hash = "sha256:8a3ce026d73290f42f08dafecbd82c193a74df280461fbf97300fec51fd133ee", size = 222837, upload-time = "2026-05-26T20:40:56.496Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/be539854f93a70dfbeec69117f33ec70dc42ff0b65b5b07ab8d40d04228e/coverage-7.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:114c95ef29302423b87d159075805f4ab973254a2638a5d7d046c94887cc87d7", size = 223650, upload-time = "2026-05-26T20:40:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/9e/24e2842fef40f35ac82ba3a7719c8023d011bf3bf652d0675316a9d088a1/coverage-7.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:a07891c3f4805442b31b71e84ba3cf29ed1aa9a428284e06deeb4b23e5b46343", size = 222218, upload-time = "2026-05-26T20:41:00.321Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1d/ac0a9df5fe31c1e8bdd658074905fc12844a05c1a7e3fdb8417e97c31e23/coverage-7.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1101a5ebb083aecb625ebb6209d4105b58f647b093cb2dc8122d7b33f743cfe1", size = 220822, upload-time = "2026-05-26T20:41:02.281Z" },
+    { url = "https://files.pythonhosted.org/packages/32/cf/f964fd9aff20323f9f1a726c97135f8a76bcd87b92dad141a456a43f3c64/coverage-7.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:851b9e1e4e8a4608e77c79714b2e77c0970d2ed7202a05e92ae407817481887b", size = 221084, upload-time = "2026-05-26T20:41:04.593Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5e/7e5ef2aba844de2b80d678619fcf0841b42e3f37f16411226f3fe4c1016f/coverage-7.14.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d5b89cdfb2ee051b71e8c3c70bd81a9eff81100f736a269136fe1a68efe00474", size = 262454, upload-time = "2026-05-26T20:41:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/64/62/75809bded87015cc4935524218a2a8ed8dd1a8498bfed30a2f4f7a4b4d34/coverage-7.14.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0177614a0370f227888b4e436a7c55686d6a9f90eb1ade2b624ba685a1686e86", size = 264578, upload-time = "2026-05-26T20:41:08.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/42/d33392dc14633525012d2d504fa1a33b05538bf535f5c1d64675e5754b78/coverage-7.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d69af5dea2de76fc485a83032a630523f985198b7e25be901ec60181587b01e", size = 266981, upload-time = "2026-05-26T20:41:10.824Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/49/0157c4428c2aca7f1e09d5565930586fd5ae36f1655f08b0daa7cf1fcae1/coverage-7.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35ab22d91de736e8966b980dc355cbcdd2c6dbbcfe275f9a2991bc8a91b3df65", size = 268112, upload-time = "2026-05-26T20:41:12.966Z" },
+    { url = "https://files.pythonhosted.org/packages/96/26/86b9ce71f4092b1ed325ce1421698081df1286b833400b6836912834d6e0/coverage-7.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:357d4e32935c36588aaba057d734fa32428c360c9fc2e4442afbf1b646beee6e", size = 261558, upload-time = "2026-05-26T20:41:15Z" },
+    { url = "https://files.pythonhosted.org/packages/20/4c/c311210c5472cf5401d8422b0d7812cdd520f24417673afabda6c323faca/coverage-7.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:51bd64741cc6fa065abd300ede1afe5a5291ece9c31da8b24884deda48bcc3f8", size = 264447, upload-time = "2026-05-26T20:41:17.369Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/71/59513f8710ed3e6b0ac0a050a5b7e977bb9c9e880354863b5d00d8809256/coverage-7.14.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:9132cd363a68a4c3daa7c8704a654b1e39d3360f6f5b8ddd470608a945236c07", size = 262048, upload-time = "2026-05-26T20:41:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/bceed32dc494f5bbf50f775cd2e78ca814953942b5ea28d3c1c3ac316f14/coverage-7.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:07c6290b1697b862c0478eab545eec949a0d0e4d6d03497f446d706da3b4f2de", size = 265781, upload-time = "2026-05-26T20:41:21.559Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c5/9348fe40dbfd4991aaf78df2c6c3098bfb2cc834d1fd362a64b4efef855a/coverage-7.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5ea0c297e27133853b4d8a3eb799bff5a2dbd9f2f41537a240d337ac9b4df890", size = 260896, upload-time = "2026-05-26T20:41:23.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/92/1ea0f03929da7cf87206b1fa24f4c8e9c158be0455481af29ec0a1f3503f/coverage-7.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:01b7733daad0237daa01ef80fe2dfceffc911e6a17fa7b55d14aa8214eaaaecd", size = 263214, upload-time = "2026-05-26T20:41:25.419Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a9/b2493c054c0e01a643266742ab45e15744e60743f9260cd930c7142b1124/coverage-7.14.1-cp314-cp314t-win32.whl", hash = "sha256:6adc5a36984624a70bf11d7184e20fa0a49aa7c47ffab43804106a1a695ea22e", size = 223624, upload-time = "2026-05-26T20:41:27.795Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/bd/3e1e6a57fccd2d7c83fcdf338e93ba98eb85c6e877dd34731ac585375490/coverage-7.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ddf799247318f34dbcd2efa8c95a8d0642674e926bb1774cf9b63dfd2a389d1c", size = 224728, upload-time = "2026-05-26T20:41:30.098Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d7/31066cf1d2f0c6c797fce911bcfa01dd35642dc6da992a950256097c5860/coverage-7.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:145986fe66647eb489f18d9a997567a3fd358584c4b5a808769113abc07466af", size = 222752, upload-time = "2026-05-26T20:41:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
+]
+
+[[package]]
+name = "cross-web"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/83/b5ef04565acc065387dda3a4fbf0c4cfb6bab805c81b66b2bc5b5ac9a282/cross_web-0.6.0.tar.gz", hash = "sha256:ae90570802615365ca1a781117b43bfd0d6cd3bf611649d24c3a206a82a693c9", size = 331315, upload-time = "2026-04-13T14:29:12.718Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/a2/dab06d9b80cb76c700883186a9a2e6fd103342c9b4def4d88f5787796e17/cross_web-0.6.0-py3-none-any.whl", hash = "sha256:bdebf0c08d02f3a48cf67b6904d3a6d8fd8cab2cd905592ab96ab00b259cd582", size = 24820, upload-time = "2026-04-13T14:29:11.198Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/b2/d6fc3f2347f43dada79e5ff118493e8109c98400a0e29a1d5264a3aa479b/distlib-0.4.1.tar.gz", hash = "sha256:c3804d0d2d4b5fcd44036eb860cb6660485fcdf5c2aba53dc324d805837ea65b", size = 610526, upload-time = "2026-06-02T11:17:40.691Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/18/3497c4fa83a76dcb154923fd2075522e8dd6995ecee4093c00ae18160046/distlib-0.4.1-py2.py3-none-any.whl", hash = "sha256:9c2c552c68cbadc619f2d0ed3a69e27c351a3f4c9baa9ffb7df9e9cdc3d19a97", size = 469216, upload-time = "2026-06-02T11:17:38.779Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.136.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/d9/e66315807e41e69e7f6a1b42a162dada2f249c5f06ad3f1a95f84ab336ef/fastapi-0.136.0.tar.gz", hash = "sha256:cf08e067cc66e106e102d9ba659463abfac245200752f8a5b7b1e813de4ff73e", size = 396607, upload-time = "2026-04-16T11:47:13.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/a3/0bd5f0cdb0bbc92650e8dc457e9250358411ee5d1b65e42b6632387daf81/fastapi-0.136.0-py3-none-any.whl", hash = "sha256:8793d44ec7378e2be07f8a013cf7f7aa47d6327d0dfe9804862688ec4541a6b4", size = 117556, upload-time = "2026-04-16T11:47:11.922Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/f9/f38573ed5844586db374d085911740a501ccfa373b455fc9413f09f85237/filelock-3.29.1.tar.gz", hash = "sha256:d97e6b1b9757569626c58caa07dc4beb1613f4a2938b1e8cc81afca398906c9e", size = 59335, upload-time = "2026-06-03T15:19:04.053Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/a0/614c5fe402fd88951df45f4dda2fa3b4e17a99ecd92340771929169b3b95/filelock-3.29.1-py3-none-any.whl", hash = "sha256:85199dfd706869641b72b2e8955d5416a4b2b7dc4b0e8e6d97b4cc1299a6983b", size = 40750, upload-time = "2026-06-03T15:19:02.959Z" },
+]
+
+[[package]]
+name = "graphql-core"
+version = "3.2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/c5/36aa96205c3ecbb3d34c7c24189e4553c7ca2ebc7e1dd07432339b980272/graphql_core-3.2.8.tar.gz", hash = "sha256:015457da5d996c924ddf57a43f4e959b0b94fb695b85ed4c29446e508ed65cf3", size = 513181, upload-time = "2026-03-05T19:55:37.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/41/cb887d9afc5dabd78feefe6ccbaf83ff423c206a7a1b7aeeac05120b2125/graphql_core-3.2.8-py3-none-any.whl", hash = "sha256:cbee07bee1b3ed5e531723685369039f32ff815ef60166686e0162f540f1520c", size = 207349, upload-time = "2026-03-05T19:55:35.911Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/08/9e7f6b5d2b5bed6ad055cdd5925f192bb403a51280f86b56554d9d0699a2/librt-0.11.0.tar.gz", hash = "sha256:075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1", size = 200139, upload-time = "2026-05-10T18:17:25.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/d0/07c77e067f0838949b43bd89232c29d72efebb9d2801a9750184eb706b71/librt-0.11.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b87504f1690a23b9a2cca841191a04f83895d4fc2dd04df91d82b1a04ca2ad46", size = 144147, upload-time = "2026-05-10T18:15:53.227Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/24/8493538fa4f62f982686398a5b8f68008138a75086abdea19ade64bf4255/librt-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40071fc5fe0ce8daa6de616702314a01e1250711682b0523d6ab8d4525910cb3", size = 143614, upload-time = "2026-05-10T18:15:54.657Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1e/f8bad050810d9171f34a1648ed910e56814c2ba61639f2bd53c6377ae24b/librt-0.11.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:137e79445c896a0ea7b265f52d23954e05b64222ee1af69e2cb34219067cbb67", size = 485538, upload-time = "2026-05-10T18:15:56.117Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/fe/3594ebfbaf03084ba4b120c9ba5c3183fd938a48725e9bbe6ff0a5159ad8/librt-0.11.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:cca6644054e78746d8d4ef238681f9c34ff8b584fe6b988ecebb8db3b15e622a", size = 479623, upload-time = "2026-05-10T18:15:57.544Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/da/5d1876984b3746c85dbd219dbfcb73c85f54ee263fd32e5b2a632ec14571/librt-0.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5b0eea49f5562861ee8d757a32ef7d559c1d35be2aaaa1ec28941d74c9ffc8a", size = 513082, upload-time = "2026-05-10T18:15:58.805Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6e/55bdf5d5ca00c3e18430690bf2c953d8d3ffd3c337418173d33dec985dc9/librt-0.11.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0d1029d7e1ae1a7e647ed6fb5df8c4ce2dffefb7a9f5fd1376a4554d96dac09f", size = 508105, upload-time = "2026-05-10T18:16:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/07/10/f1f23a7c595ee90ece4d35c851e5d104b1311a887ed1b4ac4c35bbd13da8/librt-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bc3ce6b33c5828d9e80592011a5c584cb2ce86edbc4088405f70da47dc1d1b3b", size = 522268, upload-time = "2026-05-10T18:16:01.708Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/5720f5697a7f54b78b3aefbe20df3a48cedcff1276618c4aa481177942ed/librt-0.11.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:936c5995f3514a42111f20099397d8177c79b4d7e70961e396c6f5a0a3566766", size = 527348, upload-time = "2026-05-10T18:16:03.496Z" },
+    { url = "https://files.pythonhosted.org/packages/50/db/b4a47c6f91db4ff76348a0b3dd0cc65e090a078b765a810a62ff9434c3d3/librt-0.11.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9bc0ca6ad9381cbe8e4aa6e5726e4c80c78115a6e9723c599ed1d73e092bc49d", size = 516294, upload-time = "2026-05-10T18:16:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/58/9384b2f4eb1ed1d273d40948a7c5c4b2360213b402ef3be4641c06299f9c/librt-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:070aa8c26c0a74774317a72df8851facc7f0f012a5b406557ac56992d92e1ec8", size = 553608, upload-time = "2026-05-10T18:16:06.839Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7b/5aa8848a7c6a9278c79375146da1812e695754ceec5f005e6043461a7315/librt-0.11.0-cp312-cp312-win32.whl", hash = "sha256:6bf14feb84b05ae945277395451998c89c54d0def4070eb5c08de544930b245a", size = 101879, upload-time = "2026-05-10T18:16:08.103Z" },
+    { url = "https://files.pythonhosted.org/packages/37/33/8a745436944947575b584231750a41417de1a38cf6a2e9251d1065651c09/librt-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:75672f0bc524ede266287d532d7923dbce94c7514ad07627bac3d0c6d92cc4d9", size = 119831, upload-time = "2026-05-10T18:16:09.174Z" },
+    { url = "https://files.pythonhosted.org/packages/59/67/a6739ac96e28b7855808bdb0370e250606104a859750d209e5a0716fe7ab/librt-0.11.0-cp312-cp312-win_arm64.whl", hash = "sha256:2f10cf143e4a9bb0f4f5af568a00df94a2d69ef41c2579584454bb0fe5cc642c", size = 103470, upload-time = "2026-05-10T18:16:10.369Z" },
+    { url = "https://files.pythonhosted.org/packages/82/61/e59168d4d0bf2bf90f4f0caf7a001bfc60254c3af4586013b04dc3ef517b/librt-0.11.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:78dc31f7fdfe9c9d0eb0e8f42d139db230e826415bbcabd9f0e9faaaee909894", size = 144119, upload-time = "2026-05-10T18:16:11.771Z" },
+    { url = "https://files.pythonhosted.org/packages/61/fd/caa1d60b12f7dd79ccea23054e06eeaebe266a5f52c40a6b651069200ce5/librt-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fa475675db22290c3158e1d42326d0f5a65f04f44a0e68c3630a25b53560fb9c", size = 143565, upload-time = "2026-05-10T18:16:13.334Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/dc744f5c2b4978d48db970be29f22716d3413d28b14ad99740817315cf2c/librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:621db29691044bdeda22e789e482e1b0f3a985d90e3426c9c6d17606416205ea", size = 485395, upload-time = "2026-05-10T18:16:14.729Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/21/7f8e97a1e4dae952a5a95948f6f8507a173bc1e669f54340bba6ca1ca31b/librt-0.11.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:a9010e2ed5b3a9e158c5fd966b3ab7e834bb3d3aacc8f66c91dd4b57a3799230", size = 479383, upload-time = "2026-05-10T18:16:16.321Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/6d/d8ee9c114bebf2c50e29ec2aa940826fccb62a645c3e4c18760987d0e16d/librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2", size = 513010, upload-time = "2026-05-10T18:16:17.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/43/0b5708af2bd30a46400e72ba6bdaa8f066f15fb9a688527e34220e8d6c06/librt-0.11.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7aef3cf1d5af86e770ab04bfd993dfc4ae8b8c17f66fb77dd4a7d50de7bbb1a3", size = 508433, upload-time = "2026-05-10T18:16:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/50/356187247d09013490481033183b3532b58acf8028bcb34b2b56a375c9b2/librt-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:557183ddc36babe46b27dd60facbd5adb4492181a5be887587d57cda6e092f21", size = 522595, upload-time = "2026-05-10T18:16:20.642Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e7/c6ac4240899c7f3248079d5a9900debe0dadb3fdeaf856684c987105ba47/librt-0.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:83d3e1f72bd42f6c5c0b7daec530c3f829bd02db42c70b8ddf0c2d90a2459930", size = 527255, upload-time = "2026-05-10T18:16:22.352Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/b5/a81322dbeedeeaf9c1ee6f001734d28a09d8383ac9e6779bc24bbd0743c6/librt-0.11.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4ce1f21fbe589bc1afd7872dece84fb0e1144f794a288e58a10d2c54a55c43be", size = 516847, upload-time = "2026-05-10T18:16:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/66/6e6323787d592b55204a42595ff1102da5115601b53a7e9ddebc889a6da5/librt-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b09f7044ea2b64c9da42fd3d335666518cfd1c6e8a182c95da73d0214b41e", size = 553920, upload-time = "2026-05-10T18:16:25.025Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/21/623f8ca230857102066d9ca8c6c1734995908c4d0d1bee7bb2ef0021cb33/librt-0.11.0-cp313-cp313-win32.whl", hash = "sha256:78fddc31cd4d3caa897ad5d31f856b1faadc9474021ad6cb182b9018793e254e", size = 101898, upload-time = "2026-05-10T18:16:26.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1d/b4ebd44dd723f768469007515cb92251e0ae286c94c140f374801140fa74/librt-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8ca8aa88751a775870b764e93bad5135385f563cb8dcee399abf034ea4d3cb47", size = 119812, upload-time = "2026-05-10T18:16:27.859Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e4/b2f4ca7965ca373b491cdb4bc25cdb30c1649ca81a8782056a83850292a9/librt-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:96f044bb325fd9cf1a723015638c219e9143f0dfbc0ca54c565df2b7fc748b44", size = 103448, upload-time = "2026-05-10T18:16:29.066Z" },
+    { url = "https://files.pythonhosted.org/packages/29/eb/dbce197da4e227779e56b5735f2decc3eb36e55a1cdbf1bd65d6639d76c1/librt-0.11.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4a017a95e5837dc15a8c5661d60e05daa96b90908b1aa6b7acdf443cd25c8ebd", size = 143345, upload-time = "2026-05-10T18:16:30.674Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/254bebd0c11c8ba684018efb8006ff22e466abce445215cca6c778e7d9de/librt-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b1ecbd9819deccc39b7542bf4d2a740d8a620694d39989e58661d3763458f8d4", size = 143131, upload-time = "2026-05-10T18:16:32.037Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3f/f77d6122d21ac7bf6ae8a7dfced1bd2a7ac545d3273ebdcaf8042f6d619f/librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7da327dacd7be8f8ec36547373550744a3cc0e536d54665cd83f8bcd961200e8", size = 477024, upload-time = "2026-05-10T18:16:33.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0a/2c996dadebaa7d9bbbd43ef2d4f3e66b6da545f838a41694ef6172cebec8/librt-0.11.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0dc56b1f8d06e60db362cc3fdae206681817f86ce4725d34511473487f12a34b", size = 474221, upload-time = "2026-05-10T18:16:34.864Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7e/f5d92af8486b8272c23b3e686b46ff72d89c8169585eb61eef01a2ac7147/librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175", size = 505174, upload-time = "2026-05-10T18:16:36.705Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/cb0734fe86398eb33193ab753b7326255c74cac5eb09e76b9b16536e7adb/librt-0.11.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cae74872be221df4374d10fec61f93ed1513b9546ea84f2c0bf73ab3e9bd0b03", size = 497216, upload-time = "2026-05-10T18:16:38.418Z" },
+    { url = "https://files.pythonhosted.org/packages/18/06/094820f91558b66e29943c0ec41c9914f460f48dd51fc503c3101e10842d/librt-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32bcc918c0148eb7e3d57385125bac7e5f9e4359d05f07448b09f6f778c2f31c", size = 513921, upload-time = "2026-05-10T18:16:39.848Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c2/00de9018871a282f530cacb457d5ec0428f6ac7e6fedde9aff7468d9fb04/librt-0.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f9743fc99135d5f78d2454435615f6dec0473ca507c26ce9d92b10b562a280d3", size = 520850, upload-time = "2026-05-10T18:16:41.471Z" },
+    { url = "https://files.pythonhosted.org/packages/51/9d/64631832348fd1834fb3a61b996434edddaaf25a31d03b0a76273159d2cf/librt-0.11.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5ba067f4aadae8fda802d91d2124c90c42195ff32d9161d3549e6d05cfe26f96", size = 504237, upload-time = "2026-05-10T18:16:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/ae5525eb16edc827a044e7bb8777a455ff95d4bca9379e7e6bddd7383647/librt-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:de3bf945454d032f9e390b85c4072e0a0570bf825421c8be0e71209fa65e1abe", size = 546261, upload-time = "2026-05-10T18:16:44.408Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/09/adce371f27ca039411da9659f7430fcc2ba6cd0c7b3e4467a0f091be7fa9/librt-0.11.0-cp314-cp314-win32.whl", hash = "sha256:d2277a05f6dcb9fd13db9566aac4fabd68c3ea1ea46ee5567d4eef8efa495a2f", size = 96965, upload-time = "2026-05-10T18:16:46.039Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ee/8ac720d98548f173c7ce2e632a7ca94673f74cacd5c8162a84af5b35958a/librt-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:ab73e8db5e3f564d812c1f5c3a175930a5f9bc96ccb5e3b22a34d7858b401cf7", size = 115151, upload-time = "2026-05-10T18:16:47.133Z" },
+    { url = "https://files.pythonhosted.org/packages/94/20/c900cf14efeb09b6bef2b2dff20779f73464b97fd58d1c6bccc379588ae3/librt-0.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:aea3caa317752e3a466fa8af45d91ee0ea8c7fdd96e42b0a8dd9b76a7931eba1", size = 98850, upload-time = "2026-05-10T18:16:48.597Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/71/944bfe4b64e12abffcd3c15e1cce07f72f3d55655083786285f4dedeb532/librt-0.11.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d1b36540d7aaf9b9101b3a6f376c8d8e9f7a9aec93ed05918f2c69d493ffef72", size = 151138, upload-time = "2026-05-10T18:16:49.839Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/10/99e64a5c86989357fda078c8143c533389585f6473b7439172dd8f3b3b2d/librt-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:efbb343ab2ce3540f4ecbe6315d677ed70f37cd9a72b1e58066c918ca83acbaa", size = 151976, upload-time = "2026-05-10T18:16:51.062Z" },
+    { url = "https://files.pythonhosted.org/packages/21/31/5072ad880946d83e5ea4147d6d018c78eefce85b77819b19bdd0ee229435/librt-0.11.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0dd688aab3f7914d3e6e5e3554978e0383312fb8e771d84be008a35b9ee548", size = 557927, upload-time = "2026-05-10T18:16:52.632Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8d/70b5fb7cfbab60edbe7381614ab985da58e144fbf465c86d44c95f43cdca/librt-0.11.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f5fb36b8c6c63fdcbb1d526d94c0d1331610d43f4118cc1beb4efef4f3faacb2", size = 539698, upload-time = "2026-05-10T18:16:53.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a3/ba3495a0b3edbd24a4cae0d1d3c64f39a9fc45d06e812101289b50c1a619/librt-0.11.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a9a237d13addb93715b6fee74023d5ee3469b53fce527626c0e088aa585805f", size = 577162, upload-time = "2026-05-10T18:16:55.589Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/db/36e25fb81f99937ff1b96612a1dc9fd66f039cb9cc3aee12c01fac31aab9/librt-0.11.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5ddd17bd87b2c56ddd60e546a7984a2e64c4e8eab92fb4cf3830a48ad5469d51", size = 566494, upload-time = "2026-05-10T18:16:56.975Z" },
+    { url = "https://files.pythonhosted.org/packages/33/0d/3f622b47f0b013eeb9cf4cc07ae9bfe378d832a4eec998b2b209fe84244d/librt-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd43992b4473d42f12ff9e68326079f0696d9d4e6000e8f39a0238d482ba6ee2", size = 596858, upload-time = "2026-05-10T18:16:58.374Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/02/71b90bc93039c46a2000651f6ad60122b114c8f54c4ad306e0e96f5b75ad/librt-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:f8e3e8056dd674e279741485e2e512d6e9a751c7455809d0114e6ebf8d781085", size = 590318, upload-time = "2026-05-10T18:16:59.676Z" },
+    { url = "https://files.pythonhosted.org/packages/04/04/418cb3f75621e2b761fb1ab0f017f4d70a1a72a6e7c74ee4f7e8d198c2f3/librt-0.11.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c1f708d8ae9c56cf38a903c44297243d2ec83fd82b396b977e0144a3e76217e3", size = 575115, upload-time = "2026-05-10T18:17:01.007Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/2c/5a2183ac58dd911f26b5d7e7d7d8f1d87fcecdddd99d6c12169a258ff62c/librt-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0add982e0e7b9fc14cf4b33789d5f13f66581889b88c2f58099f6ce8f92617bd", size = 617918, upload-time = "2026-05-10T18:17:02.682Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1f/dc6771a52592a4451be6effa200cbfc9cec61e4393d3033d81a9d307961d/librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8", size = 103562, upload-time = "2026-05-10T18:17:03.99Z" },
+    { url = "https://files.pythonhosted.org/packages/62/4a/7d1415567027286a75ba1093ec4aca11f073e0f559c530cf3e0a757ad55c/librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c", size = 124327, upload-time = "2026-05-10T18:17:05.465Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/62/b40b382fa0c66fee1478073eb8db352a4a6beda4a1adccf1df911d8c289c/librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253", size = 102572, upload-time = "2026-05-10T18:17:06.809Z" },
+]
+
+[[package]]
+name = "mangum"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/cb/d9f4d685a0b8eceac10991e15ac471d9568e4e42c2489ae9bf072828c1c2/mangum-0.21.0.tar.gz", hash = "sha256:e31ed72d67f9958fa4379f65df77729906dec6dfa00afa6ed4e06c77833000de", size = 89130, upload-time = "2026-02-01T17:17:42.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/50/e3c694b8e122551e4557450219283771334dee2ed5734a8398c8b8018c50/mangum-0.21.0-py3-none-any.whl", hash = "sha256:309e48f5c629542516c5106ecf079f4ec08809ed50df882238d98fe1392820c7", size = 17146, upload-time = "2026-02-01T17:17:41.553Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/15/cca9d88503549ed6fedeaa1d448cdddd542ee8a490232d732e278036fbf2/mypy-2.1.0.tar.gz", hash = "sha256:81e76ad12c2d804512e9b13240d1588316531bfba07558286078bfbce9613633", size = 3898359, upload-time = "2026-05-11T18:37:36.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/b1/55861beb5c339b44f9a2ba92df9e2cb1eeb4ae1eee674cdf7772c797778b/mypy-2.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:244358bf1c0da7722230bce60683d52e8e9fd030554926f15b747a84efb5b3af", size = 14874381, upload-time = "2026-05-11T18:37:31.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b3/b7f770114b7d0ac92d0f76e8d93c2780844a70488a90e91821927850da86/mypy-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4ec7c57657493c7a75534df2751c8ae2cda383c16ecc55d2106c54476b1b16f6", size = 13665501, upload-time = "2026-05-11T18:34:23.063Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f3/8ae2037967e2126689a0c11d99e2b707134a565191e92c60ca2572aec60a/mypy-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8161b6ff4392410023224f0969d17db93e1e154bc3e4ba62598e720723ae211", size = 14045750, upload-time = "2026-05-11T18:31:48.151Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/32/615eb5911859e43d054941b0d0a7d06cfa2870eba86529cf385b052b111c/mypy-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf03e12003084a67395184d3eb8cbd6a489dc3655b5664b28c210a9e2403ab0b", size = 15061630, upload-time = "2026-05-11T18:37:06.898Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/03/4eafbfff8bfab1b87082741eae6e6a624028c984e6708b73bce2a8570c9d/mypy-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:20509760fd791c51579d573153407d226385ec1f8bcce55d730b354f3336bc22", size = 15288831, upload-time = "2026-05-11T18:31:18.07Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/919661478e5891a3c96e549c036e467e64563ab85995b10c53c8358e16a3/mypy-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:6753d0c1fdd6b1a23b9e4f283ce80b2153b724adcb2653b20b85a8a28ac6436b", size = 11135228, upload-time = "2026-05-11T18:34:31.23Z" },
+    { url = "https://files.pythonhosted.org/packages/24/0a/6a12b9782ca0831a553192f351679f4548abc9d19a7cc93bb7feb02084c7/mypy-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:98ebb6589bb3b6d0c6f0c459d53ca55b8091fbc13d277c4041c885392e8195e8", size = 10040684, upload-time = "2026-05-11T18:36:48.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/dd/c7191469c777f07689c032a8f7326e393ea34c92d6d76eb7ce5ba57ea66d/mypy-2.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:35aac3bb114e03888f535d5eb51b8bafbb3266586b599da1940f9b1be3ec5bd5", size = 14852174, upload-time = "2026-05-11T18:31:38.929Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8c/aed55408879043d72bb9135f4d0d19a02b886dd569631e113e3d2706cb8d/mypy-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8de55a8c861f2a49331f807be98d90caeceeef520bde13d43a160207f8af613e", size = 13651542, upload-time = "2026-05-11T18:36:04.636Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8e/f371a824b1f1fa8ea6e3dbb8703d232977d572be2329554a3bc4d960302f/mypy-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5fdf2941a07434af755837d9880f7d7d25f1dacb1af9dcd4b9b66f2220a3024e", size = 14033929, upload-time = "2026-05-11T18:35:55.742Z" },
+    { url = "https://files.pythonhosted.org/packages/94/21/f54be870d6dd53a82c674407e0f8eed7174b05ec78d42e5abd7b42e84fd5/mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e195b817c13f02352a9c124301f9f30f078405444679b6753c1b96b6eed37285", size = 15039200, upload-time = "2026-05-11T18:33:10.281Z" },
+    { url = "https://files.pythonhosted.org/packages/17/99/bf21748626a40ce59fd29a39386ab46afec88b7bd2f0fa6c3a97c995523f/mypy-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5431d42af987ebd92ba2f71d45c85ed41d8e6ca9f5fd209a69f68f707d2469e5", size = 15272690, upload-time = "2026-05-11T18:32:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d7/9e90d2cf47100bea550ed2bc7b0d4de3a62181d84d5e37da0003e8462637/mypy-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:767fe8c66dc3e01e19e1737d4c38ebefead16125e1b8e58ad421903b376f5c65", size = 11147435, upload-time = "2026-05-11T18:33:56.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/46/e5c449e858798e35ffc90946282a27c62a77be743fe17480e4977374eb91/mypy-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:ecfe70d43775ab99562ab128ce49854a362044c9f894961f68f898c23cb7429d", size = 10035052, upload-time = "2026-05-11T18:32:30.049Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ca/b279a672e874aedd5498ae25f722dacc8aa86bbffb939b3f97cbb1cf6686/mypy-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7354c5a7f69d9345c3d6e69921d57088eea3ddeeb6b20d34c1b3855b02c36ec2", size = 14848422, upload-time = "2026-05-11T18:35:45.984Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e6/3efe56c631d959b9b4454e208b0ac4b7f4f58b404c89f8bec7b49efdfc21/mypy-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:49890d4f76ac9e06ec117f9e09f3174da70a620a0c300953d8595c926e80947f", size = 13677374, upload-time = "2026-05-11T18:36:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7f/8107ea87a44fd1f1b59882442f033c9c3488c127201b1d1d15f1cbd6022e/mypy-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:761be68e023ef5d94678772396a8af1220030f80837a3afd8d0aef3b419666f4", size = 14055743, upload-time = "2026-05-11T18:35:18.361Z" },
+    { url = "https://files.pythonhosted.org/packages/51/4d/b6d34db183133b83761b9199a82d31557cdbb70a380d8c3b3438e11882a3/mypy-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c90345fc182dc363b891350457ec69c35140858538f38b4540845afcc32b1aef", size = 15020937, upload-time = "2026-05-11T18:34:59.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/d7/f08360c691d758acb02f45022c34d98b92892f4ea756644e1000d4b9f3d8/mypy-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b84802e7b5a6daf1f5e15bc9fcd7ddae77be13981ffab037f1c67bb84d67d135", size = 15253371, upload-time = "2026-05-11T18:36:41.081Z" },
+    { url = "https://files.pythonhosted.org/packages/67/1b/09460a13719530a19bce27bd3bc8449e83569dd2ba7faf51c9c3c30c0b61/mypy-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:022c771234936ceac541ebaf836fe9e2abeb3f5e09aff21588fe543ff006fe21", size = 11326429, upload-time = "2026-05-11T18:34:13.526Z" },
+    { url = "https://files.pythonhosted.org/packages/40/62/75dbf0f82f7b6680340efc614af29dd0b3c17b8a4f1cd09b8bd2fd6bc814/mypy-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:498207db725cec88829a6a5c2fc771205fd043719ef98bc49aba8fb9fc4e6d57", size = 10218799, upload-time = "2026-05-11T18:32:23.491Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/66/caca04ed7d972fb6eb6dd1ccd6df1de5c38fae8c5b3dc1c4e8e0d85ee6b9/mypy-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d5e5cad0efeba72b93cd17490cc0d69c5ac9ca132994fe3fb0314808aeeb83e", size = 15923458, upload-time = "2026-05-11T18:35:28.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/52/2d90cbe49d014b13ed7ff337930c30bad35893fe38a1e4641e756bb62191/mypy-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ff715050c127d724fd260a2e666e7747fdd83511c0c47d449d98238970aef780", size = 14757697, upload-time = "2026-05-11T18:36:14.208Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/37/d98f4a14e081b238992d0ed96b6d39c7cc0148c9699eb71eaa68629665ea/mypy-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82208da9e09414d520e912d3e462d454854bed0810b71540bb016dcbca7308fd", size = 15405638, upload-time = "2026-05-11T18:33:48.249Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c2/15c46613b24a84fad2aea1248bf9619b99c2767ae9071fe224c179a0b7d4/mypy-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e79ebc1b904b84f0310dff7469655a9c36c7a68bddb37bdd42b67a332df61d08", size = 16215852, upload-time = "2026-05-11T18:32:50.296Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/90/9c16a57f482c76d25f6379762b56bbf65c711d8158cf271fb2802cfb0640/mypy-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e583edc957cfb0deb142079162ae826f58449b116c1d442f2d91c69d9fced081", size = 16452695, upload-time = "2026-05-11T18:33:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/4c/215a4eeb63cacc5f17f516691ea7285d11e249802b942476bff15922a314/mypy-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b33b6cd332695bba180d55e717a79d3038e479a2c49cc5eb3d53603409b9a5d7", size = 12866622, upload-time = "2026-05-11T18:34:39.945Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/50/1043e1db5f455ffe4c9ab22747cd8ca2bc492b1e4f4e21b130a44ee2b217/mypy-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:4f910fe825376a7b66ef7ca8c98e5a149e8cd64c19ae71d84047a74ee060d4e6", size = 10610798, upload-time = "2026-05-11T18:36:31.444Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2a/13ca1f292f6db1b98ff495ef3467736b331621c5917cad984b7043e7348d/mypy-2.1.0-py3-none-any.whl", hash = "sha256:a663814603a5c563fb87a4f96fb473eeb30d1f5a4885afcf44f9db000a366289", size = 2693302, upload-time = "2026-05-11T18:31:29.246Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927", size = 471981, upload-time = "2026-04-20T14:46:41.402Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412, upload-time = "2026-04-20T14:40:56.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/cb/5b47425556ecc1f3fe18ed2a0083188aa46e1dd812b06e406475b3a5d536/pydantic_core-2.46.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b11b59b3eee90a80a36701ddb4576d9ae31f93f05cb9e277ceaa09e6bf074a67", size = 2101946, upload-time = "2026-04-20T14:40:52.581Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4f/2fb62c2267cae99b815bbf4a7b9283812c88ca3153ef29f7707200f1d4e5/pydantic_core-2.46.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:af8653713055ea18a3abc1537fe2ebc42f5b0bbb768d1eb79fd74eb47c0ac089", size = 1951612, upload-time = "2026-04-20T14:42:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6e/b7348fd30d6556d132cddd5bd79f37f96f2601fe0608afac4f5fb01ec0b3/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75a519dab6d63c514f3a81053e5266c549679e4aa88f6ec57f2b7b854aceb1b0", size = 1977027, upload-time = "2026-04-20T14:42:02.001Z" },
+    { url = "https://files.pythonhosted.org/packages/82/11/31d60ee2b45540d3fb0b29302a393dbc01cd771c473f5b5147bcd353e593/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6cd87cb1575b1ad05ba98894c5b5c96411ef678fa2f6ed2576607095b8d9789", size = 2063008, upload-time = "2026-04-20T14:44:17.952Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/db/3a9d1957181b59258f44a2300ab0f0be9d1e12d662a4f57bb31250455c52/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f80a55484b8d843c8ada81ebf70a682f3f00a3d40e378c06cf17ecb44d280d7d", size = 2233082, upload-time = "2026-04-20T14:40:57.934Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e1/3277c38792aeb5cfb18c2f0c5785a221d9ff4e149abbe1184d53d5f72273/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3861f1731b90c50a3266316b9044f5c9b405eecb8e299b0a7120596334e4fe9c", size = 2304615, upload-time = "2026-04-20T14:42:12.584Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d5/e3d9717c9eba10855325650afd2a9cba8e607321697f18953af9d562da2f/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb528e295ed31570ac3dcc9bfdd6e0150bc11ce6168ac87a8082055cf1a67395", size = 2094380, upload-time = "2026-04-20T14:43:05.522Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/20/abac35dedcbfd66c6f0b03e4e3564511771d6c9b7ede10a362d03e110d9b/pydantic_core-2.46.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:367508faa4973b992b271ba1494acaab36eb7e8739d1e47be5035fb1ea225396", size = 2135429, upload-time = "2026-04-20T14:41:55.549Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a5/41bfd1df69afad71b5cf0535055bccc73022715ad362edbc124bc1e021d7/pydantic_core-2.46.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ad3c826fe523e4becf4fe39baa44286cff85ef137c729a2c5e269afbfd0905d", size = 2174582, upload-time = "2026-04-20T14:41:45.96Z" },
+    { url = "https://files.pythonhosted.org/packages/79/65/38d86ea056b29b2b10734eb23329b7a7672ca604df4f2b6e9c02d4ee22fe/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ec638c5d194ef8af27db69f16c954a09797c0dc25015ad6123eb2c73a4d271ca", size = 2187533, upload-time = "2026-04-20T14:40:55.367Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/a1129141678a2026badc539ad1dee0a71d06f54c2f06a4bd68c030ac781b/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:28ed528c45446062ee66edb1d33df5d88828ae167de76e773a3c7f64bd14e976", size = 2332985, upload-time = "2026-04-20T14:44:13.05Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/60/cb26f4077719f709e54819f4e8e1d43f4091f94e285eb6bd21e1190a7b7c/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aed19d0c783886d5bd86d80ae5030006b45e28464218747dcf83dabfdd092c7b", size = 2373670, upload-time = "2026-04-20T14:41:53.421Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/7e/c3f21882bdf1d8d086876f81b5e296206c69c6082551d776895de7801fa0/pydantic_core-2.46.3-cp312-cp312-win32.whl", hash = "sha256:06d5d8820cbbdb4147578c1fe7ffcd5b83f34508cb9f9ab76e807be7db6ff0a4", size = 1966722, upload-time = "2026-04-20T14:44:30.588Z" },
+    { url = "https://files.pythonhosted.org/packages/57/be/6b5e757b859013ebfbd7adba02f23b428f37c86dcbf78b5bb0b4ffd36e99/pydantic_core-2.46.3-cp312-cp312-win_amd64.whl", hash = "sha256:c3212fda0ee959c1dd04c60b601ec31097aaa893573a3a1abd0a47bcac2968c1", size = 2072970, upload-time = "2026-04-20T14:42:54.248Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f8/a989b21cc75e9a32d24192ef700eea606521221a89faa40c919ce884f2b1/pydantic_core-2.46.3-cp312-cp312-win_arm64.whl", hash = "sha256:f1f8338dd7a7f31761f1f1a3c47503a9a3b34eea3c8b01fa6ee96408affb5e72", size = 2035963, upload-time = "2026-04-20T14:44:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3c/9b5e8eb9821936d065439c3b0fb1490ffa64163bfe7e1595985a47896073/pydantic_core-2.46.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:12bc98de041458b80c86c56b24df1d23832f3e166cbaff011f25d187f5c62c37", size = 2102109, upload-time = "2026-04-20T14:41:24.219Z" },
+    { url = "https://files.pythonhosted.org/packages/91/97/1c41d1f5a19f241d8069f1e249853bcce378cdb76eec8ab636d7bc426280/pydantic_core-2.46.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:85348b8f89d2c3508b65b16c3c33a4da22b8215138d8b996912bb1532868885f", size = 1951820, upload-time = "2026-04-20T14:42:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b4/d03a7ae14571bc2b6b3c7b122441154720619afe9a336fa3a95434df5e2f/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1105677a6df914b1fb71a81b96c8cce7726857e1717d86001f29be06a25ee6f8", size = 1977785, upload-time = "2026-04-20T14:42:31.648Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/0c/4086f808834b59e3c8f1aa26df8f4b6d998cdcf354a143d18ef41529d1fe/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87082cd65669a33adeba5470769e9704c7cf026cc30afb9cc77fd865578ebaad", size = 2062761, upload-time = "2026-04-20T14:40:37.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/a649be5a5064c2df0db06e0a512c2281134ed2fcc981f52a657936a7527c/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60e5f66e12c4f5212d08522963380eaaeac5ebd795826cfd19b2dfb0c7a52b9c", size = 2232989, upload-time = "2026-04-20T14:42:59.254Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/7756e75763e810b3a710f4724441d1ecc5883b94aacb07ca71c5fb5cfb69/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b6cdf19bf84128d5e7c37e8a73a0c5c10d51103a650ac585d42dd6ae233f2b7f", size = 2303975, upload-time = "2026-04-20T14:41:32.287Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/35/68a762e0c1e31f35fa0dac733cbd9f5b118042853698de9509c8e5bf128b/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:031bb17f4885a43773c8c763089499f242aee2ea85cf17154168775dccdecf35", size = 2095325, upload-time = "2026-04-20T14:42:47.685Z" },
+    { url = "https://files.pythonhosted.org/packages/77/bf/1bf8c9a8e91836c926eae5e3e51dce009bf495a60ca56060689d3df3f340/pydantic_core-2.46.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:bcf2a8b2982a6673693eae7348ef3d8cf3979c1d63b54fca7c397a635cc68687", size = 2133368, upload-time = "2026-04-20T14:41:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/50/87d818d6bab915984995157ceb2380f5aac4e563dddbed6b56f0ed057aba/pydantic_core-2.46.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28e8cf2f52d72ced402a137145923a762cbb5081e48b34312f7a0c8f55928ec3", size = 2173908, upload-time = "2026-04-20T14:42:52.044Z" },
+    { url = "https://files.pythonhosted.org/packages/91/88/a311fb306d0bd6185db41fa14ae888fb81d0baf648a761ae760d30819d33/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:17eaface65d9fc5abb940003020309c1bf7a211f5f608d7870297c367e6f9022", size = 2186422, upload-time = "2026-04-20T14:43:29.55Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/79/28fd0d81508525ab2054fef7c77a638c8b5b0afcbbaeee493cf7c3fef7e1/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:93fd339f23408a07e98950a89644f92c54d8729719a40b30c0a30bb9ebc55d23", size = 2332709, upload-time = "2026-04-20T14:42:16.134Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/21/795bf5fe5c0f379308b8ef19c50dedab2e7711dbc8d0c2acf08f1c7daa05/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:23cbdb3aaa74dfe0837975dbf69b469753bbde8eacace524519ffdb6b6e89eb7", size = 2372428, upload-time = "2026-04-20T14:41:10.974Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b3/ed14c659cbe7605e3ef063077680a64680aec81eb1a04763a05190d49b7f/pydantic_core-2.46.3-cp313-cp313-win32.whl", hash = "sha256:610eda2e3838f401105e6326ca304f5da1e15393ae25dacae5c5c63f2c275b13", size = 1965601, upload-time = "2026-04-20T14:41:42.128Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bb/adb70d9a762ddd002d723fbf1bd492244d37da41e3af7b74ad212609027e/pydantic_core-2.46.3-cp313-cp313-win_amd64.whl", hash = "sha256:68cc7866ed863db34351294187f9b729964c371ba33e31c26f478471c52e1ed0", size = 2071517, upload-time = "2026-04-20T14:43:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/52/eb/66faefabebfe68bd7788339c9c9127231e680b11906368c67ce112fdb47f/pydantic_core-2.46.3-cp313-cp313-win_arm64.whl", hash = "sha256:f64b5537ac62b231572879cd08ec05600308636a5d63bcbdb15063a466977bec", size = 2035802, upload-time = "2026-04-20T14:43:38.507Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/db/a7bcb4940183fda36022cd18ba8dd12f2dff40740ec7b58ce7457befa416/pydantic_core-2.46.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:afa3aa644f74e290cdede48a7b0bee37d1c35e71b05105f6b340d484af536d9b", size = 2097614, upload-time = "2026-04-20T14:44:38.374Z" },
+    { url = "https://files.pythonhosted.org/packages/24/35/e4066358a22e3e99519db370494c7528f5a2aa1367370e80e27e20283543/pydantic_core-2.46.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ced3310e51aa425f7f77da8bbbb5212616655bedbe82c70944320bc1dbe5e018", size = 1951896, upload-time = "2026-04-20T14:40:53.996Z" },
+    { url = "https://files.pythonhosted.org/packages/87/92/37cf4049d1636996e4b888c05a501f40a43ff218983a551d57f9d5e14f0d/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e29908922ce9da1a30b4da490bd1d3d82c01dcfdf864d2a74aacee674d0bfa34", size = 1979314, upload-time = "2026-04-20T14:41:49.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/9ff4d676dfbdfb2d591cf43f3d90ded01e15b1404fd101180ed2d62a2fd3/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0c9ff69140423eea8ed2d5477df3ba037f671f5e897d206d921bc9fdc39613e7", size = 2056133, upload-time = "2026-04-20T14:42:23.574Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f0/405b442a4d7ba855b06eec8b2bf9c617d43b8432d099dfdc7bf999293495/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b675ab0a0d5b1c8fdb81195dc5bcefea3f3c240871cdd7ff9a2de8aa50772eb2", size = 2228726, upload-time = "2026-04-20T14:44:22.816Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f8/65cd92dd5a0bd89ba277a98ecbfaf6fc36bbd3300973c7a4b826d6ab1391/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0087084960f209a9a4af50ecd1fb063d9ad3658c07bb81a7a53f452dacbfb2ba", size = 2301214, upload-time = "2026-04-20T14:44:48.792Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/86/ef96a4c6e79e7a2d0410826a68fbc0eccc0fd44aa733be199d5fcac3bb87/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed42e6cc8e1b0e2b9b96e2276bad70ae625d10d6d524aed0c93de974ae029f9f", size = 2099927, upload-time = "2026-04-20T14:41:40.196Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/53/269caf30e0096e0a8a8f929d1982a27b3879872cca2d917d17c2f9fdf4fe/pydantic_core-2.46.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:f1771ce258afb3e4201e67d154edbbae712a76a6081079fe247c2f53c6322c22", size = 2128789, upload-time = "2026-04-20T14:41:15.868Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b0/1a6d9b6a587e118482910c244a1c5acf4d192604174132efd12bf0ac486f/pydantic_core-2.46.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a7610b6a5242a6c736d8ad47fd5fff87fcfe8f833b281b1c409c3d6835d9227f", size = 2173815, upload-time = "2026-04-20T14:44:25.152Z" },
+    { url = "https://files.pythonhosted.org/packages/87/56/e7e00d4041a7e62b5a40815590114db3b535bf3ca0bf4dca9f16cef25246/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:ff5e7783bcc5476e1db448bf268f11cb257b1c276d3e89f00b5727be86dd0127", size = 2181608, upload-time = "2026-04-20T14:41:28.933Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/22/4bd23c3d41f7c185d60808a1de83c76cf5aeabf792f6c636a55c3b1ec7f9/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:9d2e32edcc143bc01e95300671915d9ca052d4f745aa0a49c48d4803f8a85f2c", size = 2326968, upload-time = "2026-04-20T14:42:03.962Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ac/66cd45129e3915e5ade3b292cb3bc7fd537f58f8f8dbdaba6170f7cabb74/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6e42d83d1c6b87fa56b521479cff237e626a292f3b31b6345c15a99121b454c1", size = 2369842, upload-time = "2026-04-20T14:41:35.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/dd4248abb84113615473aa20d5545b7c4cd73c8644003b5259686f93996c/pydantic_core-2.46.3-cp314-cp314-win32.whl", hash = "sha256:07bc6d2a28c3adb4f7c6ae46aa4f2d2929af127f587ed44057af50bf1ce0f505", size = 1959661, upload-time = "2026-04-20T14:41:00.042Z" },
+    { url = "https://files.pythonhosted.org/packages/20/eb/59980e5f1ae54a3b86372bd9f0fa373ea2d402e8cdcd3459334430f91e91/pydantic_core-2.46.3-cp314-cp314-win_amd64.whl", hash = "sha256:8940562319bc621da30714617e6a7eaa6b98c84e8c685bcdc02d7ed5e7c7c44e", size = 2071686, upload-time = "2026-04-20T14:43:16.471Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/db/1cf77e5247047dfee34bc01fa9bca134854f528c8eb053e144298893d370/pydantic_core-2.46.3-cp314-cp314-win_arm64.whl", hash = "sha256:5dcbbcf4d22210ced8f837c96db941bdb078f419543472aca5d9a0bb7cddc7df", size = 2026907, upload-time = "2026-04-20T14:43:31.732Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c0/b3df9f6a543276eadba0a48487b082ca1f201745329d97dbfa287034a230/pydantic_core-2.46.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d0fe3dce1e836e418f912c1ad91c73357d03e556a4d286f441bf34fed2dbeecf", size = 2095047, upload-time = "2026-04-20T14:42:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/66/57/886a938073b97556c168fd99e1a7305bb363cd30a6d2c76086bf0587b32a/pydantic_core-2.46.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9ce92e58abc722dac1bf835a6798a60b294e48eb0e625ec9fd994b932ac5feee", size = 1934329, upload-time = "2026-04-20T14:43:49.655Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7c/b42eaa5c34b13b07ecb51da21761297a9b8eb43044c864a035999998f328/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a03e6467f0f5ab796a486146d1b887b2dc5e5f9b3288898c1b1c3ad974e53e4a", size = 1974847, upload-time = "2026-04-20T14:42:10.737Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9b/92b42db6543e7de4f99ae977101a2967b63122d4b6cf7773812da2d7d5b5/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2798b6ba041b9d70acfb9071a2ea13c8456dd1e6a5555798e41ba7b0790e329c", size = 2041742, upload-time = "2026-04-20T14:40:44.262Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/19/46fbe1efabb5aa2834b43b9454e70f9a83ad9c338c1291e48bdc4fecf167/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9be3e221bdc6d69abf294dcf7aff6af19c31a5cdcc8f0aa3b14be29df4bd03b1", size = 2236235, upload-time = "2026-04-20T14:41:27.307Z" },
+    { url = "https://files.pythonhosted.org/packages/77/da/b3f95bc009ad60ec53120f5d16c6faa8cabdbe8a20d83849a1f2b8728148/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f13936129ce841f2a5ddf6f126fea3c43cd128807b5a59588c37cf10178c2e64", size = 2282633, upload-time = "2026-04-20T14:44:33.271Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/401336117722e28f32fb8220df676769d28ebdf08f2f4469646d404c43a3/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28b5f2ef03416facccb1c6ef744c69793175fd27e44ef15669201601cf423acb", size = 2109679, upload-time = "2026-04-20T14:44:41.065Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/53/b289f9bc8756a32fe718c46f55afaeaf8d489ee18d1a1e7be1db73f42cc4/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:830d1247d77ad23852314f069e9d7ddafeec5f684baf9d7e7065ed46a049c4e6", size = 2108342, upload-time = "2026-04-20T14:42:50.144Z" },
+    { url = "https://files.pythonhosted.org/packages/10/5b/8292fc7c1f9111f1b2b7c1b0dcf1179edcd014fc3ea4517499f50b829d71/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0793c90c1a3c74966e7975eaef3ed30ebdff3260a0f815a62a22adc17e4c01c", size = 2157208, upload-time = "2026-04-20T14:42:08.133Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9e/f80044e9ec07580f057a89fc131f78dda7a58751ddf52bbe05eaf31db50f/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d2d0aead851b66f5245ec0c4fb2612ef457f8bbafefdf65a2bf9d6bac6140f47", size = 2167237, upload-time = "2026-04-20T14:42:25.412Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/84/6781a1b037f3b96be9227edbd1101f6d3946746056231bf4ac48cdff1a8d/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:2f40e4246676beb31c5ce77c38a55ca4e465c6b38d11ea1bd935420568e0b1ab", size = 2312540, upload-time = "2026-04-20T14:40:40.313Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/db/19c0839feeb728e7df03255581f198dfdf1c2aeb1e174a8420b63c5252e5/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:cf489cf8986c543939aeee17a09c04d6ffb43bfef8ca16fcbcc5cfdcbed24dba", size = 2369556, upload-time = "2026-04-20T14:41:09.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/15/3228774cb7cd45f5f721ddf1b2242747f4eb834d0c491f0c02d606f09fed/pydantic_core-2.46.3-cp314-cp314t-win32.whl", hash = "sha256:ffe0883b56cfc05798bf994164d2b2ff03efe2d22022a2bb080f3b626176dd56", size = 1949756, upload-time = "2026-04-20T14:41:25.717Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2a/c79cf53fd91e5a87e30d481809f52f9a60dd221e39de66455cf04deaad37/pydantic_core-2.46.3-cp314-cp314t-win_amd64.whl", hash = "sha256:706d9d0ce9cf4593d07270d8e9f53b161f90c57d315aeec4fb4fd7a8b10240d8", size = 2051305, upload-time = "2026-04-20T14:43:18.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/db/d8182a7f1d9343a032265aae186eb063fe26ca4c40f256b21e8da4498e89/pydantic_core-2.46.3-cp314-cp314t-win_arm64.whl", hash = "sha256:77706aeb41df6a76568434701e0917da10692da28cb69d5fb6919ce5fdb07374", size = 2026310, upload-time = "2026-04-20T14:41:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/34/42/f426db557e8ab2791bc7562052299944a118655496fbff99914e564c0a94/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:b12dd51f1187c2eb489af8e20f880362db98e954b54ab792fa5d92e8bcc6b803", size = 2091877, upload-time = "2026-04-20T14:43:27.091Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/86a832a9d14df58e663bfdf4627dc00d3317c2bd583c4fb23390b0f04b8e/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f00a0961b125f1a47af7bcc17f00782e12f4cd056f83416006b30111d941dfa3", size = 1932428, upload-time = "2026-04-20T14:40:45.781Z" },
+    { url = "https://files.pythonhosted.org/packages/11/1a/fe857968954d93fb78e0d4b6df5c988c74c4aaa67181c60be7cfe327c0ca/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57697d7c056aca4bbb680200f96563e841a6386ac1129370a0102592f4dddff5", size = 1997550, upload-time = "2026-04-20T14:44:02.425Z" },
+    { url = "https://files.pythonhosted.org/packages/17/eb/9d89ad2d9b0ba8cd65393d434471621b98912abb10fbe1df08e480ba57b5/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd35aa21299def8db7ef4fe5c4ff862941a9a158ca7b63d61e66fe67d30416b4", size = 2137657, upload-time = "2026-04-20T14:42:45.149Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyproject-api"
+version = "1.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/62/0fe346fe380b1aafaf819c8cb195d3241bb4f355f908e6339814131a830b/pyproject_api-1.10.1.tar.gz", hash = "sha256:c2b2726bd7aa9217b6c50b621fef5b2ae5def4d55b779c9e0694c15e0a8517ba", size = 23477, upload-time = "2026-05-28T14:22:14.049Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/d7/29e1e5e882f79133631f7bcace42d23db493f616463c157a1ab614bf69dd/pyproject_api-1.10.1-py3-none-any.whl", hash = "sha256:fa9e6f66c35b5017e909825d8f2b5d5482ea699d7be809d21c03bd1f7317f36a", size = 12992, upload-time = "2026-05-28T14:22:12.711Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/12/38c1a0b1e64806780c9563e3fc9f6e472251839662587cfbe9bfaf2ae10a/python_discovery-1.4.0.tar.gz", hash = "sha256:eb8bc7daad3c226c147e45bb4e970a1feb1bf4048ee178e6db59e197b8010ce3", size = 68455, upload-time = "2026-05-28T01:15:37.639Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/8d/3d316429f65029532bb1e28ff77b797d86b5ac3915bb44ca4e19aa283d43/python_discovery-1.4.0-py3-none-any.whl", hash = "sha256:26ed78d703e234879a66244c7d4114563fb13ec5cd30a2d1357e5fb4850782da", size = 33217, upload-time = "2026-05-28T01:15:36.573Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/29/af14f4ef3c11a50435308660e2cc68761c9a7742475e0585cd4396b91777/s3transfer-0.16.1.tar.gz", hash = "sha256:8e424355754b9ccb32467bdc568edf55be82692ef2002d934b1311dbb3b9e524", size = 154801, upload-time = "2026-04-22T20:36:06.475Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/19/90d7d4ed51932c022d53f1d02d564b62d10e272692a1f9b76425c1ad2a02/s3transfer-0.16.1-py3-none-any.whl", hash = "sha256:61bcd00ccb83b21a0fe7e91a553fff9729d46c83b4e0106e7c314a733891f7c2", size = 86825, upload-time = "2026-04-22T20:36:04.992Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "strawberry-graphql"
+version = "0.314.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cross-web" },
+    { name = "graphql-core" },
+    { name = "packaging" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/4d/df1240ee4d8fe925d0b6f0eff15cf9947f0345ab44c39eb58355b6026425/strawberry_graphql-0.314.3.tar.gz", hash = "sha256:2a841c35af61e9d5df1e215ca991cfac364c00a05fc192d9f38d0733da163097", size = 222131, upload-time = "2026-04-08T18:04:42.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/25/13773a2944cc5975d44db58233b3610ddc88d4be49e6576adf7ed4b62250/strawberry_graphql-0.314.3-py3-none-any.whl", hash = "sha256:4ef4442cea79014487acd7a0d1a2ce55c9d2a42dcd34a307d4c01f2ab477ecfa", size = 324471, upload-time = "2026-04-08T18:04:44.088Z" },
+]
+
+[package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
+    { name = "python-multipart" },
+]
+
+[[package]]
+name = "strawberry-poc"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "boto3" },
+    { name = "mangum" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "strawberry-graphql", extra = ["fastapi"] },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "testcontainers" },
+    { name = "tox" },
+    { name = "tox-uv" },
+    { name = "types-requests" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "boto3", specifier = ">=1.26" },
+    { name = "mangum", specifier = ">=0.17" },
+    { name = "pydantic", specifier = ">=2.0" },
+    { name = "python-dotenv", specifier = ">=1.0" },
+    { name = "requests", specifier = ">=2.28" },
+    { name = "strawberry-graphql", extras = ["fastapi"], specifier = ">=0.243.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "testcontainers", extras = ["dynamodb"], specifier = ">=4.0" },
+    { name = "tox" },
+    { name = "tox-uv" },
+    { name = "types-requests", specifier = ">=2.33.0.20260518" },
+]
+
+[[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
+name = "tox"
+version = "4.55.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "colorama" },
+    { name = "filelock" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "pluggy" },
+    { name = "pyproject-api" },
+    { name = "python-discovery" },
+    { name = "tomli-w" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/5b/4f09156a3f7bf3c4fa23212717f097c59126d81e2c557e6fd872a62db38a/tox-4.55.1.tar.gz", hash = "sha256:0678fbf26dd5b559b1ef128fa4388325920219322ebc8cc5f3497627c00f4472", size = 280676, upload-time = "2026-06-03T20:01:03.487Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/fd/394f00f3d3e23d87eb7b20276d88fe835e48780d3eb30e6f362428bb80c8/tox-4.55.1-py3-none-any.whl", hash = "sha256:e2084be6dfdef96ba1bed4948e6a1f73613d6952e1477be5dca45653d4c053c8", size = 215360, upload-time = "2026-06-03T20:01:01.967Z" },
+]
+
+[[package]]
+name = "tox-uv"
+version = "1.35.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tox-uv-bare" },
+    { name = "uv" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/dc/6e9994c799bdbb309f829dd6b8d98764dd0757302f3433c380438a3a127b/tox_uv-1.35.2-py3-none-any.whl", hash = "sha256:2d99b0e3c782ba49e7cbe521c8d344758595961b17a3633738d67096641c1bde", size = 6565, upload-time = "2026-05-05T01:34:16.07Z" },
+]
+
+[[package]]
+name = "tox-uv-bare"
+version = "1.35.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "tox" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/cb/168dc1ccf24e4065a9a0a33df55709ed2b5eb73bd2b13ddd53187e5dffb8/tox_uv_bare-1.35.2.tar.gz", hash = "sha256:49e28a804c97f23ea17e25859960c0fa78f35bccb7e14344cfd840e89a9aade9", size = 32333, upload-time = "2026-05-05T01:34:18.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/53/4a33dc81da39db7b31e5622333df361e8fe055b7ec636bd5fea762c9182d/tox_uv_bare-1.35.2-py3-none-any.whl", hash = "sha256:c0d590a41d1054a1ad0874e9e5943ff52402786e3d4599d8f8d37a65b566ef53", size = 22307, upload-time = "2026-05-05T01:34:17.681Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.33.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/01/c5a19253fe1ac159159ddf9a3a07cec8bb5e486ec4d9002ad2821da0e5d2/types_requests-2.33.0.20260518.tar.gz", hash = "sha256:df7bd3bfe0ca8402dfb841e7d9be714bb5578203283d66d7dc4ef69343449a5e", size = 24752, upload-time = "2026-05-18T06:07:37.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl", hash = "sha256:626d697d1adaaff76e2044dc8c5c051d8f21abc157bdfe204a75558076fe0bf0", size = 21391, upload-time = "2026-05-18T06:07:37.044Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uv"
+version = "0.11.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/f0/6254502aebfdc0a9df6069269a126dd58252ac29d2d6cdf4777cea3e90b5/uv-0.11.19.tar.gz", hash = "sha256:f56f5bf853626a30423052d7ee00bf5cc940a08347d6ee7ede96862d084054a5", size = 4213580, upload-time = "2026-06-03T22:37:15.976Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/73/be32c2f6ba30fa9d8b3baceb478107cc23722d4aaab87145a332e4985185/uv-0.11.19-py3-none-linux_armv6l.whl", hash = "sha256:c729f56ffef9b945053412c839695e8a0b13758aa15b7763e95a7dd539a6f522", size = 23620003, upload-time = "2026-06-03T22:37:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ed/3aefe4a4ca4ac9204c6745670dbe12f4add69194d40f5abd1c7bd45ba9af/uv-0.11.19-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a98495b9dd67287d8c1a0786f98cb037a50f0ee6c3d648572edaa7137aabc277", size = 23183211, upload-time = "2026-06-03T22:37:20.699Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/eb/5d1469f9e709d56066f292978711fbf1f805b7fb46f901d3c1f260fd9908/uv-0.11.19-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7fdd881cd6d80782afcf8c1d446dd15a42985167fd812b763d38ba1e4a8d944d", size = 21754003, upload-time = "2026-06-03T22:37:05.027Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/93/109b5ee6678f54492f94fdef74149643eaa1f2f4716906a2a10816b31247/uv-0.11.19-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:7222f45b5541551057bfc2e3021f113800704f665c119fdf3ea700c6c4859b21", size = 23518832, upload-time = "2026-06-03T22:37:28.794Z" },
+    { url = "https://files.pythonhosted.org/packages/08/0c/8c59bbcf78e94ca9994256920efa99d1c4dc9d0b966eb62ebba075585a16/uv-0.11.19-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:2e0e0b8ad59ec56f1440d6e4313b64a1d8119275dcec73d19eef33c43f99428c", size = 23163128, upload-time = "2026-06-03T22:37:23.226Z" },
+    { url = "https://files.pythonhosted.org/packages/89/d6/69caf9e6f11c84b5fb92df190b46fbecb7dc6645ae891c6ed66d7aaaa310/uv-0.11.19-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4aa17ffd719daf37b7a6265efd3ee4922a8ddaabaf0406d2b28c7e5ce2f20ff", size = 23164395, upload-time = "2026-06-03T22:37:18.11Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/83/0c2242b77c51ac33a0ddd8b06790429a0b8b9623974c9594ab2b0070ec47/uv-0.11.19-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:32d7988c0dfb6f90941f201c871a4478e96e4f2a32bdb2256d62a78ee20593fc", size = 24541708, upload-time = "2026-06-03T22:37:08.093Z" },
+    { url = "https://files.pythonhosted.org/packages/54/10/b1404fc52c0eddc3655f57a8b76e79dcf8dd02568382272f17e2fa68c4bb/uv-0.11.19-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2d663bacb97e2e8412d1c26eace28c7ebbde9d6f5d7d78760fafd114d693817f", size = 25575501, upload-time = "2026-06-03T22:37:47.526Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/17/4cda5994195ba9ce1f6971d40d5f2ceec58e2a79030d9052b3bf322557b1/uv-0.11.19-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:574f5dd4f31666661ea6386d3b91c5f0e8b84a8cae98ebba447c4674f2e6a4c7", size = 24827200, upload-time = "2026-06-03T22:37:34.039Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/74/2bd8b51e1d76210fd424ae55ec3f34ded5a10eeff3dd38aeb03c816a0af2/uv-0.11.19-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:731d9fab8db5d41590af64236d03f8069c8da665fd0f9493b85985f19c86cd90", size = 24872664, upload-time = "2026-06-03T22:37:11.301Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b1/44b0764f656bbdd0728118610a63f2feddd9cbe450f974d80c5bb56aad34/uv-0.11.19-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:301fd78309fc545c2cec2bfcc61a6bbdde876856c6d2041502737cf44085c178", size = 23617890, upload-time = "2026-06-03T22:37:44.796Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/25/312fa33cd4c34e7618f86cad0c9fdb312d8fef2e7fc61944c1a2f1bf1256/uv-0.11.19-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:62b0b35a51d3034ff30ecd0f381e9bbc20d5b335754f54b098da29424d551ceb", size = 24267220, upload-time = "2026-06-03T22:37:39.425Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/25/13856aeff9e14c98ee3e1ceae4d209301cbdeabde93abcd758433601dc82/uv-0.11.19-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:65e932720daed1af1f720a0ff5f9b33ee5f7ad97488dcceceb85154fc1323b82", size = 24376177, upload-time = "2026-06-03T22:37:50.276Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/590b3ab420e03504cf658d2981e1fcb4af60f3858d42da1d4d8740141dd9/uv-0.11.19-py3-none-musllinux_1_1_i686.whl", hash = "sha256:8f90b6687a480d154595aa619fb836a9a20d00ce37293db8099aad924f2b18f9", size = 23808336, upload-time = "2026-06-03T22:37:26.086Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8e/40acebd4ea419c870930580623e8367e23d810a0ecb8cc2f44d852a27293/uv-0.11.19-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:28b0d612a766eb25756dbaa315433b726e93affa467d29a2682cc317547952ba", size = 25080747, upload-time = "2026-06-03T22:37:13.886Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d3/4037b2acb2bb73b1a3ee47a1d23864ecc503f5840387afd29f621d4fd2ec/uv-0.11.19-py3-none-win32.whl", hash = "sha256:aa6a7e8d07b33ad22f4732848ebb1d9486503973c248d6e632c06ce4339fe347", size = 22459533, upload-time = "2026-06-03T22:37:36.741Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/43/f374fad7ad94e4a8c47cf09f00d803c76c6cc7f225668c41f4e2fb5de000/uv-0.11.19-py3-none-win_amd64.whl", hash = "sha256:480fc34a8d0967af6a90b3f99a6e5687cd5c6e29528de96bec04d6e305a59363", size = 25143888, upload-time = "2026-06-03T22:37:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/18/98/d2db53ae036528b0a9407529ef175ee200b01f626c9c160978784c8af870/uv-0.11.19-py3-none-win_arm64.whl", hash = "sha256:50e4d4796ca1a6da359a4f723a0fea86640c381d3ff4fa759a41badd7cb52dee", size = 23601290, upload-time = "2026-06-03T22:37:31.393Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/0d/4e93c8e6d1001a75763f87d8f5ecda8ebc7f4aa2153dddfaf4ae8892821a/virtualenv-21.4.2.tar.gz", hash = "sha256:38e6ee0a555615c0ea9da2ac7e9998fe8dc3b911dd33ad8eaad2020957653b0c", size = 7613326, upload-time = "2026-05-31T17:01:22.827Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/c4/557dc082be035381b85fdb2b74e21d3d21b57750b74f2b47a32f3a639ff9/virtualenv-21.4.2-py3-none-any.whl", hash = "sha256:854210ca524a1a4d0d744734f4acbc721c3ffe163b85bbf5d56d14d5ae2f0fae", size = 7594079, upload-time = "2026-05-31T17:01:20.735Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/9f/06263fcd8ad6c405f05a3905fd7a84dd3176eb5ad46e44bccc0cd16348bb/wrapt-2.2.1.tar.gz", hash = "sha256:6744f504375775d7609c82c8d3d94af1c9a6f05586984536905908ba905277b9", size = 127620, upload-time = "2026-05-22T14:49:43.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/0c/bfae7b9401583b6d05938cd16dedc43857d96da2f8a3d50d78cc515bf6ff/wrapt-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3ffad790d9d11d8ecf9f17c4bb671a5b4089e4d8b575c46c5129597f41f836b0", size = 81021, upload-time = "2026-05-22T14:48:00.313Z" },
+    { url = "https://files.pythonhosted.org/packages/26/58/80f6a6599f933f4caecc1cb3ee88a04faf81e8b9bddbd6109c688dd63e0f/wrapt-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:628f5220c7a904d5fc78f7075c8d7871433eb6d035c94728a22fdf85f193d2a8", size = 81692, upload-time = "2026-05-22T14:48:01.49Z" },
+    { url = "https://files.pythonhosted.org/packages/17/93/fb357cc7847c58a8ae790be718903afa81a28d23e642c843dc4129e8a0b2/wrapt-2.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:61acce4257a9883669703c525447c5b4c392edf0f987ae77ec32668440158f0e", size = 169364, upload-time = "2026-05-22T14:48:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0b/76b601ee309a8bd556af0eecb184394c20b3c49aa9c8e085aa1ffacc2568/wrapt-2.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:727ab4244622cd6ad2390f322642090c877d2e83a608d2653a7643ae5368d926", size = 171079, upload-time = "2026-05-22T14:48:04.22Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/87/ee3f32d5658e3e26d3e0e457922b47a36dd3bfbdfee7f97bb3e802344a66/wrapt-2.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:03df9ebed4c73ab93fa8c07e3d41d818dfca1852b15731a3de59457b27814624", size = 160205, upload-time = "2026-05-22T14:48:05.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/d0/ae2fd64277a67f5d7bffcf2d05eea1e476263fb2a072baf0b0129ab85984/wrapt-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0d9ff006f420b2ec8296aa56ade43ea7da3e997e85769f0aafc5e0661aacb710", size = 168922, upload-time = "2026-05-22T14:48:07.132Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f3/2d541a060c5bbafb9400bca4917e4d78bfd1f239f404782c86831a8f6b29/wrapt-2.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:844c858fc3bb7eacc0ba8efa904935d16aac6a4470948ad1e7e55c9f5a2a665f", size = 158388, upload-time = "2026-05-22T14:48:08.629Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/68/8d92c8800c57e93cb116ae9e9d6cbafc34fade5ee9f9107b6f203fb4dc35/wrapt-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87bacdaf225117a342a20d9c03438d701c02112f6e3f351ce9b7f32354f14797", size = 167682, upload-time = "2026-05-22T14:48:10.042Z" },
+    { url = "https://files.pythonhosted.org/packages/30/72/83ea3790ea352439442349388e29ff07b76e0686265f9088bbb505d1608d/wrapt-2.2.1-cp312-cp312-win32.whl", hash = "sha256:2f8c90c8afde51969487be4e1343ae049b268854877d415c2510baf833775052", size = 77857, upload-time = "2026-05-22T14:48:11.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/cb/99450668dd3502d62a54a1c8aa56e44f34cb8c1261b381cfe2e7926c3b75/wrapt-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ce32763ac31ce94fe9aada947e479b1975012bff166da409b4b9e4e376cf7e5", size = 80825, upload-time = "2026-05-22T14:48:13.046Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3a/87512881be64e743f9ee4c66f4cbe8e884974bef2a5989af71f999653ac7/wrapt-2.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:8d1b4d0e0c2119587a31f5c029abd547e0c81d93b89d394566fe1588659eb579", size = 79087, upload-time = "2026-05-22T14:48:14.323Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/a1b08f8f4fac8cbb156fa51cf64ee2c7f7f74f9875ba3cf70b3c58368694/wrapt-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d2beb1c7cab10603aecdc42f8edd6ff013f9a32e4543474e38e6b77ce9975aeb", size = 80831, upload-time = "2026-05-22T14:48:15.598Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ce/57890814991446a845e09b3445ce8b694f27eb0577004f2c2a36a9772ed4/wrapt-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e0cb7e4dd71f4c32e5e84843cd3c4cd65dda034314004bbe1d7f99af2426ab80", size = 81375, upload-time = "2026-05-22T14:48:17.071Z" },
+    { url = "https://files.pythonhosted.org/packages/38/65/08d7a6c76ac4493bdb668205ee9c1de1bd5daca61717c3e9aa49b4c01499/wrapt-2.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95821352042722cd9f1108874579a47989d0a7e12a37d87d2fc4af20fd99ab8a", size = 167417, upload-time = "2026-05-22T14:48:18.303Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ce/f1ccbee7a1bfe5cdc6b3da6bab4b45713d628b9294da32a39f563d648140/wrapt-2.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abd621552ede77c4c69be7fac44ba911225b0c812b6ba604e5964cf98085b474", size = 166948, upload-time = "2026-05-22T14:48:19.768Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2a/f85d48d1cd4869aee6704028d257d740a47c1c467b457ce396b4b5b55d07/wrapt-2.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e3677c7146ce694874941ba82b57092cc4875445aadf29d72807351023105143", size = 158148, upload-time = "2026-05-22T14:48:21.96Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/5c/93939ad11d4a12358ab1aab219a2ef5efa5612e0db6b9fc65af8af1a891b/wrapt-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9a5934eaea872e17936b5f45501eba5ab0bce9a74122e172b663d7c28c459c4a", size = 165905, upload-time = "2026-05-22T14:48:23.373Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/b8c2aa89862ff58605934d7abf4b70e6a5a1c33df96656f49035ccdf1c8a/wrapt-2.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f5b9daf6b629fce418e0cc3dd0436eac045188fa35deadb7a7f3941d5b8203f9", size = 156712, upload-time = "2026-05-22T14:48:24.767Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/bf00a7b02239c12bb02ddcc3c0b971bfcc36e578c5a44f1ccfef5b458545/wrapt-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f53ac9f3ef573326d009ed809beff4efcac6451931c2b8132586da4b9e53ff31", size = 166560, upload-time = "2026-05-22T14:48:26.83Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/93/6390ca9c5b787683cef588d04f57c8d41b9a2323b5597a65f18638c90ef2/wrapt-2.2.1-cp313-cp313-win32.whl", hash = "sha256:1ffa9cfd4bdb581539951b14ae661ff20ed0c3599b3e911a131ee0ec5ac11337", size = 77817, upload-time = "2026-05-22T14:48:28.221Z" },
+    { url = "https://files.pythonhosted.org/packages/97/73/ce10f0e71c0cfaa1a65faadb8efd4852028b3bb9ba28932b8889df769d38/wrapt-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:368eac1e20fd0bb03dd3cc42bf9887154c3861b60989389ccb5fac032617d215", size = 80736, upload-time = "2026-05-22T14:48:30.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/4c/89f4a6818fafbbd840330e4fa3873073e1bfc166133a64cac7f8fde7a5e3/wrapt-2.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:c754dafdf5aaf0b401b644a90a30046929a0dd1a536e0ff0ec959a59155d9c7f", size = 79099, upload-time = "2026-05-22T14:48:31.405Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f2/9a8741c46f8c208ac0a45b25ba170bcb4fb72a2781d5fb97dbd7b6be73cb/wrapt-2.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ed928d0fda15fc0adc8d13305c8b3c0f2fba5b0669950c9e6d019d9162a3b3e8", size = 82802, upload-time = "2026-05-22T14:48:33.307Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0d/e9c855716a3705eef1416456bdf062b60620726fdc59428ff670fc3c60dc/wrapt-2.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fafb4e739e43544d12cb4abd1605fd4683b6ca6a9ad682b7fd8f4d21973eafa8", size = 83329, upload-time = "2026-05-22T14:48:34.593Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d6/a88f1c13112b7831adac75cea65d8310e0d696d570c8961844c90a57b865/wrapt-2.2.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:74d6a0c31472fe5d814917266b9f46495d7c61ed890af08b468acea92fb89a8d", size = 202937, upload-time = "2026-05-22T14:48:35.859Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/e29d54aef06a4d898a5b8a25589a0b3769bde454f922fad8f6f89fbfb650/wrapt-2.2.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab5be648d5a0b86b7438864f8df3c705a65cef35a2fd3e5561e3e203167e0f27", size = 209997, upload-time = "2026-05-22T14:48:38.153Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/91/e4454263516cf0e12640912fbca9a83654e424f0a6ddb79f5cd7ce14bf33/wrapt-2.2.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d8f204c8e3a8bf9ece17e0a83d137fd807440977f8a5e762d59306795011440", size = 194856, upload-time = "2026-05-22T14:48:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d0/fe0ee202286afdf4a7f77dd29f195703145764d572aec209c5086e57d924/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d047f6498c973874ba08ac3f97c69a2c4b2211c8de6f4c205f75cb1c9522596e", size = 205654, upload-time = "2026-05-22T14:48:43.456Z" },
+    { url = "https://files.pythonhosted.org/packages/23/b6/87d860dfc6460c246af70b1fd5c8b76df77571b42a493459423ded94fd7d/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:7a4fdb9326aab4a5a477a1640e5ad786a8495901009d7e7b038371edd23a9d2b", size = 192206, upload-time = "2026-05-22T14:48:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/df/46/3eea8cde077d985f239a38c0257087b8064fd9ee9b1a99e282d2c86da4ef/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c8cc5094b08abeae52da9c73c8a32003623be691a5193df2f4e3eac3d557c394", size = 198428, upload-time = "2026-05-22T14:48:46.319Z" },
+    { url = "https://files.pythonhosted.org/packages/18/dc/b927ee9c7fc67adc3a5658f246a0d275425eb840ba36e7b702e70f18bde8/wrapt-2.2.1-cp313-cp313t-win32.whl", hash = "sha256:9907a4402ab6db12b7077a0ea5d7a4d028ecb22c8eee2b53527080d347cd1562", size = 79448, upload-time = "2026-05-22T14:48:47.901Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b3/fd30b473fe498c70e6b9a5f328b8d3fbaf1b8c3c481465f59724bba8eb70/wrapt-2.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:5590d63f5243251641cf543009b4c9314a79d0598fdb8a8e4cfc918494536c53", size = 83021, upload-time = "2026-05-22T14:48:49.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/96c39153a8737a6e9aa85adef254ac4195bea3f2d24efc60472ccc3c9e2e/wrapt-2.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:c318a64b53d97b841d7b5e637517e50a27be64bc695128422953d4b21710954e", size = 80295, upload-time = "2026-05-22T14:48:50.479Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a3/11d7f34ebbf3231bc907a3e6d5ee051b14d034c1bc7b65a97d5cc00516df/wrapt-2.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f56a647e4eaf5f0ca40330fb070f566bdf9f7b0db89a1af20d71c28dcd7a0ab", size = 80879, upload-time = "2026-05-22T14:48:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3c/b74cfd984cef560b900fb1a727af20352d89e1f06bf2e1114dd3f00f5f5a/wrapt-2.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:64b7deeda4b70408e382328d8bbe52a256fe9bc63ae3db86d804608367e5422c", size = 81462, upload-time = "2026-05-22T14:48:53.18Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a3/7c8f704b8dc07dfe0a5d01c2edbfd88317aa8e5e3fa7c743eb7a085ae767/wrapt-2.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9cf53ba90717db2e292401de290776c498d4bbfb0d4a559ca2895db8b9dcb5c", size = 167251, upload-time = "2026-05-22T14:48:54.562Z" },
+    { url = "https://files.pythonhosted.org/packages/80/85/a34d1888d97247da6c2ff6118c3a721c73ed8cc4dd198c00208bb73b6f80/wrapt-2.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf3638274ab9d9b724c9baa0b4c04e132cd6faefb78b4dd3dd1a02a4bdaad41e", size = 166316, upload-time = "2026-05-22T14:48:56.065Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d7/72ffaeb01eebc704afe3fb99e840480f4bda45f0fa66e3381b6a39251c8f/wrapt-2.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aed9658797d0b45d6c49adcfc6b41f66e6f2d0c6de3ec79e16cf4b1855df240f", size = 157952, upload-time = "2026-05-22T14:48:57.924Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5b/36f5d6b024e4edfdd90b140742d11ebcf7836daf5c9daf326c55c24db412/wrapt-2.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1d676ee388bc42a04d56dd7deb5605244dac2e35cc2fadbb43c9fa25bbd93508", size = 166130, upload-time = "2026-05-22T14:48:59.384Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/9296d9e97bfdef5483dfcc859d57b095b257144b2bc5300ab521e06f4bc7/wrapt-2.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e395f7bc31851ef9b612050368cb446e9bc14cd7454b025018980349caf25ae5", size = 156604, upload-time = "2026-05-22T14:49:00.921Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/16953929ed6776175720e58fc966e779926d8d71e2c7b2273230590ca71f/wrapt-2.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f1845c2a8cc1180ccccfa45785dd06f562730d19ef75be180334254012b6283", size = 166007, upload-time = "2026-05-22T14:49:02.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/73/20ee58c0612dae7c31131a7095345812ed2c7b389019e175f68cde34e5b4/wrapt-2.2.1-cp314-cp314-win32.whl", hash = "sha256:436addbc4bb4fc0a88c702577f51195d7d73683a7f3e0e5b253d8404d7847243", size = 78327, upload-time = "2026-05-22T14:49:03.722Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b3/ef7c3295d02e0448a71c639a36a057f46d524d057c9486291a7a3039e65c/wrapt-2.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:50972a1d974ea07725a7f6b1cec5f8759008afd030a0024843ebe7d52de47f2b", size = 81144, upload-time = "2026-05-22T14:49:05.093Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/dc/7bdf336953f99f4ceb0a584bb8870e42c8f26f93ea10c87834dad62f1668/wrapt-2.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:1c9934ea5d92957e3cd0adbc0845539dccfd62710ebe16195a8c66c53954db36", size = 79569, upload-time = "2026-05-22T14:49:06.413Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6d/6dfae80150ff1919c356d1dd528f049bcdfaae29b4d284bc957e022caef4/wrapt-2.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:17de18fc12cea55b8a9587314cb830573e37fb33b247a7515696350863714188", size = 82892, upload-time = "2026-05-22T14:49:07.925Z" },
+    { url = "https://files.pythonhosted.org/packages/82/7b/4e34766a7d7804ffce9e71befe47e9b3225dc350c49c94493c4ab39fd3a5/wrapt-2.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a9dec1aca52dddde7df94818310fa2fe79739c8f385b2014c4cb1035f5508199", size = 83333, upload-time = "2026-05-22T14:49:09.257Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/57/0b34db3e8de44ccfece62d7b337abd1631dd810f5adc5f3db571727836b5/wrapt-2.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:69f2e9244542cb34dd59c7f073445b9e54ad9f3fce8d93606c368a1b499fc413", size = 202899, upload-time = "2026-05-22T14:49:10.572Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/ac0c459f154b99d92789a6cba7ca727185b83513b986f8ec7fe2aacddcbf/wrapt-2.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d83966dc7f4f45e8b97b5933685ac2e6e67fc0e19246ea314bceb9a8970c956", size = 209986, upload-time = "2026-05-22T14:49:12.229Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/77e37ff33ad018fa81ade52c25fa327b80b56f81d734279a63614fcb4cbc/wrapt-2.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78b0aa6bfb7be8deed0ab23e7aa028cc5210c29bc2d32a04d52b50e517a7307e", size = 194893, upload-time = "2026-05-22T14:49:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9d/7ea651d1ab032fc5fa222fbec91d0f8a1397f6ae04ebb93fa7219aa921d7/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:05d5cb74d1b232ec8cfa130a8f900708699ff2491d97b8f85a4cdc5996294b85", size = 205636, upload-time = "2026-05-22T14:49:15.714Z" },
+    { url = "https://files.pythonhosted.org/packages/09/af/8e88031a701275b9085c54e64bc88c0b1cd55c77eadd400691c371cd76c4/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f6518b94edb9150452e9aba08027d4cc293433753ec1fbefb4629a21cbc74181", size = 192267, upload-time = "2026-05-22T14:49:17.283Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a8/e657ca876b06710194f243d81c4b0896ade646e244bdbec2d87c8c56a8bd/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ed55af48b3eb28f43228ca2306788892bcb629eb2b5c4876e2a3659872c2f17a", size = 198378, upload-time = "2026-05-22T14:49:18.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/59/822efe4ea722a3961331bfa35b7d90937790d2c20f0616de1997ccc3aebd/wrapt-2.2.1-cp314-cp314t-win32.whl", hash = "sha256:2e08688ab16525897da6589d56d0aebaf417bbe91c2d8e3b96203b1efa596e85", size = 80226, upload-time = "2026-05-22T14:49:20.264Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/2a7dc5f6abb2fca0b6e1610e120419f603650aceb4f1d3ac4cae0354e162/wrapt-2.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:fd0135d34387f5fd087d9be368ea77ea89cf2451dc1cd1c622d35021bcb3ab50", size = 83835, upload-time = "2026-05-22T14:49:21.634Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c0/782b86e28d1ceebeb74cccea12d2cd3d2ba0bd68e3dec20b1bc5873f6127/wrapt-2.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:f70db64e8266d7c45d3b735f2e08eeb434b5e03da9a479ae42b2e2e486a21a00", size = 80722, upload-time = "2026-05-22T14:49:23.59Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/29ac9daf11a86c22a8c38cd9236c62928ccae83f7ceb06bd3b0467cf9d05/wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f", size = 61000, upload-time = "2026-05-22T14:49:41.593Z" },
+]


### PR DESCRIPTION
## Summary

Adds `spike/strawberry_poc/` — a parallel Strawberry+FastAPI implementation of the legacy Graphene+Flask GraphQL API, scoped as a feasibility spike under `spike/`. **Does not touch any legacy code or change runtime behaviour of the deployed API.** Side-by-side Lambda wiring and CI workflow ship in stacked PRs (#2 and #3 below).

The spike has been incrementally validated against the production-like `stage=test` deploy and has caught several weka-impacting bugs (missing `update_automation_task` resolver, unsafe enum coercion crashing all GeneralTask fields on production data, file_size BigInt overflow, missing `total_count` on relay connections, ToshiFile type-name mismatch).

## What's in it

**Schema parity for the production weka query set:**
- `GeneralTask`, `AutomationTask`, `RuptureGenerationTask` (+ `subtask_result`, safe enum coercion for unknown production values)
- `InversionSolution` family: `InversionSolution`, `ScaledInversionSolution`, `AggregateInversionSolution`, `TimeDependentInversionSolution`, `InversionSolutionNrml`
- `RuptureSet`, `Table` (incl. `name`, `mfd_table_id`, `hazard_table_id`), `ToshiFile`, `SmsFile`, `StrongMotionStation`
- `OpenquakeHazardTask`/`Solution`/`Config` (HAZARD + DISAGG, JSON logic trees, csv/hdf5/task_args archives, predecessors)

**Interfaces** — the bits weka's `... on InversionSolutionInterface { ... }` fragment queries depend on:
- `FileInterface` (file_url/post_url stubs ready for S3 wiring)
- `PredecessorsInterface`
- `InversionSolutionInterface` (mfd_table, tables, relations { total_count }, produced_by union)

**Queries:** `node`, `nodes(id_in:)` with deep AutomationTask.parents traversal (canonical weka batch pattern), `object_identities`, `legacy_object_identities`, search proxy, `reindex` mutation.

**Mutations:** create + update across all types, including `update_automation_task` (triggers ES re-index via `update_thing` → `index_document`).

**Custom BigInt scalar** for `file_size` >2GB (matches legacy schema; previously GraphQL Int's 32-bit limit silently rejected production values).

**Pydantic v2 data layer** mirroring legacy JSON storage schema with resilient enum coercion (unknown enum values return `None` instead of crashing the whole node resolution).

**Relay `ListConnection` subclasses with `total_count` override** (`FileRelationsConnection`, `TaskRelationsConnection`) that survive Strawberry's edge-skipping optimisation.

**Infrastructure:** testcontainers (DynamoDB Local + ES 7.1.0), atomic DynamoDB writes via `transact_write_items` + ID counter, ruff/mypy config, tox setup.

## Test plan

- [x] `uv run pytest tests/` in `spike/strawberry_poc/` — 151 passed, 1 skipped
- [x] `uv run tox` (matches CI flow) — 151 passed, 1 skipped in ~24s
- [x] Schema loads cleanly: `uv run python -c "from schema import schema; print('OK')"`
- [x] Manually validated against `stage=test` deploy with real weka queries
- [ ] CI workflow run (lands in stacked PR #3)

## Stacked PRs

- This PR — POC code only (no production impact)
- PR #2 (head `strawberry-poc-deploy`) — wires `/graphql-v2` Lambda side-by-side with legacy
- PR #3 (head `strawberry-poc-ci`) — GH Actions workflow for the POC test suite

Both stacked PRs target `strawberry-poc-spike` to show clean diffs; they'll be retargeted to `deploy-test` once this merges.

## Coverage gap analysis

`spike/strawberry_poc/COVERAGE_GAPS.md` documents the legacy-vs-POC test coverage analysis that motivated the most recent additions — top-priority weka-critical gaps are all closed.