### PR TITLE
feat: add schema parity diff tool to surface legacy/POC divergence

### DIFF
--- a/spike/strawberry_poc/tests/test_schema_parity.py
+++ b/spike/strawberry_poc/tests/test_schema_parity.py
@@ -1,0 +1,315 @@
+"""
+Tests for tools/schema_parity.py — the legacy↔POC SDL diff tool.
+
+Each "bugs caught this session" test reproduces a real schema-level
+divergence that was discovered in production / manual smoketests, and
+verifies the diff tool would have caught it earlier in CI.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tools.schema_parity import (  # noqa: E402
+    diff_schemas,
+    extract_types,
+    format_report,
+    has_any_diff,
+    main,
+)
+
+
+# ── Unit tests: extractor ─────────────────────────────────────────────────────
+
+
+def test_extract_types_picks_up_object_kind_and_fields():
+    sdl = "type Foo { id: ID! name: String }"
+    types = extract_types(sdl)
+    assert types["Foo"]["kind"] == "object"
+    assert types["Foo"]["fields"]["id"]["type"] == "ID!"
+    assert types["Foo"]["fields"]["name"]["type"] == "String"
+
+
+def test_extract_types_handles_interface_union_enum_input_scalar():
+    sdl = """
+    scalar BigInt
+    interface Node { id: ID! }
+    type Foo implements Node { id: ID! }
+    union FooOrBar = Foo | Bar
+    type Bar { id: ID! }
+    enum Color { RED GREEN BLUE }
+    input FilterInput { q: String limit: Int }
+    """
+    types = extract_types(sdl)
+    assert types["BigInt"]["kind"] == "scalar"
+    assert types["Node"]["kind"] == "interface"
+    assert types["Foo"]["interfaces"] == ["Node"]
+    assert types["FooOrBar"]["kind"] == "union"
+    assert types["FooOrBar"]["members"] == ["Bar", "Foo"]
+    assert types["Color"]["kind"] == "enum"
+    assert types["Color"]["values"] == ["BLUE", "GREEN", "RED"]
+    assert types["FilterInput"]["kind"] == "input"
+    assert types["FilterInput"]["fields"] == {"q": "String", "limit": "Int"}
+
+
+def test_extract_field_with_arguments():
+    sdl = "type Query { node(id: ID!, deep: Boolean): String }"
+    types = extract_types(sdl)
+    field = types["Query"]["fields"]["node"]
+    assert field["type"] == "String"
+    assert field["args"] == {"id": "ID!", "deep": "Boolean"}
+
+
+# ── Unit tests: diff primitives ───────────────────────────────────────────────
+
+
+def test_diff_detects_type_only_in_legacy():
+    legacy = "type Foo { id: ID! }"
+    poc = "type Bar { id: ID! }"
+    d = diff_schemas(legacy, poc)
+    assert d["types_only_in_legacy"] == ["Foo"]
+    assert d["types_only_in_poc"] == ["Bar"]
+
+
+def test_diff_detects_field_only_in_legacy():
+    legacy = "type Foo { id: ID! name: String }"
+    poc = "type Foo { id: ID! }"
+    d = diff_schemas(legacy, poc)
+    assert d["type_diffs"]["Foo"]["fields_only_in_legacy"] == ["name"]
+
+
+def test_diff_detects_field_only_in_poc():
+    legacy = "type Foo { id: ID! }"
+    poc = "type Foo { id: ID! extra: Int }"
+    d = diff_schemas(legacy, poc)
+    assert d["type_diffs"]["Foo"]["fields_only_in_poc"] == ["extra"]
+
+
+def test_diff_detects_field_type_mismatch():
+    legacy = "type Foo { size: BigInt }"
+    poc = "type Foo { size: Int }"
+    d = diff_schemas(legacy, poc)
+    assert d["type_diffs"]["Foo"]["field_type_mismatches"] == {"size": ("BigInt", "Int")}
+
+
+def test_diff_detects_kind_mismatch():
+    legacy = "type Foo { id: ID! }"
+    poc = "interface Foo { id: ID! }"
+    d = diff_schemas(legacy, poc)
+    assert d["type_diffs"]["Foo"]["kind_mismatch"] == ("object", "interface")
+
+
+def test_diff_detects_enum_value_drift():
+    legacy = "enum Color { RED GREEN BLUE }"
+    poc = "enum Color { RED GREEN }"
+    d = diff_schemas(legacy, poc)
+    assert d["type_diffs"]["Color"]["values_only_in_legacy"] == ["BLUE"]
+
+
+def test_diff_detects_union_member_drift():
+    legacy = "type A { id: ID! } type B { id: ID! } type C { id: ID! } union AB = A | B | C"
+    poc = "type A { id: ID! } type B { id: ID! } union AB = A | B"
+    d = diff_schemas(legacy, poc)
+    assert d["type_diffs"]["AB"]["members_only_in_legacy"] == ["C"]
+
+
+def test_diff_detects_argument_drift_on_field():
+    legacy = "type Query { node(id: ID!, deep: Boolean): String }"
+    poc = "type Query { node(id: ID!): String }"
+    d = diff_schemas(legacy, poc)
+    assert d["type_diffs"]["Query"]["field_arg_mismatches"]["node"]["args_only_in_legacy"] == [
+        "deep"
+    ]
+
+
+def test_diff_detects_interface_implementation_drift():
+    legacy = "interface Node { id: ID! } interface FI { fn: String } type Foo implements Node & FI { id: ID! fn: String }"
+    poc = "interface Node { id: ID! } type Foo implements Node { id: ID! fn: String }"
+    d = diff_schemas(legacy, poc)
+    assert d["type_diffs"]["Foo"]["interfaces_only_in_legacy"] == ["FI"]
+
+
+def test_diff_input_field_type_mismatch():
+    legacy = "input CreateInput { file_size: BigInt }"
+    poc = "input CreateInput { file_size: Int }"
+    d = diff_schemas(legacy, poc)
+    assert d["type_diffs"]["CreateInput"]["field_type_mismatches"] == {
+        "file_size": ("BigInt", "Int")
+    }
+
+
+def test_identical_schemas_produce_empty_diff():
+    sdl = "type Foo { id: ID! } enum Color { RED }"
+    d = diff_schemas(sdl, sdl)
+    assert d == {"types_only_in_legacy": [], "types_only_in_poc": [], "type_diffs": {}}
+    assert not has_any_diff(d)
+
+
+# ── Bugs this tool would have caught this session ─────────────────────────────
+
+
+@pytest.fixture
+def legacy_minimal():
+    """SDL fragment matching key legacy-schema declarations that the POC
+    must mirror. Each field/type below corresponds to a real production
+    issue we hit during the migration."""
+    return """
+        scalar BigInt
+        type ToshiFile { id: ID! file_name: String file_size: BigInt }
+        type GeneralTask {
+          id: ID!
+          title: String
+          subtask_result: EventResult
+          children(first: Int): TaskTaskRelationConnection
+        }
+        type TaskTaskRelationConnection {
+          total_count: Int
+          edges: [TaskTaskRelationEdge]
+        }
+        type TaskTaskRelationEdge { node: TaskTaskRelation }
+        type TaskTaskRelation { parent: GeneralTask }
+        type Mutation {
+          update_automation_task(input: UpdateAutomationTaskInput!): UpdateAutomationTaskPayload
+        }
+        input UpdateAutomationTaskInput { task_id: ID! }
+        type UpdateAutomationTaskPayload { task_result: AutomationTask }
+        type AutomationTask { id: ID! }
+        enum EventResult { SUCCESS FAILURE PARTIAL UNDEFINED }
+        enum TaskSubType {
+          INVERSION
+          HAZARD
+          DISAGG
+          SCALE_SOLUTION
+        }
+    """
+
+
+def test_catches_toshifile_to_file_rename(legacy_minimal):
+    """Legacy has `ToshiFile`, an earlier POC iteration registered it as `File`.
+    The diff must surface ToshiFile in legacy_only and File in poc_only."""
+    poc = """
+        type File { id: ID! file_name: String file_size: BigInt }
+        type GeneralTask { id: ID! }
+        scalar BigInt
+    """
+    d = diff_schemas(legacy_minimal, poc)
+    assert "ToshiFile" in d["types_only_in_legacy"]
+    assert "File" in d["types_only_in_poc"]
+
+
+def test_catches_missing_update_automation_task_mutation(legacy_minimal):
+    """Legacy defines `update_automation_task`; an earlier POC didn't wire it."""
+    poc = """
+        type Mutation { create_automation_task(input: ID!): String }
+        type ToshiFile { id: ID! }
+        type GeneralTask { id: ID! }
+        scalar BigInt
+    """
+    d = diff_schemas(legacy_minimal, poc)
+    mutation_diff = d["type_diffs"]["Mutation"]
+    assert "update_automation_task" in mutation_diff["fields_only_in_legacy"]
+
+
+def test_catches_subtask_result_missing_from_general_task(legacy_minimal):
+    """Production crashed because GeneralTask.subtask_result was missing in POC."""
+    poc = """
+        type GeneralTask { id: ID! title: String }
+        type ToshiFile { id: ID! }
+        scalar BigInt
+    """
+    d = diff_schemas(legacy_minimal, poc)
+    assert "subtask_result" in d["type_diffs"]["GeneralTask"]["fields_only_in_legacy"]
+
+
+def test_catches_file_size_int_vs_bigint_mismatch():
+    """The POC originally typed file_size as Int (32-bit), legacy uses BigInt.
+    Production values >2GB silently failed validation."""
+    legacy = "type ToshiFile { id: ID! file_size: BigInt }"
+    poc = "type ToshiFile { id: ID! file_size: Int }"
+    d = diff_schemas(legacy, poc)
+    assert d["type_diffs"]["ToshiFile"]["field_type_mismatches"] == {
+        "file_size": ("BigInt", "Int")
+    }
+
+
+def test_catches_missing_total_count_on_connection(legacy_minimal):
+    """relay.ListConnection in POC didn't expose total_count until we added the
+    custom connection subclass with override. The diff surfaces it as a missing field."""
+    poc = """
+        type TaskTaskRelationConnection { edges: [TaskTaskRelationEdge] }
+        type TaskTaskRelationEdge { node: TaskTaskRelation }
+        type TaskTaskRelation { parent: GeneralTask }
+        type GeneralTask { id: ID! }
+        type ToshiFile { id: ID! }
+        scalar BigInt
+    """
+    d = diff_schemas(legacy_minimal, poc)
+    assert "total_count" in d["type_diffs"]["TaskTaskRelationConnection"]["fields_only_in_legacy"]
+
+
+def test_catches_disagg_enum_value_missing(legacy_minimal):
+    """POC initially only tested HAZARD task_type. Missing DISAGG would be a real
+    enum-value gap caught by the diff."""
+    poc = """
+        enum TaskSubType { INVERSION HAZARD SCALE_SOLUTION }
+        type ToshiFile { id: ID! }
+        type GeneralTask { id: ID! }
+        scalar BigInt
+    """
+    d = diff_schemas(legacy_minimal, poc)
+    assert "DISAGG" in d["type_diffs"]["TaskSubType"]["values_only_in_legacy"]
+
+
+# ── Format + CLI smoke tests ──────────────────────────────────────────────────
+
+
+def test_format_report_handles_empty_diff():
+    sdl = "type Foo { id: ID! }"
+    text = format_report(diff_schemas(sdl, sdl))
+    assert "full parity" in text
+
+
+def test_format_report_includes_all_categories(legacy_minimal):
+    poc = """
+        type File { id: ID! }
+        type GeneralTask { id: ID! file_size: Int }
+        scalar BigInt
+    """
+    text = format_report(diff_schemas(legacy_minimal, poc))
+    assert "Types in legacy but not in POC" in text
+    assert "Types in POC but not in legacy" in text
+    assert "Per-type differences" in text
+
+
+def test_cli_self_diff_returns_zero(tmp_path):
+    sdl = tmp_path / "schema.sdl"
+    sdl.write_text("type Foo { id: ID! }")
+    exit_code = main([str(sdl), str(sdl), "--fail-on-diff"])
+    assert exit_code == 0
+
+
+def test_cli_fail_on_diff_returns_one(tmp_path, capsys):
+    a = tmp_path / "a.sdl"
+    b = tmp_path / "b.sdl"
+    a.write_text("type Foo { id: ID! }")
+    b.write_text("type Bar { id: ID! }")
+    exit_code = main([str(a), str(b), "--fail-on-diff"])
+    assert exit_code == 1
+
+
+def test_cli_json_format(tmp_path, capsys):
+    a = tmp_path / "a.sdl"
+    b = tmp_path / "b.sdl"
+    a.write_text("type Foo { id: ID! }")
+    b.write_text("type Bar { id: ID! }")
+    exit_code = main([str(a), str(b), "--format", "json"])
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert "Foo" in parsed["types_only_in_legacy"]
+    assert "Bar" in parsed["types_only_in_poc"]
+    # Without --fail-on-diff, exit is 0 even with divergences
+    assert exit_code == 0

