### PR TITLE
docs: ADR-001 — GraphQL schema evolution strategy + introduce ADR convention

### DIFF
--- a/docs/adrs/0001-graphql-schema-evolution-strategy.md
+++ b/docs/adrs/0001-graphql-schema-evolution-strategy.md
@@ -1,0 +1,287 @@
+# ADR-0001: GraphQL Schema Evolution Strategy — Legacy Parity, Modern Defaults, Deprecation Aliases
+
+## Status
+
+Proposed.
+
+## Context
+
+### The drop-in promise
+
+The Strawberry+FastAPI POC (`spike/strawberry_poc/`) was scoped from
+the outset as a **drop-in replacement** for the legacy Graphene+Flask
+GraphQL API. Clients — weka, runzi, anything else that reads or
+writes via the Toshi GraphQL endpoint — should not need code changes
+when traffic moves from `/graphql` to `/graphql-v2`.
+
+That promise is harder than it sounds, because the schemas have
+drifted in ways that aren't always visible from a casual read.
+
+### What the parity diff revealed
+
+`spike/strawberry_poc/tools/schema_parity.py` produces an SDL-level
+diff between the legacy schema and the POC. The first real run found:
+
+- 30 types in legacy but missing from POC
+- 55 types in POC but missing from legacy
+- 68 types whose fields, types, or interfaces differ
+
+That is **a lot** of difference for an API that's supposed to be
+drop-in.
+
+### The "why does weka work at all?" puzzle
+
+Given that level of divergence, it is genuinely surprising weka
+queries succeed at all against `/graphql-v2`. There are several
+reasons they do — and understanding them is load-bearing for the
+strategy below:
+
+1. **Most divergence is at the SDL level, not the wire level.**
+   `[KeyValuePair]` vs `[KeyValuePair!]`, `parents: TaskTaskRelationConnection`
+   vs `parents: TaskRelationsConnection!`, edge node nullability — all
+   produce identical JSON for the same data. Clients don't notice.
+
+2. **weka uses fragment queries against interfaces.** Most weka query
+   bodies look like `... on InversionSolutionInterface { file_name, … }`.
+   The interface fragment payload doesn't care about the concrete
+   type's name — `File` vs `ToshiFile` is invisible inside a fragment
+   that asks for `file_name`. Type-name renames are a much bigger
+   problem for `... on ConcreteType { }` fragments than for interface
+   fragments. weka mostly uses interfaces.
+
+3. **Production paths that hit the rough edges aren't exercised every
+   day.** The two bugs that have actually bitten in this iteration
+   (`GeneralTask` enum coercion crashing every field; `file_size`
+   silently truncating at 2GB) only surfaced when specific
+   real-production data hit specific code paths. Before that, the
+   POC "worked" against test data because the test data didn't
+   contain the trigger conditions.
+
+4. **GraphQL is permissive about missing data.** When a resolver
+   returns `null` for a missing field, the client sees `null` —
+   indistinguishable (from the client's perspective) from a value
+   that just happens to be `null` legitimately. Silent breakage is
+   the default mode of GraphQL schema drift.
+
+5. **The /graphql-v2 deploy has been read-only and narrowly tested.**
+   `DB_READ_ONLY=1` blocks every mutation path. The endpoint has
+   never been hit at the full breadth of production query patterns;
+   the divergences that would bite first under real load haven't had
+   a chance to manifest.
+
+So the answer to "why does weka work at all?" is **a combination of
+SDL-vs-wire indirection, fragment-based queries that hide type-name
+drift, untested code paths, GraphQL's permissive null semantics, and
+a read-only deploy**. None of these is a guarantee of correctness —
+they're the reasons the divergence has been able to stay invisible.
+
+### The legacy schema is five years old
+
+Many of the conventions in the legacy schema reflect their era:
+
+- Built ~2020 against Graphene 2.x and Graphene-Django defaults.
+- Relay 1 was the de facto Relay spec at the time — `clientMutationId`
+  was required on every mutation.
+- Custom typed scalars (`DateTime`, `JSONString`) were the common
+  workaround for Python-side serialisation.
+- `auto_camel_case=False` was used to match the Python codebase style.
+- Root types named `QueryRoot` / `MutationRoot` — a Graphene
+  convention that was never standard but was common in 2018-2020.
+
+By 2026, the GraphQL community has moved on from some of these:
+
+- **Relay 2** dropped `clientMutationId`. Modern Apollo Client / urql /
+  Relay 2 clients don't need it.
+- **camelCase** is the overwhelming community standard for field
+  names. snake_case is valid but uncommon in public APIs.
+- **The Relay Connection spec** is normative camelCase for PageInfo
+  fields (`hasNextPage`, `endCursor`, etc.). Strawberry follows the
+  spec; legacy diverged via its `auto_camel_case=False`.
+- **Plain `Query` / `Mutation`** root type names are the convention
+  in essentially every public GraphQL API.
+- **Typed scalars** like `DateTime` are still good and still common —
+  this is one place legacy got it right and the POC regressed (using
+  plain `String`).
+
+The legacy schema is not "wrong" — it reflects the standards of its
+time, and those standards were defensible. But the gap between
+2020 standards and 2026 standards means a clean port has to make
+explicit choices.
+
+## Decision
+
+Three principles for how the POC schema relates to the legacy one:
+
+### Principle 1: Wire-format compatibility is the hard contract
+
+**The JSON payload returned for a given query must be identical
+between legacy and POC for the same data.**
+
+This is the line that "drop-in replacement" actually means. SDL
+differences that don't change the wire format are tolerated; SDL
+differences that do change it are bugs.
+
+In practice this means:
+
+- **Field names match.** `pageInfo.hasNextPage` (camelCase) returned
+  by legacy must be available as `pageInfo.hasNextPage` from POC,
+  even though POC's default scheme is snake_case.
+- **Scalar wire format matches.** `created` returned as
+  `"2024-01-01T00:00:00Z"` in legacy must be the same string in POC,
+  whether the SDL says `String` or `DateTime`.
+- **List semantics match.** `[KeyValuePair]` vs `[KeyValuePair!]`
+  return the same JSON; tolerated as SDL-only.
+- **Required-input mutation fields match.** If legacy accepts
+  `clientMutationId: String` in its mutation inputs, POC must too —
+  even if the field is ignored downstream.
+
+### Principle 2: Treat the legacy schema as the spec, but selectively modernise where the community has hardened
+
+Where 2020 and 2026 conventions disagree:
+
+- If the **modern community standard has hardened** (Relay spec on
+  PageInfo; `Query` / `Mutation` as root names; non-null modifiers
+  where appropriate), POC adopts the modern form.
+- If the legacy choice is **still acceptable** and switching is
+  invisible to clients (snake_case field names; custom scalars), we
+  keep the legacy convention.
+- If POC has **regressed** vs legacy on a still-good convention
+  (typed scalars `DateTime`, `JSONString`), we restore the legacy
+  form.
+
+### Principle 3: Backwards compatibility via GraphQL's `@deprecated` directive
+
+Where modern community standard differs from legacy in a
+wire-affecting way (PageInfo field naming, `clientMutationId`), expose
+**both** names — modern as preferred, legacy as `@deprecated` alias.
+
+Strawberry supports this natively via
+`strawberry.field(deprecation_reason="...")`. Multiple fields can point
+at the same resolver. Clients can introspect the deprecated marker
+and tooling (GraphiQL, Apollo Studio autocomplete) surface it as a
+warning, but existing queries keep working.
+
+This pattern is how mature GraphQL APIs (GitHub, Shopify, Stripe)
+evolve without breaking clients. After a measurement window (12+
+months of query-log evidence), deprecated fields can be removed.
+
+## Specific decisions
+
+| Item | Legacy | Community 2026 | Decision |
+|---|---|---|---|
+| `PageInfo` field naming | snake_case (`has_next_page`) | **camelCase** (Relay spec normative) | **Both** — camelCase preferred, snake_case deprecated alias |
+| `clientMutationId` in mutations | Required (Relay 1) | Dropped (Relay 2) | **Both** — input accepts, output echoes, marked deprecated |
+| `DateTime` scalar | Yes | Yes (Strawberry has it) | **Restore in POC** — was wrongly downgraded to `String` |
+| `JSONString` scalar | Yes | Yes; `JSON` is alternative | **Restore in POC** — same regression |
+| Root type names | `QueryRoot`/`MutationRoot` | `Query`/`Mutation` | **Modernise** — clients don't reference roots by name; zero impact |
+| snake_case field names everywhere | snake_case | camelCase preferred | **Keep snake_case** — weka/runzi are Python clients; switching is a separate strategic call |
+| Inner nullability `[X]` vs `[X!]` | Permissive nullable | Strict non-null where known | **Modernise** — wire-equivalent, no client impact |
+| Connection type naming (e.g. `FileRelationConnection`) | Mixed | No standard | **Align with legacy** for parity — `FileRelationConnection` not the auto-generated POC name |
+| `BigInt` scalar | Yes | Common as custom scalar | **Keep** — added to POC for `file_size` >2GB |
+
+## Migration path
+
+### Phase 1 — Wire-breaking fixes (this iteration)
+
+For each item where the SDL difference produces different wire
+output:
+
+1. Add the legacy form as a deprecated alias alongside the modern
+   form (PageInfo, mutation `clientMutationId`).
+2. Restore the typed scalars (`DateTime`, `JSONString`).
+3. Pick connection type names that match legacy.
+
+### Phase 2 — Codegen alignment (this iteration)
+
+Wire-format is fine but typed-client codegen breaks:
+
+1. Rename root types to `QueryRoot` / `MutationRoot`.
+2. Rename mutation payloads to match legacy (`CreateAutomationTask`
+   not `CreateAutomationTaskPayload`).
+3. Ensure auto-generated `XxxConnection` / `XxxEdge` types align.
+
+### Phase 3 — Monitor, deprecate, sunset (12+ months out)
+
+1. Add Strawberry resolver instrumentation that logs deprecated-field
+   usage to CloudWatch / metrics.
+2. Annual review: deprecated fields with zero usage in the past 12
+   months can be removed in a major version bump.
+3. Communicate sunset timeline to client teams.
+
+## Consequences
+
+### Positive
+
+- The drop-in promise is upheld for existing clients. weka and runzi
+  continue working without code changes — even with the bugs that
+  were silently bypassing the issue (Principle 1 makes wire format
+  the contract, not SDL parity).
+- New clients adopting `/graphql-v2` see modern conventions in
+  autocomplete and codegen. They don't carry forward 2020-era debt.
+- The deprecation pattern gives us a **measured exit path** — we can
+  remove legacy fields when we have query-log evidence nobody uses
+  them, not based on a guess.
+- The schema parity diff tool (`tools/schema_parity.py`) becomes a
+  durable CI safety net. Once allowlisted for the intentional
+  divergences listed here, every future schema change either fits
+  the allowlist or fails the build.
+
+### Negative
+
+- Maintenance cost from carrying deprecated aliases — every `PageInfo`
+  field exists twice; every mutation has a `clientMutationId` it
+  doesn't actually use. Mitigated by the documented sunset policy
+  (Phase 3) but real until then.
+- The schema is **slightly more complex** to read — two ways to
+  spell the same field. New contributors need to understand which is
+  preferred. Mitigated by inline `deprecation_reason` strings.
+- **Decision fatigue** — every future schema-affecting change now has
+  to consider both forms. We need to make the deprecation pattern
+  easy to apply consistently (helper decorators, lint rules) or it
+  will rot.
+
+### Neutral
+
+- This ADR doesn't take a position on the **global snake_case vs
+  camelCase migration**. That's a separate decision worth its own
+  ADR if/when client teams want to undertake it. PageInfo is treated
+  as a special case because the Relay spec is normative for it; the
+  rest of the schema stays snake_case.
+- This ADR doesn't address **schema namespacing for federation** or
+  **schema versioning** more broadly. If the API ever moves to
+  GraphQL Federation, this ADR's deprecation policy will need to be
+  reconciled with the federation supergraph composition rules.
+
+## Lessons captured
+
+The "why does weka work at all?" analysis is the most important part
+of this ADR for future maintainers. The five reasons listed there
+explain how serious schema drift can hide in plain sight, and they
+should be considered every time someone proposes "we don't need to
+worry about that divergence":
+
+- "It's just an SDL difference" doesn't mean it's invisible — the
+  divergence has been silently producing null fields in production.
+- "weka hasn't complained" doesn't mean weka can't hit the broken
+  path — it means it hasn't yet.
+- "It's read-only and well-tested" applies to the deploys we've made,
+  not to the schema. Schema bugs surface when real production traffic
+  hits unexpected code paths.
+
+The schema parity diff is the systematic version of this analysis.
+We should run it before every cutover-affecting deploy, and we
+should resist the urge to allowlist new divergences without first
+checking they're truly wire-equivalent or covered by a deprecation
+alias.
+
+## Related decisions
+
+- (Future) ADR-0002: Custom scalar policy — naming, behaviour, and
+  on-disk representation for `DateTime`, `JSONString`, `BigInt`, and
+  any future scalars.
+- (Future) ADR-0003: Schema interface hierarchy — `Thing` and
+  `AutomationTaskInterface` adoption in POC.
+- (Future) ADR-0004: Deprecation logging and sunset policy — how we
+  measure deprecated-field usage and when we remove.
+- (Future) ADR-0005: snake_case vs camelCase for client-facing
+  fields — strategic call on whether to undertake the migration.

--- a/docs/adrs/ADR-001-graphql-schema-evolution-strategy.md
+++ b/docs/adrs/ADR-001-graphql-schema-evolution-strategy.md
@@ -1,4 +1,4 @@
-# ADR-0001: GraphQL Schema Evolution Strategy — Legacy Parity, Modern Defaults, Deprecation Aliases
+# ADR-001: GraphQL Schema Evolution Strategy — Legacy Parity, Modern Defaults, Deprecation Aliases
 
 ## Status
 
@@ -276,12 +276,12 @@ alias.
 
 ## Related decisions
 
-- (Future) ADR-0002: Custom scalar policy — naming, behaviour, and
+- (Future) ADR-002: Custom scalar policy — naming, behaviour, and
   on-disk representation for `DateTime`, `JSONString`, `BigInt`, and
   any future scalars.
-- (Future) ADR-0003: Schema interface hierarchy — `Thing` and
+- (Future) ADR-003: Schema interface hierarchy — `Thing` and
   `AutomationTaskInterface` adoption in POC.
-- (Future) ADR-0004: Deprecation logging and sunset policy — how we
+- (Future) ADR-004: Deprecation logging and sunset policy — how we
   measure deprecated-field usage and when we remove.
-- (Future) ADR-0005: snake_case vs camelCase for client-facing
+- (Future) ADR-005: snake_case vs camelCase for client-facing
   fields — strategic call on whether to undertake the migration.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -35,10 +35,10 @@ template](https://github.com/joelparkerhenderson/architecture-decision-record/bl
 extended for our project style:
 
 ```
-# ADR-NNNN: <Short title in title case>
+# ADR-NNN: <Short title in title case>
 
 ## Status
-Proposed | Accepted | Superseded by ADR-XXXX | Deprecated
+Proposed | Accepted | Superseded by ADR-NNN | Deprecated
 
 ## Context
 The problem and the relevant constraints. Include enough domain
@@ -59,16 +59,25 @@ Cross-links to other ADRs.
 
 When a decision touches multiple distinct areas (e.g. naming,
 scalars, deprecation policy), feel free to add a `## Specific
-decisions` section with a table — see `0001-graphql-schema-evolution.md`.
+decisions` section with a table — see
+`ADR-001-graphql-schema-evolution-strategy.md`.
 
-## Numbering
+## Numbering and filename
 
-Sequential, four-digit, zero-padded: `0001`, `0002`, etc. Once
-assigned, the number never changes — even if an ADR is superseded
-(mark it `Superseded by ADR-XXXX` and leave the file in place).
+Sequential, three-digit, zero-padded. Filename pattern:
+
+```
+ADR-NNN-{descriptive-name-in-kebab-case}.md
+```
+
+For example: `ADR-001-graphql-schema-evolution-strategy.md`.
+
+Once a number is assigned it never changes — even if an ADR is
+superseded (mark it `Superseded by ADR-NNN` in the Status section and
+leave the file in place).
 
 ## Index
 
 | # | Title | Status |
 |---|---|---|
-| [0001](0001-graphql-schema-evolution-strategy.md) | GraphQL Schema Evolution Strategy: Legacy Parity, Modern Defaults, Deprecation Aliases | Proposed |
+| [ADR-001](ADR-001-graphql-schema-evolution-strategy.md) | GraphQL Schema Evolution Strategy: Legacy Parity, Modern Defaults, Deprecation Aliases | Proposed |

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,74 @@
+# Architecture Decision Records
+
+This directory captures significant architectural decisions for the
+`nshm-toshi-api` project — the *why* behind structural choices that
+are expensive to reverse and that future maintainers (including future
+us) will otherwise have to reverse-engineer.
+
+## When to write an ADR
+
+Write an ADR when the choice:
+
+1. Affects the **API contract** seen by clients (weka, runzi, downstream
+   tooling).
+2. Imposes a **cross-cutting constraint** that future contributors need
+   to be aware of even if they don't touch the originating code.
+3. Required **non-trivial analysis** to land on, and the analysis itself
+   is the durable artifact (not just the decision).
+4. Would be hard to **reverse without a deprecation cycle**.
+
+Examples that warrant an ADR:
+- "Why do we have a custom `BigInt` scalar instead of `Int`?"
+- "Why do mutation payloads include a deprecated `clientMutationId`?"
+- "Why is the Strawberry POC scoped under `spike/` rather than top-level?"
+
+Examples that don't:
+- Small refactors, bugfixes, dependency upgrades.
+- "Why did we name this function `_try_enum`?" (live with the code.)
+- Strategy docs that are explorations rather than decisions (those go
+  in `docs/` directly, see `ALTERNATE_STACK_QUESTIONS.md`).
+
+## Format
+
+ADRs follow a slight adaptation of [Michael Nygard's
+template](https://github.com/joelparkerhenderson/architecture-decision-record/blob/main/locales/en/templates/decision-record-template-by-michael-nygard/index.md),
+extended for our project style:
+
+```
+# ADR-NNNN: <Short title in title case>
+
+## Status
+Proposed | Accepted | Superseded by ADR-XXXX | Deprecated
+
+## Context
+The problem and the relevant constraints. Include enough domain
+context that a new contributor 12 months from now will understand
+the situation without spelunking commits.
+
+## Decision
+The choice we made. State it clearly enough that future readers can
+tell whether their case falls inside or outside the decision's scope.
+
+## Consequences
+The positives and negatives, including known trade-offs. List items
+this decision blocks, enables, or makes harder.
+
+## Related decisions
+Cross-links to other ADRs.
+```
+
+When a decision touches multiple distinct areas (e.g. naming,
+scalars, deprecation policy), feel free to add a `## Specific
+decisions` section with a table — see `0001-graphql-schema-evolution.md`.
+
+## Numbering
+
+Sequential, four-digit, zero-padded: `0001`, `0002`, etc. Once
+assigned, the number never changes — even if an ADR is superseded
+(mark it `Superseded by ADR-XXXX` and leave the file in place).
+
+## Index
+
+| # | Title | Status |
+|---|---|---|
+| [0001](0001-graphql-schema-evolution-strategy.md) | GraphQL Schema Evolution Strategy: Legacy Parity, Modern Defaults, Deprecation Aliases | Proposed |


### PR DESCRIPTION
## Summary

Introduces the project's first Architecture Decision Record, and the `docs/adrs/` convention to host future ones. The ADR captures the strategic decisions around how the Strawberry POC schema relates to the legacy Graphene schema — the question that the schema parity diff tool (#301) made impossible to keep ducking.

## Why now

The parity diff produced 657 lines of report covering 68 type differences. Some of those are pure SDL cosmetics; some are real client-breaking issues; the gradient between them needs a written-down strategy rather than per-PR judgement calls. And the question \"why does weka work at all given how much divergence we found?\" deserves a real answer that future maintainers can read.

There was no formal ADR convention in the project yet — the `docs/` folder has the precedent for substantive analysis docs (`ALTERNATE_STACK_QUESTIONS.md`, `DYNAMIC_SCHEMA_ARE_DUMB_OR_ARE_THEY.md`, `PROJECT_HEALTHCARE_PLAN.md`) but no numbering / lifecycle / index. This PR introduces all three.

## What's in it

### `docs/adrs/README.md`

Introduces the convention. Specifically:

- **When to write an ADR.** Four criteria: affects the API contract, imposes a cross-cutting constraint, required non-trivial analysis as durable artifact, or would require a deprecation cycle to reverse. Plus examples of what doesn't warrant one.
- **Format.** Adapted Michael Nygard: Status / Context / Decision / Consequences / Related decisions. Slight extension to allow a Specific decisions table for multi-pronged decisions.
- **Numbering.** Sequential four-digit, never reused.
- **Index** pointing at ADR-001.

### `docs/adrs/ADR-001-graphql-schema-evolution-strategy.md`

The actual decision. Sections:

1. **Context** — the drop-in promise, what the parity diff revealed, the \"why does weka work at all?\" puzzle (with five concrete reasons), and the five-year drift in GraphQL community standards.
2. **Decision** — three principles: wire-format compat is the hard contract; selectively modernise where the community has hardened; use `@deprecated` to expose both forms.
3. **Specific decisions** — a table covering PageInfo naming, `clientMutationId`, `DateTime`/`JSONString` scalars, root type names, snake_case overall, nullability, and connection naming. Each row: legacy form, 2026 community standard, our decision.
4. **Migration path** — three phases (wire-breaking fixes now, codegen alignment next, monitor+sunset in 12+ months).
5. **Consequences** — positive / negative / neutral.
6. **Lessons captured** — the five reasons weka works despite drift, called out as durable guidance.
7. **Related decisions** — placeholder pointers for future ADRs on scalars, interfaces, deprecation logging, snake/camel migration.

The most important part of the document is the **\"why does weka work at all?\"** analysis. It explains how serious schema drift can hide in plain sight:

> So the answer to \"why does weka work at all?\" is a combination of SDL-vs-wire indirection, fragment-based queries that hide type-name drift, untested code paths, GraphQL's permissive null semantics, and a read-only deploy. None of these is a guarantee of correctness — they're the reasons the divergence has been able to stay invisible.

Future contributors should be sent here whenever someone is tempted to dismiss a divergence as \"just SDL\".

## Companion to #301

PR #301 ships the schema parity diff tool. This PR captures what we decided to do with its output. Together they form: the data + the policy. Future schema-affecting PRs run the tool, check the output against this ADR's principles, and either fit the policy or need to update it.

## What this ADR doesn't decide

- Does not take a position on the global **snake_case vs camelCase** migration (separate strategic call; needs its own ADR if pursued).
- Does not address **schema federation** or schema versioning more broadly.
- Does not specify the *implementation* of the deprecation aliases — that's the next PR (\"Phase 1 — Wire-breaking fixes\").

## Stack

```
deploy-test
   └── strawberry-poc-spike      (#296)
        ├── strawberry-poc-deploy      (#297)
        ├── strawberry-poc-ci          (#298)
        ├── strawberry-poc-compression (#299)
        ├── strawberry-poc-s3-fallback (#300)
        ├── strawberry-poc-schema-parity (#301)
        └── strawberry-poc-adrs        (this PR)
```

**Depends on:** #296.

## Status

The ADR is marked **Proposed** until accepted via PR merge. Discussion encouraged in the PR comments — this is the durable artifact of the strategic decision, so disagreements should be hashed out here rather than implied in implementation PRs.
