### PR TITLE
feat: wire Strawberry POC as side-by-side /graphql-v2 Lambda

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ license = "AGPL-3.0-or-later"
 dependencies = [
     "backoff",
     "boto3>=1.24.57",
+    "mangum>=0.17",
+    "strawberry-graphql[fastapi]>=0.243.0",
     "elasticsearch>=9",
     "elasticsearch7-compatible",
     "flask>=3.0.3",

--- a/serverless.yml
+++ b/serverless.yml
@@ -257,6 +257,15 @@ functions:
       DB_READ_ONLY: "1"
       DEPLOYMENT_STAGE: ${self:custom.stage}
       GRAPHQL_PATH: /graphql-v2
+      # REGION + S3_BUCKET_NAME inherit from provider.environment but we set
+      # S3_BUCKET_NAME explicitly so the dependency for _from_s3 / S3 fallback
+      # paths in data/dynamo.py + data/s3.py is visible at function scope.
+      S3_BUCKET_NAME: ${self:custom.s3_bucket}
+      # Watermark for legacy_object_identities — IDs below this are S3-only.
+      # Tracks custom.first_dynamo_id so the POC and legacy stay in lockstep.
+      FIRST_DYNAMO_ID: ${self:custom.first_dynamo_id}
+      # S3 IAM (s3:*) is inherited from provider.iamRoleStatements — covers
+      # the s3:GetObject + s3:ListBucket needed by the read fallback paths.
     warmup:
       lowConcurrencyWarmer:
         enabled: false

--- a/serverless.yml
+++ b/serverless.yml
@@ -12,6 +12,9 @@ plugins:
   - serverless-plugin-ifelse
 package:
   individually: false
+  include:
+    - spike/strawberry_poc/**
+    - strawberry_poc_handler.py
   exclude:
     - .env
     - .env.*
@@ -224,6 +227,39 @@ functions:
         enabled:
           - test
           - prod
+
+  strawberry-poc:
+    description: Strawberry/FastAPI POC at /graphql-v2 (read-only)
+    handler: strawberry_poc_handler.handler
+    memorySize: 1024
+    timeout: 30
+    events:
+      - http:
+          path: graphql-v2
+          method: OPTIONS
+      - http:
+          path: graphql-v2
+          method: GET
+          authorizer:
+            name: jwtAuthorizer
+            resultTtlInSeconds: 0
+            identitySource: ''
+            type: request
+      - http:
+          path: graphql-v2
+          method: POST
+          authorizer:
+            name: jwtAuthorizer
+            resultTtlInSeconds: 0
+            identitySource: ''
+            type: request
+    environment:
+      DB_READ_ONLY: "1"
+      DEPLOYMENT_STAGE: ${self:custom.stage}
+      GRAPHQL_PATH: /graphql-v2
+    warmup:
+      lowConcurrencyWarmer:
+        enabled: false
 
 resources:
   Resources:

--- a/strawberry_poc_handler.py
+++ b/strawberry_poc_handler.py
@@ -1,0 +1,18 @@
+"""
+Lambda entry point shim for the Strawberry/FastAPI POC.
+
+The POC lives in spike/strawberry_poc/ and uses root-relative imports
+(e.g. `from data.search import ...`). Lambda's working directory is the
+repo root, so we insert the POC directory into sys.path before the POC
+modules are imported. This lets the POC remain self-contained without
+restructuring its imports.
+
+Handler in serverless.yml: strawberry_poc_handler.handler
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "spike", "strawberry_poc"))
+
+from app import handler  # noqa: E402, F401 — re-export for Lambda

--- a/uv.lock
+++ b/uv.lock
@@ -440,6 +440,18 @@ wheels = [
 ]
 
 [[package]]
+name = "cross-web"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/a0/bdb8370215987cc5bde497cb8b976b17ab14841566ecef2aab6ae3e6c7b0/cross_web-0.7.0.tar.gz", hash = "sha256:15fbc8b9a824a055db8127fd6e43e0773074f620fdecb6b2b587d3d0a2bdd459", size = 332407, upload-time = "2026-05-19T14:18:48.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/4a/78b52ec2edcbd9b123638f4e0421fd8699ebe653ebf63ac5f82abd2665bc/cross_web-0.7.0-py3-none-any.whl", hash = "sha256:ddea9be3c68b48eaf16561847a5831a559786949c544b3701432e00a4e8d19d9", size = 25207, upload-time = "2026-05-19T14:18:47.614Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "48.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -579,6 +591,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bb/b7/2587ab980d479adec3033a2066e3415630f1eedf0e914d77b5b274a0aa36/elasticsearch7-compatible-10.0.5.tar.gz", hash = "sha256:0420897b07dd1bf811a97b0f0dc1249b8fa3a192e260572cb70cc3e7ee70457e", size = 197201, upload-time = "2025-10-17T10:49:58.674Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/a0/d4ce1826df224d944becd3fa11e792e473b0f28476cbfc67aeba845f3480/elasticsearch7_compatible-10.0.5-py2.py3-none-any.whl", hash = "sha256:8ddae43112499d35992ed2cfc6edafbb13b68983f31f0f78d718f4ddbcda489a", size = 354500, upload-time = "2025-10-17T10:49:57.363Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.136.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
 ]
 
 [[package]]
@@ -866,6 +894,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
+]
+
+[[package]]
+name = "mangum"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/cb/d9f4d685a0b8eceac10991e15ac471d9568e4e42c2489ae9bf072828c1c2/mangum-0.21.0.tar.gz", hash = "sha256:e31ed72d67f9958fa4379f65df77729906dec6dfa00afa6ed4e06c77833000de", size = 89130, upload-time = "2026-02-01T17:17:42.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/50/e3c694b8e122551e4557450219283771334dee2ed5734a8398c8b8018c50/mangum-0.21.0-py3-none-any.whl", hash = "sha256:309e48f5c629542516c5106ecf079f4ec08809ed50df882238d98fe1392820c7", size = 17146, upload-time = "2026-02-01T17:17:41.553Z" },
 ]
 
 [[package]]
@@ -1213,6 +1253,7 @@ dependencies = [
     { name = "gql" },
     { name = "graphene" },
     { name = "graphql-server" },
+    { name = "mangum" },
     { name = "nzshm-common" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "pynamodb" },
@@ -1222,6 +1263,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests-aws4auth" },
     { name = "requests-toolbelt" },
+    { name = "strawberry-graphql", extra = ["fastapi"] },
 ]
 
 [package.dev-dependencies]
@@ -1256,6 +1298,7 @@ requires-dist = [
     { name = "gql" },
     { name = "graphene", specifier = ">=3.3" },
     { name = "graphql-server", specifier = "==3.0.0b7" },
+    { name = "mangum", specifier = ">=0.17" },
     { name = "nzshm-common" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8.0" },
     { name = "pynamodb" },
@@ -1265,6 +1308,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "requests-aws4auth" },
     { name = "requests-toolbelt" },
+    { name = "strawberry-graphql", extras = ["fastapi"], specifier = ">=0.243.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1754,6 +1798,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.29"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
+]
+
+[[package]]
 name = "python-slugify"
 version = "8.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2113,6 +2166,41 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
+]
+
+[[package]]
+name = "strawberry-graphql"
+version = "0.316.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cross-web" },
+    { name = "graphql-core" },
+    { name = "packaging" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/09/f189fd3c70544322eeba0398ccaa980d17857894c0a66d447aa0b5704686/strawberry_graphql-0.316.0.tar.gz", hash = "sha256:bee5ce0e20d522325bd1ed2db186c812c03c2ea7db29f997b35e7d694649820c", size = 223985, upload-time = "2026-05-19T17:06:10.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/dd/b2cf54803cbd0d37e3ce73c7274bdb144ba83743bc83351b5790eb2a5fad/strawberry_graphql-0.316.0-py3-none-any.whl", hash = "sha256:222e16fbbf953f5a1fa75f62bf9a8e95f274180f928f70bec459b566053aa2cb", size = 326530, upload-time = "2026-05-19T17:06:07.844Z" },
+]
+
+[package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
+    { name = "python-multipart" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a second Lambda function pointing at the `spike/strawberry_poc/` Strawberry+FastAPI handler, exposed at `/graphql-v2` alongside the production legacy `/graphql` endpoint. **Read-only (`DB_READ_ONLY=1`)** to guarantee no production-data side effects from POC traffic. Production `/graphql` Lambda + behaviour are untouched.

## Changes

- **`serverless.yml`** — new `strawberry-poc` function. 1024MB / 30s. Reuses the same `jwtAuthorizer` (matching production auth). Package include rules pull in `spike/strawberry_poc/**` + the handler module.
- **`strawberry_poc_handler.py`** — thin Mangum entrypoint that imports the FastAPI app from `spike/strawberry_poc/main.py`.
- **`pyproject.toml` + `uv.lock`** — adds `strawberry-graphql[fastapi]` + `mangum` to runtime deps so they're packaged in the Lambda zip.

## Production safety

- New Lambda function only — does not modify the existing production Lambda or its routing.
- `DB_READ_ONLY=1` in environment — `_assert_writable()` in `spike/strawberry_poc/data/dynamo.py` blocks every mutation path before any DynamoDB write happens.
- Reuses the existing JWT authorizer, so auth/identity behaviour is consistent with `/graphql`.
- API Gateway path `/graphql-v2` is distinct from `/graphql`.

## Test plan

- [x] Manually deployed and validated against `stage=test`
- [x] Weka-style queries hit `/graphql-v2` successfully (including the `nodes(id_in:)` deep traversal pattern)
- [x] Confirmed `DB_READ_ONLY=1` blocks mutations (every `create_*` resolver path through `_assert_writable()`)
- [ ] Smoketest query against deployed `/graphql-v2` after merge

## Stacking

Targets `strawberry-poc-spike` while #296 is in review (so this PR shows only its own diff). After #296 merges to `deploy-test`, this PR will be retargeted to `deploy-test`.

**Depends on:** #296 (the spike directory must exist for the package include rules to find anything).