--- a/spike/strawberry_poc/tools/README.md
+++ b/spike/strawberry_poc/tools/README.md
@@ -1,0 +1,60 @@
+# Tools
+
+## `schema_parity.py` — legacy ↔ POC SDL diff
+
+Catches schema-level divergences between the legacy Graphene/Flask API
+and the Strawberry/FastAPI POC. Designed to surface the class of bugs
+that hit production this session before they ship:
+
+- Types missing on one side (e.g. `ToshiFile` renamed to `File`)
+- Fields missing on one side (e.g. `GeneralTask.subtask_result`)
+- Field type mismatches (e.g. `file_size: BigInt` vs `Int`)
+- Mutations missing on one side (e.g. `update_automation_task`)
+- Enum value drift (e.g. `DISAGG` task type)
+- Union member drift
+
+### Usage
+
+Step 1 — dump the POC SDL (run from `spike/strawberry_poc/`):
+
+```bash
+uv run python tools/dump_poc_sdl.py > /tmp/poc.sdl
+```
+
+Step 2 — dump the legacy SDL (run from repo root, in the legacy venv):
+
+```bash
+uv run python -c "
+from graphql.utilities import print_schema
+from graphql_api.schema import root_schema
+print(print_schema(root_schema.graphql_schema))
+" > /tmp/legacy.sdl
+```
+
+Step 3 — diff:
+
+```bash
+uv run python tools/schema_parity.py /tmp/legacy.sdl /tmp/poc.sdl
+```
+
+For CI usage, add `--fail-on-diff` to exit 1 when any divergence is
+found. For machine-readable output use `--format json`.
+
+### Allowlisting intentional divergences
+
+The tool is deliberately allow-list-free in this first version. The
+report is meant to be read by humans, who decide which divergences are
+intentional (e.g. POC adds `BigInt` scalar, drops some legacy-only
+bugfix-test types) and which are accidental regressions.
+
+When the divergence set stabilises, a future iteration can add a YAML
+allowlist file (`expected_diffs.yaml`) that the tool subtracts from the
+diff before checking `--fail-on-diff`.
+
+### Why SDL rather than introspection JSON
+
+Both Graphene's `print_schema` and Strawberry's `schema.as_str()` emit
+the same standard SDL format, so the diff is symmetric and doesn't care
+which framework produced the schema. The tool uses `graphql-core`'s
+parser (already a transitive dep via `strawberry-graphql`) to turn each
+SDL into a structural dict before diffing.

