### PR TITLE
fix: port File.relations compression to Strawberry POC for legacy parity

### DIFF
--- a/spike/strawberry_poc/COVERAGE_GAPS.md
+++ b/spike/strawberry_poc/COVERAGE_GAPS.md
@@ -23,7 +23,7 @@ Legend: ✅ Full coverage  ⚠️ Partial coverage  ❌ Not yet ported  N/A (inf
 | `test_sms_file_link_schema.py` | 2 | `test_sms_file.py` + `test_smoketest_ab.py` | 4+partial | ⚠️ |
 | `test_task_task_relations_db.py` | 1 | `test_general_task.py` + `test_smoketest_ab.py` | — | ⚠️ |
 | `test_file_relation_bugfix_126.py` | 5 | `test_file_relation.py` | 3 | ⚠️ |
-| `test_file_relation_compression.py` | 3 | — | — | ❌ |
+| `test_file_relation_compression.py` | 3 | — | — | ❌ (High — see Gap 6) |
 | `test_nodes_bugfix_220.py` | 3 | `test_inversion_solution.py` (partial) | — | ⚠️ |
 | `test_general_task_bugfix_29.py` | 1 | `test_general_task.py` | — | ⚠️ |
 | `test_general_task_bugfix_217.py` | 1 | — | — | ❌ |
@@ -346,7 +346,7 @@ Legend: ✅ Full coverage  ⚠️ Partial coverage  ❌ Not yet ported  N/A (inf
 | Field: `file_id` | Yes | Yes | Yes | implicit |
 | Field: `file` (resolved) | Yes | Yes | Yes | Yes |
 | Field: `thing` (resolved) | Yes | Yes | Yes | Yes |
-| Relation compression (large relation lists) | Yes | Yes (3 tests) | **No** | No |
+| Relation compression (>100 relations stored as compressed string) | Yes | Yes (3 tests) | **No — High-severity gap** | No |
 
 ### TaskTaskRelation
 
@@ -401,8 +401,14 @@ Legend: ✅ Full coverage  ⚠️ Partial coverage  ❌ Not yet ported  N/A (inf
 
 - **Legacy file:** `test_file_relation_compression.py` — 3 tests: counting relations in a 390k-relation scenario; adding with compression; round-trip with compression
 - **What it exercises:** That the data layer compresses and decompresses large `relations` lists stored in DynamoDB
-- **Closest POC equivalent:** None — the POC stores relations differently (as normalised DynamoDB items) and does not need compression; this gap may be intentionally N/A in the POC architecture
-- **Gap severity:** **Low** — only relevant for legacy data migration; POC uses a different storage model
+- **Storage shape (corrected from earlier analysis):** Both legacy and POC store relations as an embedded array under `ToshiFileObject.object_content.relations`. The POC's storage shape is **identical** to legacy — only the compression behaviour differs.
+- **POC behaviour:** No compression on write (`data/dynamo.py` `_patch_file` appends unconditionally). No decompression on read (`get_file` returns `object_content` as-is). Pydantic `ToshiFileData.relations` is typed as `list[dict] | None`; a compressed-string value would fail validation.
+- **Concrete bugs this introduces in the POC:**
+  1. **Read failure on legacy data.** Any production File with >100 relations is currently stored as a base64-encoded zlib string (`compress_string(json.dumps(relations))`). The POC's `from_dict` will fail Pydantic validation on those rows, propagating as "Unexpected error" on every field of the affected node — same failure mode as the production GeneralTask incident, but for any RuptureSet that's been used by many tasks.
+  2. **Write failure at DynamoDB's 400KB item limit.** Without compression, a list of `{"id": "...", "role": "read"}` entries (~40 bytes each in JSON) hits the limit at roughly 10,000 entries. Legacy fits ~80,000 in the same space via compression. Files aggregating many tasks (RuptureSets in active inversion pipelines) will fail `put_item` with `ValidationException`.
+- **Closest POC equivalent:** None — needs implementation.
+- **Fix shape:** Port `nzshm_common.util.compress_string` / `decompress_string` calls; ~30 lines in `data/dynamo.py` (read-side `_ensure_decompressed` in `get_file`/`list_files`, write-side threshold check in `create_file_relation`).
+- **Gap severity:** **High** — this is required for read interoperability with production data, not just for archival migration. Was previously misclassified as Low/N/A.
 
 ### Gap 7: S3 fallback and DynamoDB + S3 combined queries
 
@@ -595,24 +601,21 @@ Fields present in legacy schema but absent or different in POC model classes.
 
 ## 6. Priorities for New POC Tests
 
-The following gaps represent the highest-value work to close, ordered by severity:
+The following gaps represent the highest-value work to close, ordered by severity.
 
-1. **`update_automation_task` mutation** — add the mutation to `schema.py` and create `tests/test_automation_task.py` covering state/result/duration/metrics update and ES re-indexing.
+### Closed in this round (PRs #296–#298)
 
-2. **`nodes(id_in: [...])` with deep interface expansion** — add a test that fetches a `ScaledInversionSolution` through `nodes`, expands `InversionSolutionInterface.produced_by`, then expands `AutomationTaskInterface.parents` to retrieve the parent `GeneralTask`. This directly mirrors the weka client query pattern from `test_nodes_bugfix_220.py`.
+1. ~~**`update_automation_task` mutation**~~ — done. Resolver + payload type wired in `schema.py`; `tests/test_automation_task.py` covers create + update + ES re-index monkeypatch.
+2. ~~**`nodes(id_in: [...])` with deep interface expansion**~~ — done. `tests/test_nodes_query.py` mirrors the weka batch traversal pattern (ScaledIS → produced_by → AutomationTask → parents → GeneralTask).
+3. ~~**`InversionSolutionNrml` test file**~~ — done. `tests/test_inversion_solution_nrml.py`: 6 tests covering all three source types + predecessors.
+4. ~~**DISAGG task type**~~ — done. New fixture in `tests/test_openquake.py`.
+5. ~~**JSON logic tree round-trips**~~ — done.
+6. ~~**`OpenquakeHazardSolution` archives**~~ — done.
+7. ~~**Table `name` field**~~ — done.
+8. ~~**`create_file` type coercion**~~ — done; BigInt scalar landed in `models/common.py` so >2GB file_size values now round-trip correctly.
+9. **Rupture set upload / `post_url`** — schema-level test only (post_url returns null in POC; real S3 wiring deferred).
+10. ~~**`update_automation_task` ES re-indexing**~~ — done; automatic via existing `update_thing` → `index_document` path, asserted via monkeypatch in test.
 
-3. **`InversionSolutionNrml` test file** — create `tests/test_inversion_solution_nrml.py` covering: create from IS, ScaledIS, TDIS; with predecessors; node lookup; verify `source_solution` union resolution.
+### Open — needs a follow-up PR
 
-4. **DISAGG task type** — add test for `create_openquake_hazard_task` with `task_type: DISAGG` to `test_openquake.py`.
-
-5. **`srm_logic_tree` / `gmcm_logic_tree` / `openquake_config` JSON round-trip** — extend `test_openquake.py` to set and verify these fields.
-
-6. **`OpenquakeHazardSolution` full fields** — extend `test_openquake.py` to test `csv_archive`, `hdf5_archive`, `task_args`, and predecessors.
-
-7. **Table `name` field** — add `name` to `CreateTableInput` and `Table` model, then add test.
-
-8. **`create_file` type coercion** — add a test asserting `file_size` accepts integer values and rejects non-numeric strings.
-
-9. **Rupture set upload / `post_url`** — if S3 integration is in scope, add a presigned URL test.
-
-10. **`update_automation_task` ES re-indexing** — verify the updated document body is sent to ES (mirrors `test_automation_task_mutation_deep.py`).
+11. **File relation compression (Gap 6)** — High severity (re-categorised from earlier "Low/N/A" misanalysis). Port `nzshm_common.util.compress_string` / `decompress_string` calls into `data/dynamo.py`. Two failure modes today: (a) the POC's Pydantic validation crashes on legacy compressed-string rows; (b) without compression on write, files with >~10,000 relations hit DynamoDB's 400KB item limit (legacy fits ~80,000 via compression). See Gap 6 detail above for exact patch shape.

--- a/spike/strawberry_poc/data/dynamo.py
+++ b/spike/strawberry_poc/data/dynamo.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import boto3
 from botocore.exceptions import ClientError
+from nzshm_common.util import compress_string, decompress_string
 
 from .ids import append_uniq, read_current_id
 from .search import index_document
@@ -29,10 +30,38 @@ REGION = os.environ.get("REGION", "ap-southeast-2")
 S3_BUCKET_NAME = os.environ.get("S3_BUCKET_NAME", "")
 DB_READ_ONLY = os.environ.get("DB_READ_ONLY", "") not in ("", "0")
 
+# Matches graphql_api/data/file_relation_data.py — when a File's relations list
+# grows beyond this, the legacy stores it as a base64-encoded zlib string to
+# stay under DynamoDB's 400KB item-size limit. The POC must use the same value
+# (and the same compress_string/decompress_string from nzshm_common) so that
+# data written by either side is readable by the other.
+UNCOMPRESSED_LIMIT = 100
+
 
 def _assert_writable() -> None:
     if DB_READ_ONLY:
         raise RuntimeError("Aborting write: DB_READ_ONLY is set")
+
+
+def _ensure_decompressed(maybe: str | list | None) -> list:
+    """Decompress a File.relations field that may be stored as a string.
+
+    Legacy storage: relations is a list[dict] for small lists, or a
+    compressed string once len(relations) > UNCOMPRESSED_LIMIT. Always
+    returns a list (empty list if None).
+    """
+    if maybe is None:
+        return []
+    if isinstance(maybe, str):
+        return json.loads(decompress_string(maybe))
+    return maybe
+
+
+def _decompress_file_relations(data: dict | None) -> dict | None:
+    """In-place normalise a file dict so callers always see relations as list[dict]."""
+    if data is not None and "relations" in data:
+        data["relations"] = _ensure_decompressed(data["relations"])
+    return data
 
 
 def _dynamodb(endpoint_url: str | None = None):
@@ -263,10 +292,11 @@ def get_file(dynamodb, object_id: str, stage: str = STAGE) -> dict | None:
     if item:
         data = json.loads(item["object_content"])
         data["object_id"] = object_id
-        return data
+        return _decompress_file_relations(data)
     data = _from_s3(object_id, "FileData")
     if data is not None:
         data["object_id"] = object_id
+        _decompress_file_relations(data)
     return data
 
 
@@ -293,7 +323,7 @@ def list_files(dynamodb, clazz_name: str, stage: str = STAGE) -> list[dict]:
         for item in resp.get("Items", []):
             data = json.loads(item["object_content"])
             data["object_id"] = item["object_id"]
-            results.append(data)
+            results.append(_decompress_file_relations(data))
         last = resp.get("LastEvaluatedKey")
         if not last:
             break
@@ -444,13 +474,24 @@ def create_file_relation(dynamodb, thing_id: str, file_id: str, role: str, stage
 
     Thing.files  → [..., {"file_id": file_id, "file_role": role}]
     File.relations → [..., {"id": thing_id, "role": role}]
+
+    When the file's relations list grows beyond UNCOMPRESSED_LIMIT, it is
+    stored as a compressed string — matches the legacy storage format so
+    data written here is readable by the legacy API and vice versa.
     """
+
+    def _append_file_relation(d: dict) -> None:
+        rels = _ensure_decompressed(d.get("relations"))
+        rels.append({"id": thing_id, "role": role})
+        if len(rels) > UNCOMPRESSED_LIMIT:
+            d["relations"] = compress_string(json.dumps(rels))
+        else:
+            d["relations"] = rels
+
     _patch_thing(
         dynamodb, thing_id, lambda d: d.setdefault("files", []).append({"file_id": file_id, "file_role": role}), stage
     )
-    _patch_file(
-        dynamodb, file_id, lambda d: d.setdefault("relations", []).append({"id": thing_id, "role": role}), stage
-    )
+    _patch_file(dynamodb, file_id, _append_file_relation, stage)
     thing_data = get_thing(dynamodb, thing_id, stage)
     if thing_data:
         index_document(f"ThingData_{thing_id}", thing_data)

--- a/spike/strawberry_poc/pyproject.toml
+++ b/spike/strawberry_poc/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "strawberry-graphql[fastapi]>=0.243.0",
     "boto3>=1.26",
     "mangum>=0.17",
+    "nzshm-common>=0.9.0",
     "pydantic>=2.0",
     "python-dotenv>=1.0",
     "requests>=2.28",

--- a/spike/strawberry_poc/tests/test_file_relation_compression.py
+++ b/spike/strawberry_poc/tests/test_file_relation_compression.py
@@ -1,0 +1,303 @@
+"""
+Tests for File.relations compression behaviour.
+
+Mirrors graphql_api/tests/test_file_relation_compression.py — when the
+relations list crosses UNCOMPRESSED_LIMIT entries, the data layer stores
+it as a compressed string instead of a JSON list. The same nzshm_common
+compress_string is used so this format is byte-compatible with the
+legacy production data layer.
+
+Covers COVERAGE_GAPS.md gap 6 (re-categorised from "Low/N/A" to "High"
+once we noticed that the POC would crash on legacy compressed rows and
+would hit DynamoDB's 400KB item limit at ~10k uncompressed relations).
+"""
+
+import base64
+import json
+
+import pytest
+from nzshm_common.util import compress_string, decompress_string
+
+from data import dynamo
+from schema import schema
+
+
+CREATE_AT_MUTATION = """
+mutation CreateTask($input: CreateAutomationTaskInput!) {
+    create_automation_task(input: $input) {
+        task_result { id }
+    }
+}
+"""
+
+CREATE_FILE_MUTATION = """
+mutation CreateFile($input: CreateFileInput!) {
+    create_file(input: $input) {
+        ok
+        file_result { id file_name }
+    }
+}
+"""
+
+CREATE_FILE_RELATION_MUTATION = """
+mutation CreateFileRelation($input: CreateFileRelationInput!) {
+    create_file_relation(input: $input) { ok }
+}
+"""
+
+FILE_WITH_RELATIONS_QUERY = """
+query GetFile($id: ID!) {
+    node(id: $id) {
+        ... on ToshiFile {
+            id
+            file_name
+            relations {
+                total_count
+                edges {
+                    node {
+                        role
+                        thing {
+                            ... on AutomationTask { id }
+                            ... on GeneralTask { id }
+                            ... on RuptureGenerationTask { id }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+
+@pytest.fixture
+def lower_threshold(monkeypatch):
+    """Drop UNCOMPRESSED_LIMIT to 25 so threshold-crossing tests run fast."""
+    monkeypatch.setattr(dynamo, "UNCOMPRESSED_LIMIT", 25)
+    return 25
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+def test_helper_round_trip():
+    """_ensure_decompressed accepts both list and compressed-string forms."""
+    relations = [{"id": f"100000abc{i:03d}", "role": "read"} for i in range(150)]
+    compressed = compress_string(json.dumps(relations))
+    assert isinstance(compressed, str)
+
+    assert dynamo._ensure_decompressed(relations) == relations
+    assert dynamo._ensure_decompressed(compressed) == relations
+    assert dynamo._ensure_decompressed(None) == []
+
+
+def test_relations_stored_as_list_under_threshold(gql_context, lower_threshold):
+    """At <UNCOMPRESSED_LIMIT relations, storage stays as a JSON list."""
+    file_result = schema.execute_sync(
+        CREATE_FILE_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "compression_under.zip",
+                "md5_digest": "00aa",
+                "file_size": 1024,
+                "created": "2024-07-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert file_result.errors is None, file_result.errors
+    file_gid = file_result.data["create_file"]["file_result"]["id"]
+    file_raw_id = base64.b64decode(file_gid).decode().split(":")[1]
+
+    # Add 5 relations — well below the lowered threshold of 25.
+    for i in range(5):
+        at = schema.execute_sync(
+            CREATE_AT_MUTATION,
+            variable_values={
+                "input": {
+                    "state": "DONE",
+                    "result": "SUCCESS",
+                    "task_type": "INVERSION",
+                    "created": "2024-07-01T00:00:00Z",
+                }
+            },
+            context_value=gql_context,
+        )
+        assert at.errors is None, at.errors
+        thing_gid = at.data["create_automation_task"]["task_result"]["id"]
+        rel = schema.execute_sync(
+            CREATE_FILE_RELATION_MUTATION,
+            variable_values={
+                "input": {"thing_id": thing_gid, "file_id": file_gid, "role": "READ"}
+            },
+            context_value=gql_context,
+        )
+        assert rel.errors is None, rel.errors
+
+    raw = gql_context["dynamodb"].Table("ToshiFileObject-TEST").get_item(Key={"object_id": file_raw_id})["Item"]
+    stored = json.loads(raw["object_content"])
+    assert isinstance(stored["relations"], list)
+    assert len(stored["relations"]) == 5
+
+
+def test_relations_compressed_above_threshold(gql_context, lower_threshold):
+    """Crossing UNCOMPRESSED_LIMIT switches storage to compressed-string form."""
+    file_result = schema.execute_sync(
+        CREATE_FILE_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "compression_over.zip",
+                "md5_digest": "01bb",
+                "file_size": 1024,
+                "created": "2024-07-02T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert file_result.errors is None, file_result.errors
+    file_gid = file_result.data["create_file"]["file_result"]["id"]
+    file_raw_id = base64.b64decode(file_gid).decode().split(":")[1]
+
+    # Add lower_threshold + 1 = 26 relations to cross the threshold.
+    for i in range(lower_threshold + 1):
+        at = schema.execute_sync(
+            CREATE_AT_MUTATION,
+            variable_values={
+                "input": {
+                    "state": "DONE",
+                    "result": "SUCCESS",
+                    "task_type": "INVERSION",
+                    "created": "2024-07-02T00:00:00Z",
+                }
+            },
+            context_value=gql_context,
+        )
+        assert at.errors is None, at.errors
+        thing_gid = at.data["create_automation_task"]["task_result"]["id"]
+        rel = schema.execute_sync(
+            CREATE_FILE_RELATION_MUTATION,
+            variable_values={
+                "input": {"thing_id": thing_gid, "file_id": file_gid, "role": "READ"}
+            },
+            context_value=gql_context,
+        )
+        assert rel.errors is None, rel.errors
+
+    raw = gql_context["dynamodb"].Table("ToshiFileObject-TEST").get_item(Key={"object_id": file_raw_id})["Item"]
+    stored = json.loads(raw["object_content"])
+    assert isinstance(stored["relations"], str), (
+        f"expected compressed-string storage above threshold, got {type(stored['relations']).__name__}"
+    )
+    # The compressed payload round-trips back to the full list.
+    decompressed = json.loads(decompress_string(stored["relations"]))
+    assert len(decompressed) == lower_threshold + 1
+
+
+def test_relations_round_trip_through_graphql(gql_context, lower_threshold):
+    """Query node(id:) on a file with compressed relations returns full count + edges."""
+    file_result = schema.execute_sync(
+        CREATE_FILE_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "compression_roundtrip.zip",
+                "md5_digest": "02cc",
+                "file_size": 1024,
+                "created": "2024-07-03T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert file_result.errors is None, file_result.errors
+    file_gid = file_result.data["create_file"]["file_result"]["id"]
+
+    thing_gids = []
+    for i in range(lower_threshold + 5):  # 30 relations, well above threshold
+        at = schema.execute_sync(
+            CREATE_AT_MUTATION,
+            variable_values={
+                "input": {
+                    "state": "DONE",
+                    "result": "SUCCESS",
+                    "task_type": "INVERSION",
+                    "created": "2024-07-03T00:00:00Z",
+                }
+            },
+            context_value=gql_context,
+        )
+        assert at.errors is None, at.errors
+        thing_gid = at.data["create_automation_task"]["task_result"]["id"]
+        thing_gids.append(thing_gid)
+        rel = schema.execute_sync(
+            CREATE_FILE_RELATION_MUTATION,
+            variable_values={
+                "input": {"thing_id": thing_gid, "file_id": file_gid, "role": "READ"}
+            },
+            context_value=gql_context,
+        )
+        assert rel.errors is None, rel.errors
+
+    # Query the file — node lookup should decompress transparently.
+    result = schema.execute_sync(
+        FILE_WITH_RELATIONS_QUERY, variable_values={"id": file_gid}, context_value=gql_context
+    )
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["file_name"] == "compression_roundtrip.zip"
+    assert node["relations"]["total_count"] == lower_threshold + 5
+
+    returned_thing_ids = {edge["node"]["thing"]["id"] for edge in node["relations"]["edges"]}
+    assert returned_thing_ids == set(thing_gids)
+
+
+def test_pre_compressed_legacy_data_reads_correctly(gql_context):
+    """A pre-existing file with relations already stored as a compressed string
+    (e.g. read from legacy production DynamoDB) must round-trip through node lookup."""
+    file_result = schema.execute_sync(
+        CREATE_FILE_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "legacy_compressed.zip",
+                "md5_digest": "03dd",
+                "file_size": 1024,
+                "created": "2024-07-04T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert file_result.errors is None, file_result.errors
+    file_gid = file_result.data["create_file"]["file_result"]["id"]
+    file_raw_id = base64.b64decode(file_gid).decode().split(":")[1]
+
+    # Directly write a compressed-string relations field — bypassing the mutation
+    # so we exercise the read-side decompression in isolation.
+    table = gql_context["dynamodb"].Table("ToshiFileObject-TEST")
+    item = table.get_item(Key={"object_id": file_raw_id})["Item"]
+    content = json.loads(item["object_content"])
+    fake_relations = [{"id": f"10000{i:03d}xyz", "role": "read"} for i in range(60)]
+    content["relations"] = compress_string(json.dumps(fake_relations))
+    table.put_item(
+        Item={
+            "object_id": file_raw_id,
+            "object_type": item["object_type"],
+            "object_content": json.dumps(content),
+        }
+    )
+
+    # Read it back via the standard get_file path used by node lookup.
+    data = dynamo.get_file(gql_context["dynamodb"], file_raw_id)
+    assert isinstance(data["relations"], list), (
+        f"get_file must decompress legacy compressed-string rows; got {type(data['relations']).__name__}"
+    )
+    assert len(data["relations"]) == 60
+
+
+def test_80k_relations_fit_under_dynamodb_limit():
+    """Ceiling check: legacy depends on 80k relations compressing under 390KB.
+    This guards against any future change to compress_string semantics (e.g.
+    swapping compression algo) that would silently shrink the headroom."""
+    relations = [{"id": f"{100_000 + i:09d}", "role": "read"} for i in range(80_000)]
+    compressed = compress_string(json.dumps(relations))
+    assert len(compressed) < 390_000, (
+        f"compressed 80k relations = {len(compressed)} bytes; expected <390KB to "
+        f"stay under DynamoDB's 400KB item-size limit"
+    )

--- a/spike/strawberry_poc/uv.lock
+++ b/spike/strawberry_poc/uv.lock
@@ -548,6 +548,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nzshm-common"
+version = "0.9.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/cc/ad2063f93335d2ef19099adbb8032870e9420c2be4616056066a835029f3/nzshm_common-0.9.4.tar.gz", hash = "sha256:5f985f4e76fbe36bbaa5987b1bd08ecdc1b2183e4e023f279b1db6b2b3dd877c", size = 269324, upload-time = "2026-03-30T22:45:43.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/a0/215dac876966fbf9d7cf216b9e3b6be4ae82e8e3889cc0be59e52b6c7239/nzshm_common-0.9.4-py3-none-any.whl", hash = "sha256:d2d18df08d7ed58b6922b653c7321907de46e1c5d59c77df7d4d3ba4c95d9175", size = 289751, upload-time = "2026-03-30T22:45:41.798Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.1"
 source = { registry = "https://pypi.org/simple" }
@@ -861,6 +870,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "boto3" },
     { name = "mangum" },
+    { name = "nzshm-common" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "requests" },
@@ -883,6 +893,7 @@ dev = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.26" },
     { name = "mangum", specifier = ">=0.17" },
+    { name = "nzshm-common", specifier = ">=0.9.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "requests", specifier = ">=2.28" },


### PR DESCRIPTION
## Summary

Closes the highest-priority gap remaining after #296 — File relation compression.

The POC stores `File.relations` in the same DynamoDB column shape as legacy (embedded array under `object_content.relations`), but did **not** replicate the compression behaviour: legacy switches storage to a base64-encoded zlib string once the list exceeds `UNCOMPRESSED_LIMIT=100`. Without that, the POC has two concrete bugs against production data:

1. **Read failure on legacy compressed rows.** Any production File with >100 relations stores the field as a string. The POC's Pydantic validation on `ToshiFileData.relations: list[dict] | None` rejects strings — propagates as \"Unexpected error\" on every field of the affected node (same failure mode as the GeneralTask enum-coercion incident that triggered the safe-enum work).

2. **Write failure at DynamoDB's 400KB item-size limit.** Without compression, a list of `{\"id\": \"...\", \"role\": \"read\"}` entries (~40 bytes each in JSON) hits the limit at ~10,000 entries. Legacy fits ~80,000 in the same space.

This PR was originally categorised as \"Low / N/A — different storage model\" in `COVERAGE_GAPS.md`. That was wrong — storage shape is identical, only compression differs. The doc has been corrected.

## Changes

- **`data/dynamo.py`**:
  - Import `compress_string` / `decompress_string` from `nzshm_common.util` — same helpers the legacy uses, so on-disk format is byte-compatible.
  - Add `UNCOMPRESSED_LIMIT = 100` (matches legacy).
  - Add `_ensure_decompressed()` helper that accepts list-or-string-or-None and always returns a list.
  - Add `_decompress_file_relations()` in-place normaliser.
  - Decompress on read in `get_file()` and `list_files()`.
  - Replace the one-line append lambda in `create_file_relation()` with `_append_file_relation` closure that decompresses → appends → re-compresses past the threshold.
- **`pyproject.toml` + `uv.lock`**: add `nzshm-common>=0.9.0` as a runtime dep.
- **`tests/test_file_relation_compression.py`** (new) — 6 tests:
  - Helper round-trip (list, compressed string, None inputs)
  - Below-threshold: stored as JSON list
  - Above-threshold: stored as compressed string; decompresses to expected list
  - Full GraphQL round-trip through `node(id:)` with `relations { total_count edges { ... } }`
  - **Pre-compressed legacy-data read path** — writes a fake legacy row directly to DynamoDB and confirms `get_file()` decompresses it transparently
  - 80,000-relation ceiling check (compressed fits under 390KB)
- **`COVERAGE_GAPS.md`**: recategorise Gap 6 from \"Low / N/A\" to High; correct the storage-shape analysis; mark closure status in the Priorities section.

## Production safety

The on-disk format is byte-compatible with legacy because:
- Same threshold (`UNCOMPRESSED_LIMIT = 100`)
- Same compression helpers (`nzshm_common.util.compress_string` — base64-encoded zlib)
- Same JSON serialisation order via `json.dumps(rels)`

Data written by legacy is readable by the POC; data written by the POC is readable by legacy. No migration required.

## Test plan

- [x] `uv run pytest tests/` — 157 passed, 1 skipped (was 151 / 1)
- [x] `uv run tox` — same
- [x] All 6 new compression tests green
- [ ] After merge, weka query against `/graphql-v2` for a known RuptureSet with hundreds of relations no longer fails

## Stacking

Targets `strawberry-poc-spike` to show clean diff. After #296 merges to `deploy-test`, this PR will be retargeted to `deploy-test`.

**Depends on:** #296.