### PR TITLE
ci: add GH Actions workflow for Strawberry POC tests

### DIFF
--- a/.github/workflows/strawberry-poc-tests.yaml
+++ b/.github/workflows/strawberry-poc-tests.yaml
@@ -1,0 +1,43 @@
+# Runs the Strawberry POC test suite via the GNS-Science shared workflow.
+#
+# Delegates to nshm-github-actions/python-run-tests-uv.yml, which handles
+# uv install + tox + Codecov upload + Slack alerts. The shared workflow
+# expects a tox config at the working-directory root — see
+# spike/strawberry_poc/setup.cfg.
+#
+# Scope: only triggers on changes under spike/strawberry_poc/** so it
+# doesn't slow PRs that touch only legacy graphql_api code. Legacy CI
+# (run-tests-on-pull-request.yaml) is unaffected.
+name: Strawberry POC Tests
+
+on:
+  pull_request:
+    branches: [deploy-test, main]
+    paths:
+      - 'spike/strawberry_poc/**'
+      - '.github/workflows/strawberry-poc-tests.yaml'
+  push:
+    branches:
+      - chore/strawberry-fields
+    paths:
+      - 'spike/strawberry_poc/**'
+      - '.github/workflows/strawberry-poc-tests.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: strawberry-poc-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  call-test-workflow:
+    uses: GNS-Science/nshm-github-actions/.github/workflows/python-run-tests-uv.yml@main
+    with:
+      operating-systems: "['ubuntu-latest']"
+      python-versions: "['3.12']"
+      working-directory: spike/strawberry_poc
+      optional-dependency-groups: dev
+      timeout-minutes: 20
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+junit.xml
 *.cover
 *.py,cover
 .hypothesis/


### PR DESCRIPTION
## Summary

Delegates to the GNS-Science/nshm-github-actions shared workflow (`python-run-tests-uv.yml`), matching the convention used by the legacy `run-tests-on-pull-request.yaml`. Path-filtered to `spike/strawberry_poc/**` so it doesn't run on legacy-only PRs; concurrency-cancelled on superseded pushes; triggers on PRs to `deploy-test` or `main`.

The shared workflow handles:
- `uv` install via the org's `python-install-uv` composite action
- `tox` orchestration (driven by `spike/strawberry_poc/setup.cfg`)
- Codecov upload on the first Python/Linux matrix combo
- Slack alerts on scheduled-build failures (the `cwg-scheduled-builds` channel)

Also adds `junit.xml` to `.gitignore` (tox writes it locally).

## Test plan

- [x] Verified against `chore/strawberry-fields` push events — green in 1m07s including testcontainers startup
- [x] `uv run tox` locally — 151 passed, 1 skipped in ~24s
- [x] Coverage XML written; Codecov submission step succeeded
- [ ] First PR-triggered run after merge

## Stacking

Targets `strawberry-poc-spike` while #296 is in review. After #296 merges to `deploy-test`, this PR will be retargeted to `deploy-test`.

**Depends on:** #296 (the spike's `setup.cfg` is what drives the shared workflow's tox step).