--- a/spike/strawberry_poc/tools/dump_poc_sdl.py
+++ b/spike/strawberry_poc/tools/dump_poc_sdl.py
@@ -1,0 +1,25 @@
+"""Dump the Strawberry POC SDL to stdout.
+
+Usage (from spike/strawberry_poc/):
+    uv run python tools/dump_poc_sdl.py > poc.sdl
+"""
+
+import sys
+from pathlib import Path
+
+# Make spike/strawberry_poc/ importable when invoked as `python tools/dump_poc_sdl.py`
+# from the spike root. pytest config does this via pythonpath but a bare python
+# call doesn't pick that up.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from schema import schema  # noqa: E402
+
+
+def main() -> int:
+    sys.stdout.write(schema.as_str())
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/spike/strawberry_poc/tools/schema_parity.py
+++ b/spike/strawberry_poc/tools/schema_parity.py
@@ -1,0 +1,357 @@
+"""
+Schema parity diff — compare two GraphQL schemas at the SDL level.
+
+Designed to catch the exact class of bugs that surfaced this session:
+  - Types missing from one side (e.g. ToshiFile renamed to File)
+  - Fields missing from one side (e.g. GeneralTask.subtask_result)
+  - Field type mismatches (e.g. file_size: BigInt vs Int)
+  - Mutations missing from one side (e.g. update_automation_task)
+  - Enum value drift (e.g. DISAGG task type)
+  - Union member drift
+
+Inputs are two SDL strings (or files). Output is a structured diff dict
+plus a markdown report. Designed for CI: `--fail-on-diff` exits 1 when
+unexpected divergence is found, so a workflow step can gate merges.
+
+Implementation uses graphql-core's parser (already a transitive dep via
+strawberry-graphql) rather than the introspection JSON because SDL is
+the canonical comparable representation and works for any schema that
+can emit SDL — both Graphene (`print_schema(root_schema)`) and
+Strawberry (`schema.as_str()`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from graphql.language import parse
+from graphql.language.ast import (
+    DocumentNode,
+    EnumTypeDefinitionNode,
+    FieldDefinitionNode,
+    InputObjectTypeDefinitionNode,
+    InputValueDefinitionNode,
+    InterfaceTypeDefinitionNode,
+    ListTypeNode,
+    NamedTypeNode,
+    NonNullTypeNode,
+    ObjectTypeDefinitionNode,
+    ScalarTypeDefinitionNode,
+    UnionTypeDefinitionNode,
+)
+
+
+def _type_to_str(node) -> str:
+    """Render a type AST node back to SDL form (e.g. '[String!]!')."""
+    if isinstance(node, NonNullTypeNode):
+        return f"{_type_to_str(node.type)}!"
+    if isinstance(node, ListTypeNode):
+        return f"[{_type_to_str(node.type)}]"
+    if isinstance(node, NamedTypeNode):
+        return node.name.value
+    return str(node)
+
+
+def _args_to_dict(field: FieldDefinitionNode) -> dict[str, str]:
+    """{arg_name: rendered_type} for a field's arguments."""
+    return {a.name.value: _type_to_str(a.type) for a in field.arguments}
+
+
+def _fields_to_dict(field_defs) -> dict[str, dict]:
+    """{field_name: {type: ..., args: {...}}} for object/interface fields."""
+    out = {}
+    for f in field_defs:
+        entry: dict = {"type": _type_to_str(f.type)}
+        if isinstance(f, FieldDefinitionNode) and f.arguments:
+            entry["args"] = _args_to_dict(f)
+        out[f.name.value] = entry
+    return out
+
+
+def _input_fields_to_dict(field_defs) -> dict[str, str]:
+    """{field_name: rendered_type} for input object fields."""
+    return {
+        f.name.value: _type_to_str(f.type)
+        for f in field_defs
+        if isinstance(f, InputValueDefinitionNode)
+    }
+
+
+def extract_types(sdl: str) -> dict[str, dict]:
+    """Parse SDL → {type_name: {kind, ...}} dict suitable for diffing."""
+    doc = parse(sdl)
+    return _extract_types(doc)
+
+
+def _extract_types(doc: DocumentNode) -> dict[str, dict]:
+    types: dict[str, dict] = {}
+    for defn in doc.definitions:
+        if not hasattr(defn, "name"):
+            continue
+        name = defn.name.value
+        if isinstance(defn, ObjectTypeDefinitionNode):
+            types[name] = {
+                "kind": "object",
+                "interfaces": sorted(i.name.value for i in defn.interfaces),
+                "fields": _fields_to_dict(defn.fields),
+            }
+        elif isinstance(defn, InterfaceTypeDefinitionNode):
+            types[name] = {
+                "kind": "interface",
+                "fields": _fields_to_dict(defn.fields),
+            }
+        elif isinstance(defn, UnionTypeDefinitionNode):
+            types[name] = {
+                "kind": "union",
+                "members": sorted(t.name.value for t in defn.types),
+            }
+        elif isinstance(defn, EnumTypeDefinitionNode):
+            types[name] = {
+                "kind": "enum",
+                "values": sorted(v.name.value for v in defn.values),
+            }
+        elif isinstance(defn, InputObjectTypeDefinitionNode):
+            types[name] = {
+                "kind": "input",
+                "fields": _input_fields_to_dict(defn.fields),
+            }
+        elif isinstance(defn, ScalarTypeDefinitionNode):
+            types[name] = {"kind": "scalar"}
+    return types
+
+
+def _diff_object_or_interface(legacy: dict, poc: dict) -> dict:
+    l_fields = legacy["fields"]
+    p_fields = poc["fields"]
+    l_names = set(l_fields.keys())
+    p_names = set(p_fields.keys())
+
+    type_mismatches = {}
+    args_mismatches = {}
+    for name in l_names & p_names:
+        if l_fields[name]["type"] != p_fields[name]["type"]:
+            type_mismatches[name] = (l_fields[name]["type"], p_fields[name]["type"])
+        # Compare args if either side has them
+        l_args = l_fields[name].get("args", {})
+        p_args = p_fields[name].get("args", {})
+        if l_args != p_args:
+            args_mismatches[name] = {
+                "args_only_in_legacy": sorted(set(l_args) - set(p_args)),
+                "args_only_in_poc": sorted(set(p_args) - set(l_args)),
+                "arg_type_mismatches": {
+                    a: (l_args[a], p_args[a])
+                    for a in set(l_args) & set(p_args)
+                    if l_args[a] != p_args[a]
+                },
+            }
+
+    out = {}
+    only_l = sorted(l_names - p_names)
+    only_p = sorted(p_names - l_names)
+    if only_l:
+        out["fields_only_in_legacy"] = only_l
+    if only_p:
+        out["fields_only_in_poc"] = only_p
+    if type_mismatches:
+        out["field_type_mismatches"] = type_mismatches
+    if args_mismatches:
+        out["field_arg_mismatches"] = args_mismatches
+
+    # Interface list diff (objects only)
+    if legacy["kind"] == "object" and poc["kind"] == "object":
+        l_ifaces = set(legacy.get("interfaces", []))
+        p_ifaces = set(poc.get("interfaces", []))
+        if l_ifaces != p_ifaces:
+            out["interfaces_only_in_legacy"] = sorted(l_ifaces - p_ifaces)
+            out["interfaces_only_in_poc"] = sorted(p_ifaces - l_ifaces)
+
+    return out
+
+
+def _diff_input(legacy: dict, poc: dict) -> dict:
+    l_fields = legacy["fields"]
+    p_fields = poc["fields"]
+    l_names = set(l_fields.keys())
+    p_names = set(p_fields.keys())
+
+    out = {}
+    only_l = sorted(l_names - p_names)
+    only_p = sorted(p_names - l_names)
+    if only_l:
+        out["fields_only_in_legacy"] = only_l
+    if only_p:
+        out["fields_only_in_poc"] = only_p
+
+    type_mismatches = {
+        name: (l_fields[name], p_fields[name])
+        for name in l_names & p_names
+        if l_fields[name] != p_fields[name]
+    }
+    if type_mismatches:
+        out["field_type_mismatches"] = type_mismatches
+    return out
+
+
+def _diff_enum(legacy: dict, poc: dict) -> dict:
+    l_vals = set(legacy["values"])
+    p_vals = set(poc["values"])
+    out = {}
+    if l_vals - p_vals:
+        out["values_only_in_legacy"] = sorted(l_vals - p_vals)
+    if p_vals - l_vals:
+        out["values_only_in_poc"] = sorted(p_vals - l_vals)
+    return out
+
+
+def _diff_union(legacy: dict, poc: dict) -> dict:
+    l_mems = set(legacy["members"])
+    p_mems = set(poc["members"])
+    out = {}
+    if l_mems - p_mems:
+        out["members_only_in_legacy"] = sorted(l_mems - p_mems)
+    if p_mems - l_mems:
+        out["members_only_in_poc"] = sorted(p_mems - l_mems)
+    return out
+
+
+def diff_schemas(legacy_sdl: str, poc_sdl: str) -> dict:
+    """Top-level diff. Returns a dict with the divergences between the two SDL inputs."""
+    legacy = extract_types(legacy_sdl)
+    poc = extract_types(poc_sdl)
+
+    legacy_names = set(legacy.keys())
+    poc_names = set(poc.keys())
+    in_both = legacy_names & poc_names
+
+    type_diffs: dict[str, dict] = {}
+    for name in sorted(in_both):
+        l = legacy[name]
+        p = poc[name]
+        if l["kind"] != p["kind"]:
+            type_diffs[name] = {"kind_mismatch": (l["kind"], p["kind"])}
+            continue
+        kind = l["kind"]
+        if kind in ("object", "interface"):
+            d = _diff_object_or_interface(l, p)
+        elif kind == "input":
+            d = _diff_input(l, p)
+        elif kind == "enum":
+            d = _diff_enum(l, p)
+        elif kind == "union":
+            d = _diff_union(l, p)
+        else:
+            d = {}
+        if d:
+            type_diffs[name] = d
+
+    return {
+        "types_only_in_legacy": sorted(legacy_names - poc_names),
+        "types_only_in_poc": sorted(poc_names - legacy_names),
+        "type_diffs": type_diffs,
+    }
+
+
+def has_any_diff(diff: dict) -> bool:
+    return bool(diff["types_only_in_legacy"] or diff["types_only_in_poc"] or diff["type_diffs"])
+
+
+def format_report(diff: dict) -> str:
+    """Render a diff dict as markdown."""
+    lines: list[str] = ["# Schema Parity Report", ""]
+
+    if diff["types_only_in_legacy"]:
+        lines.append(f"## Types in legacy but not in POC ({len(diff['types_only_in_legacy'])})")
+        for t in diff["types_only_in_legacy"]:
+            lines.append(f"- `{t}`")
+        lines.append("")
+
+    if diff["types_only_in_poc"]:
+        lines.append(f"## Types in POC but not in legacy ({len(diff['types_only_in_poc'])})")
+        for t in diff["types_only_in_poc"]:
+            lines.append(f"- `{t}`")
+        lines.append("")
+
+    if diff["type_diffs"]:
+        lines.append(f"## Per-type differences ({len(diff['type_diffs'])} types)")
+        for name in sorted(diff["type_diffs"]):
+            d = diff["type_diffs"][name]
+            lines.append(f"\n### `{name}`")
+            if "kind_mismatch" in d:
+                lk, pk = d["kind_mismatch"]
+                lines.append(f"- **kind differs**: legacy=`{lk}` poc=`{pk}`")
+                continue
+            for key, label in (
+                ("fields_only_in_legacy", "Fields only in legacy"),
+                ("fields_only_in_poc", "Fields only in POC"),
+                ("values_only_in_legacy", "Enum values only in legacy"),
+                ("values_only_in_poc", "Enum values only in POC"),
+                ("members_only_in_legacy", "Union members only in legacy"),
+                ("members_only_in_poc", "Union members only in POC"),
+                ("interfaces_only_in_legacy", "Interfaces only in legacy"),
+                ("interfaces_only_in_poc", "Interfaces only in POC"),
+            ):
+                if d.get(key):
+                    lines.append(f"- **{label}:**")
+                    for item in d[key]:
+                        lines.append(f"  - `{item}`")
+            if d.get("field_type_mismatches"):
+                lines.append("- **Field type mismatches (legacy → poc):**")
+                for f, (lt, pt) in sorted(d["field_type_mismatches"].items()):
+                    lines.append(f"  - `{f}`: `{lt}` → `{pt}`")
+            if d.get("field_arg_mismatches"):
+                lines.append("- **Field argument mismatches:**")
+                for f, am in sorted(d["field_arg_mismatches"].items()):
+                    parts = []
+                    if am.get("args_only_in_legacy"):
+                        parts.append(f"only-legacy={am['args_only_in_legacy']}")
+                    if am.get("args_only_in_poc"):
+                        parts.append(f"only-poc={am['args_only_in_poc']}")
+                    if am.get("arg_type_mismatches"):
+                        parts.append(f"type-mismatches={am['arg_type_mismatches']}")
+                    lines.append(f"  - `{f}`: {'; '.join(parts)}")
+
+    if not has_any_diff(diff):
+        lines.append("✅ Schemas are at full parity (no divergences detected).")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Diff a legacy GraphQL SDL against a Strawberry POC SDL"
+    )
+    parser.add_argument("legacy", help="Path to legacy SDL file")
+    parser.add_argument("poc", help="Path to POC SDL file")
+    parser.add_argument(
+        "--format",
+        choices=["markdown", "json"],
+        default="markdown",
+        help="Output format (default: markdown)",
+    )
+    parser.add_argument(
+        "--fail-on-diff",
+        action="store_true",
+        help="Exit with status 1 if any divergence is found (suitable for CI gate)",
+    )
+    args = parser.parse_args(argv)
+
+    legacy_sdl = Path(args.legacy).read_text()
+    poc_sdl = Path(args.poc).read_text()
+
+    diff = diff_schemas(legacy_sdl, poc_sdl)
+
+    if args.format == "json":
+        sys.stdout.write(json.dumps(diff, indent=2, default=str))
+    else:
+        sys.stdout.write(format_report(diff))
+
+    if args.fail_on_diff and has_any_diff(diff):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Every schema-level regression we hit this session was a comparable difference between the legacy Graphene SDL and the Strawberry POC SDL:

- `ToshiFile` renamed to `File`
- Missing `update_automation_task` mutation
- `file_size: Int` (32-bit) vs `BigInt` (production values silently overflowed)
- Missing `GeneralTask.subtask_result`
- Missing `total_count` on relay connections
- `legacy_object_identities` returning store-bucket name instead of `clazz_name`

A simple SDL diff would have caught each of them in CI before deployment. This PR ships that tool.

## What's in it

**`spike/strawberry_poc/tools/schema_parity.py`** — the diff engine.
- Parses two SDL strings with `graphql-core` (already a transitive dep via Strawberry).
- Walks the AST into a structural `{type_name: {kind, fields|values|members, …}}` dict.
- Diffs across the divergence classes the bugs above belong to:
  - Types missing on either side
  - Fields missing on either side, per type
  - Field type mismatches (the BigInt case)
  - Field argument drift
  - Interface implementation drift
  - Enum value drift (the DISAGG case)
  - Union member drift
  - Input object field drift
- Kind mismatches (e.g. legacy object vs POC interface) short-circuit per-type comparison and surface explicitly.
- CLI supports `--format json` for machine consumption and `--fail-on-diff` to exit 1 for CI gating.

**`spike/strawberry_poc/tools/dump_poc_sdl.py`** — one-liner that emits the Strawberry SDL via `schema.as_str()`. Adds the spike root to `sys.path` so it runs as a bare script.

**`spike/strawberry_poc/tools/README.md`** — step-by-step usage including how to dump the legacy SDL via `print_schema(root_schema.graphql_schema)`.

**`spike/strawberry_poc/tests/test_schema_parity.py`** — 25 tests:
- Extractor unit tests across all six type kinds (object, interface, union, enum, input, scalar)
- Diff primitive tests for each divergence class
- **Six \"bugs caught this session\" reproductions**: ToshiFile rename, missing `update_automation_task`, missing `subtask_result`, `file_size` BigInt vs Int, missing `total_count` on relay connection, missing `DISAGG` enum value — each verifies the diff tool surfaces the bug correctly
- CLI smoke tests: self-diff exits 0, `--fail-on-diff` exits 1, JSON format is parseable

## Why no allowlist (yet)

Deliberately allow-list-free in v1. The report is meant to be read by humans who decide which divergences are intentional (POC adds `BigInt` by design; some legacy bugfix-test types are out-of-scope). Once the divergence set stabilises, a future iteration can add an `expected_diffs.yaml` that the tool subtracts before evaluating `--fail-on-diff`. Keeping it simple now means reviewers actually look at the report rather than maintaining the allowlist.

## How to wire into CI (separate follow-up)

A workflow that runs after the existing test job:

```yaml
- name: Dump legacy SDL
  run: uv run python -c \"from graphql.utilities import print_schema; from graphql_api.schema import root_schema; print(print_schema(root_schema.graphql_schema))\" > /tmp/legacy.sdl
- name: Dump POC SDL
  working-directory: spike/strawberry_poc
  run: uv run python tools/dump_poc_sdl.py > /tmp/poc.sdl
- name: Schema parity report
  working-directory: spike/strawberry_poc
  run: uv run python tools/schema_parity.py /tmp/legacy.sdl /tmp/poc.sdl
- name: Upload report as PR comment
  uses: marocchino/sticky-pull-request-comment@v2
  with:
    path: /tmp/parity_report.md
```

Not included in this PR — wanted to keep the tool itself reviewable in isolation. Easy to add once we've used the tool locally for a few days and tuned the expected output.

## Test plan

- [x] `uv run pytest tests/test_schema_parity.py` — 25 passed
- [x] Full POC suite — 176 passed, 1 skipped (was 151 / 1 on spike base)
- [x] CLI self-diff round-trip on the live POC SDL (1597-line) — zero divergences, exit 0
- [ ] Run the tool against the actual legacy SDL once #296 merges — will produce the first real parity report

## Stacking

Targets `strawberry-poc-spike` to show clean diff. After #296 merges to `deploy-test`, retarget with `gh pr edit 301 --base deploy-test`.

**Depends on:** #296.

## Stack now

```
deploy-test
   └── strawberry-poc-spike      (#296)
        ├── strawberry-poc-deploy      (#297)
        ├── strawberry-poc-ci          (#298)
        ├── strawberry-poc-compression (#299)
        ├── strawberry-poc-s3-fallback (#300)
        └── strawberry-poc-schema-parity (this PR)
```