### PR TITLE
feat: restore DateTime + JSONString typed scalars (ADR-001 Phase 1)

### DIFF
--- a/spike/strawberry_poc/models/aggregate_inversion_solution.py
+++ b/spike/strawberry_poc/models/aggregate_inversion_solution.py
@@ -11,7 +11,7 @@ from strawberry.types import Info
 from data.dynamo import create_file, get_file, list_files
 from data.models import AggregateInversionSolutionData
 
-from .common import AggregationFn, BigInt, KeyValuePair, KeyValuePairInput, _try_enum
+from .common import AggregationFn, BigInt, DateTime, KeyValuePair, KeyValuePairInput, _try_enum
 from .file_interface import FileInterface
 from .inversion_solution import LabelledTableRelation, _ltr_from_dict
 from .inversion_solution_interface import InversionSolutionInterface
@@ -102,7 +102,7 @@ class CreateAggregateInversionSolutionInput:
     md5_digest: str | None = None
     file_size: BigInt | None = None
     meta: list[KeyValuePairInput] | None = None
-    created: str | None = None
+    created: DateTime | None = None
     predecessors: list[PredecessorInput] | None = None
 
 

--- a/spike/strawberry_poc/models/automation_task.py
+++ b/spike/strawberry_poc/models/automation_task.py
@@ -19,7 +19,7 @@ from strawberry.types import Info
 from data.dynamo import create_thing, get_thing, list_things, update_thing
 from data.models import AutomationTaskData
 
-from .common import EventResult, EventState, KeyValuePair, KeyValuePairInput, ModelType, TaskSubType, _try_enum
+from .common import DateTime, EventResult, EventState, KeyValuePair, KeyValuePairInput, ModelType, TaskSubType, _try_enum
 from .relations import (
     FileRelation,
     FileRelationsConnection,
@@ -49,7 +49,7 @@ class AutomationTask(relay.Node):
     result: EventResult | None = None
     task_type: TaskSubType | None = None
     model_type: ModelType | None = None
-    created: str | None = None
+    created: DateTime | None = None
     duration: float | None = None
     general_task_id: strawberry.ID | None = None
     arguments: list[KeyValuePair] | None = None
@@ -110,7 +110,7 @@ class RuptureGenerationTask(relay.Node):
     state: EventState | None = None
     result: EventResult | None = None
     task_type: TaskSubType | None = None
-    created: str | None = None
+    created: DateTime | None = None
     duration: float | None = None
     general_task_id: strawberry.ID | None = None
     arguments: list[KeyValuePair] | None = None
@@ -165,7 +165,7 @@ class RuptureGenerationTask(relay.Node):
 class CreateAutomationTaskInput:
     state: EventState
     result: EventResult
-    created: str
+    created: DateTime
     task_type: TaskSubType
     duration: float | None = None
     model_type: ModelType | None = None

--- a/spike/strawberry_poc/models/common.py
+++ b/spike/strawberry_poc/models/common.py
@@ -28,6 +28,26 @@ BigInt = strawberry.scalar(
     "Used for file_size where production values can exceed 2GB.",
 )
 
+# ADR-001 Phase 1: restore the legacy typed scalars. Wire format is an ISO 8601
+# string (DateTime) or a JSON-encoded string (JSONString). Python type stays as
+# `str` so we don't force every resolver to construct typed values; the scalar
+# rename is what fixes typed-client codegen parity with legacy.
+DateTime = strawberry.scalar(
+    NewType("DateTime", str),
+    serialize=str,
+    parse_value=str,
+    description="An ISO 8601 datetime string. Wire-compatible with the legacy graphene "
+    "DateTime scalar; typed clients get a `DateTime` rather than a plain `String`.",
+)
+
+JSONString = strawberry.scalar(
+    NewType("JSONString", str),
+    serialize=str,
+    parse_value=str,
+    description="A JSON-encoded string. Wire-compatible with the legacy graphene "
+    "JSONString scalar; used for embedded JSON payloads like Openquake logic trees.",
+)
+
 
 @strawberry.type
 class KeyValuePair:

--- a/spike/strawberry_poc/models/file.py
+++ b/spike/strawberry_poc/models/file.py
@@ -16,7 +16,7 @@ from strawberry.types import Info
 from data.dynamo import create_file, get_file, list_files
 from data.models import ToshiFileData
 
-from .common import BigInt, KeyValuePair, KeyValuePairInput
+from .common import BigInt, DateTime, KeyValuePair, KeyValuePairInput
 from .file_interface import FileInterface
 from .relations import FileRelation, FileRelationsConnection, build_file_relations_for_file
 
@@ -64,7 +64,7 @@ class CreateFileInput:
     md5_digest: str | None = None
     file_size: BigInt | None = None
     meta: list[KeyValuePairInput] | None = None
-    created: str | None = None
+    created: DateTime | None = None
 
 
 def resolve_files(info: Info) -> Iterable[ToshiFile]:

--- a/spike/strawberry_poc/models/file_interface.py
+++ b/spike/strawberry_poc/models/file_interface.py
@@ -5,7 +5,7 @@ from strawberry.types import Info
 
 from data.s3 import presigned_download_url
 
-from .common import BigInt, KeyValuePair
+from .common import BigInt, DateTime, JSONString, KeyValuePair
 
 
 @strawberry.interface
@@ -15,7 +15,7 @@ class FileInterface:
     file_name: str | None = None
     md5_digest: str | None = None
     file_size: BigInt | None = None
-    created: str | None = None
+    created: DateTime | None = None
     meta: list[KeyValuePair] | None = None
 
     @strawberry.field
@@ -31,5 +31,5 @@ class FileInterface:
         return None
 
     @strawberry.field
-    def post_data_v2(self) -> str | None:
+    def post_data_v2(self) -> JSONString | None:
         return None

--- a/spike/strawberry_poc/models/general_task.py
+++ b/spike/strawberry_poc/models/general_task.py
@@ -19,6 +19,7 @@ from data.dynamo import create_thing, get_thing, list_things, update_thing
 from data.models import GeneralTaskData
 
 from .common import (
+    DateTime,
     EventResult,
     KeyValueListPair,
     KeyValueListPairInput,
@@ -49,8 +50,8 @@ class GeneralTask(relay.Node):
     title: str | None = None
     description: str | None = None
     agent_name: str | None = None
-    created: str | None = None
-    updated: str | None = None
+    created: DateTime | None = None
+    updated: DateTime | None = None
     notes: str | None = None
     subtask_count: int | None = None
     subtask_type: TaskSubType | None = None
@@ -121,7 +122,7 @@ class CreateGeneralTaskInput:
     title: str | None = None
     description: str | None = None
     agent_name: str | None = None
-    created: str | None = None
+    created: DateTime | None = None
     notes: str | None = None
     subtask_count: int | None = None
     subtask_type: TaskSubType | None = None
@@ -137,7 +138,7 @@ class UpdateGeneralTaskInput:
     title: str | None = None
     description: str | None = None
     agent_name: str | None = None
-    updated: str | None = None
+    updated: DateTime | None = None
     notes: str | None = None
     subtask_count: int | None = None
     subtask_type: TaskSubType | None = None

--- a/spike/strawberry_poc/models/inversion_solution.py
+++ b/spike/strawberry_poc/models/inversion_solution.py
@@ -21,6 +21,7 @@ from data.models import InversionSolutionData
 
 from .common import (
     BigInt,
+    DateTime,
     KeyValueListPair,
     KeyValueListPairInput,
     KeyValuePair,
@@ -47,7 +48,7 @@ class LabelledTableRelation:
     """A labelled reference to a ToshiTableObject, stored inline in the parent."""
 
     identity: str | None = None
-    created: str | None = None
+    created: DateTime | None = None
     produced_by_id: strawberry.ID | None = None
     label: str | None = None
     table_id: strawberry.ID | None = None
@@ -138,7 +139,7 @@ class CreateInversionSolutionInput:
     md5_digest: str | None = None
     file_size: BigInt | None = None
     meta: list[KeyValuePairInput] | None = None
-    created: str | None = None
+    created: DateTime | None = None
     produced_by: strawberry.ID | None = None
     metrics: list[KeyValuePairInput] | None = None
     tables: list[LabelledTableRelationInput] | None = None

--- a/spike/strawberry_poc/models/inversion_solution_interface.py
+++ b/spike/strawberry_poc/models/inversion_solution_interface.py
@@ -21,7 +21,7 @@ from strawberry.types import Info
 
 from data.dynamo import get_table, get_thing
 
-from .common import BigInt, KeyValuePair, TableType
+from .common import BigInt, DateTime, KeyValuePair, TableType
 from .relations import InversionSolutionRelations, build_file_relations_for_file
 
 # ── Lazy forward refs ─────────────────────────────────────────────────────────
@@ -73,7 +73,7 @@ class InversionSolutionInterface:
     file_name: str | None = None
     md5_digest: str | None = None
     file_size: BigInt | None = None
-    created: str | None = None
+    created: DateTime | None = None
     meta: list[KeyValuePair] | None = None
 
     @strawberry.field

--- a/spike/strawberry_poc/models/inversion_solution_nrml.py
+++ b/spike/strawberry_poc/models/inversion_solution_nrml.py
@@ -11,7 +11,7 @@ from strawberry.types import Info
 from data.dynamo import create_file, get_file, list_files
 from data.models import InversionSolutionNrmlData
 
-from .common import BigInt, KeyValuePair, KeyValuePairInput
+from .common import BigInt, DateTime, KeyValuePair, KeyValuePairInput
 from .file_interface import FileInterface
 from .predecessor import PredecessorInput
 from .predecessors_interface import PredecessorsInterface
@@ -63,7 +63,7 @@ class CreateInversionSolutionNrmlInput:
     md5_digest: str | None = None
     file_size: BigInt | None = None
     meta: list[KeyValuePairInput] | None = None
-    created: str | None = None
+    created: DateTime | None = None
     predecessors: list[PredecessorInput] | None = None
 
 

--- a/spike/strawberry_poc/models/openquake_hazard_config.py
+++ b/spike/strawberry_poc/models/openquake_hazard_config.py
@@ -10,6 +10,7 @@ from strawberry.types import Info
 
 from data.dynamo import create_thing, get_file, get_thing, list_things
 from data.models import OpenquakeHazardConfigData
+from models.common import DateTime
 from models.file import ToshiFile
 from models.inversion_solution_nrml import InversionSolutionNrml
 
@@ -37,7 +38,7 @@ def dispatch_nrml(data: dict):
 @strawberry.type
 class OpenquakeHazardConfig(relay.Node):
     pk: relay.NodeID[str]
-    created: str | None = None
+    created: DateTime | None = None
 
     source_models_raw_ids: strawberry.Private[list[str] | None] = None
     template_archive_raw_id: strawberry.Private[str | None] = None
@@ -88,7 +89,7 @@ class OpenquakeHazardConfig(relay.Node):
 class CreateOpenquakeHazardConfigInput:
     template_archive: strawberry.ID
     source_models: list[strawberry.ID] | None = None
-    created: str | None = None
+    created: DateTime | None = None
 
 
 def resolve_openquake_hazard_configs(info: Info) -> Iterable[OpenquakeHazardConfig]:

--- a/spike/strawberry_poc/models/openquake_hazard_solution.py
+++ b/spike/strawberry_poc/models/openquake_hazard_solution.py
@@ -13,7 +13,7 @@ from data.models import OpenquakeHazardSolutionData
 from models.file import ToshiFile
 from models.openquake_hazard_task import OpenquakeHazardTask
 
-from .common import KeyValuePair, KeyValuePairInput, OpenquakeTaskType
+from .common import DateTime, KeyValuePair, KeyValuePairInput, OpenquakeTaskType
 from .predecessor import PredecessorInput
 from .predecessors_interface import PredecessorsInterface
 
@@ -24,7 +24,7 @@ _ToshiFile = Annotated["ToshiFile", strawberry.lazy("models.file")]
 @strawberry.type
 class OpenquakeHazardSolution(relay.Node, PredecessorsInterface):
     pk: relay.NodeID[str]
-    created: str | None = None
+    created: DateTime | None = None
     task_type: OpenquakeTaskType | None = None
     metrics: list[KeyValuePair] | None = None
     meta: list[KeyValuePair] | None = None
@@ -98,7 +98,7 @@ class OpenquakeHazardSolution(relay.Node, PredecessorsInterface):
 class CreateOpenquakeHazardSolutionInput:
     produced_by: strawberry.ID
     task_type: OpenquakeTaskType
-    created: str | None = None
+    created: DateTime | None = None
     csv_archive: strawberry.ID | None = None
     hdf5_archive: strawberry.ID | None = None
     task_args: strawberry.ID | None = None

--- a/spike/strawberry_poc/models/openquake_hazard_task.py
+++ b/spike/strawberry_poc/models/openquake_hazard_task.py
@@ -11,7 +11,7 @@ from strawberry.types import Info
 from data.dynamo import create_thing, get_thing, list_things, update_thing
 from data.models import OpenquakeHazardTaskData
 
-from .common import EventResult, EventState, KeyValuePair, KeyValuePairInput, ModelType, TaskSubType, _try_enum
+from .common import DateTime, EventResult, EventState, JSONString, KeyValuePair, KeyValuePairInput, ModelType, TaskSubType, _try_enum
 from .relations import (
     FileRelation,
     FileRelationsConnection,
@@ -32,16 +32,16 @@ class OpenquakeHazardTask(relay.Node):
     result: EventResult | None = None
     task_type: TaskSubType | None = None
     model_type: ModelType | None = None
-    created: str | None = None
+    created: DateTime | None = None
     duration: float | None = None
     general_task_id: strawberry.ID | None = None
     arguments: list[KeyValuePair] | None = None
     environment: list[KeyValuePair] | None = None
     metrics: list[KeyValuePair] | None = None
     executor: str | None = None
-    srm_logic_tree: str | None = None  # JSON string
-    gmcm_logic_tree: str | None = None  # JSON string
-    openquake_config: str | None = None  # JSON string
+    srm_logic_tree: JSONString | None = None
+    gmcm_logic_tree: JSONString | None = None
+    openquake_config: JSONString | None = None
 
     files_raw: strawberry.Private[list | None] = None
     parents_raw: strawberry.Private[list | None] = None
@@ -108,7 +108,7 @@ class OpenquakeHazardTask(relay.Node):
 class CreateOpenquakeHazardTaskInput:
     state: EventState
     result: EventResult
-    created: str
+    created: DateTime
     task_type: TaskSubType
     duration: float | None = None
     model_type: ModelType | None = None
@@ -116,9 +116,9 @@ class CreateOpenquakeHazardTaskInput:
     environment: list[KeyValuePairInput] | None = None
     metrics: list[KeyValuePairInput] | None = None
     executor: str | None = None
-    srm_logic_tree: str | None = None
-    gmcm_logic_tree: str | None = None
-    openquake_config: str | None = None
+    srm_logic_tree: JSONString | None = None
+    gmcm_logic_tree: JSONString | None = None
+    openquake_config: JSONString | None = None
     hazard_solution: strawberry.ID | None = None
 
 

--- a/spike/strawberry_poc/models/rupture_set.py
+++ b/spike/strawberry_poc/models/rupture_set.py
@@ -18,7 +18,7 @@ from data.dynamo import create_file, get_file, get_thing, list_files
 from data.models import RuptureSetData
 
 from .automation_task import RuptureGenerationTask  # noqa: F401 — re-exported for schema.py
-from .common import BigInt, KeyValuePair, KeyValuePairInput
+from .common import BigInt, DateTime, KeyValuePair, KeyValuePairInput
 from .file_interface import FileInterface
 
 # ── RuptureSet ────────────────────────────────────────────────────────────────
@@ -74,7 +74,7 @@ class CreateRuptureSetInput:
     produced_by: strawberry.ID
     md5_digest: str | None = None
     file_size: BigInt | None = None
-    created: str | None = None
+    created: DateTime | None = None
     fault_models: list[str] | None = None
     metrics: list[KeyValuePairInput] | None = None
 

--- a/spike/strawberry_poc/models/scaled_inversion_solution.py
+++ b/spike/strawberry_poc/models/scaled_inversion_solution.py
@@ -11,7 +11,7 @@ from strawberry.types import Info
 from data.dynamo import create_file, get_file, list_files
 from data.models import ScaledInversionSolutionData
 
-from .common import BigInt, KeyValuePair, KeyValuePairInput
+from .common import BigInt, DateTime, KeyValuePair, KeyValuePairInput
 from .file_interface import FileInterface
 from .inversion_solution import InversionSolution, LabelledTableRelation, _ltr_from_dict
 from .inversion_solution_interface import InversionSolutionInterface
@@ -108,7 +108,7 @@ class CreateScaledInversionSolutionInput:
     md5_digest: str | None = None
     file_size: BigInt | None = None
     meta: list[KeyValuePairInput] | None = None
-    created: str | None = None
+    created: DateTime | None = None
     predecessors: list[PredecessorInput] | None = None
 
 

--- a/spike/strawberry_poc/models/sms_file.py
+++ b/spike/strawberry_poc/models/sms_file.py
@@ -12,7 +12,7 @@ from strawberry.types import Info
 from data.dynamo import create_file, get_file, list_files
 from data.models import SmsFileData
 
-from .common import BigInt, KeyValuePair, SmsFileType, _try_enum
+from .common import BigInt, DateTime, KeyValuePair, SmsFileType, _try_enum
 from .file_interface import FileInterface
 from .relations import FileRelation, FileRelationsConnection, build_file_relations_for_file
 
@@ -56,7 +56,7 @@ class CreateSmsFileInput:
     file_type: SmsFileType
     md5_digest: str | None = None
     file_size: BigInt | None = None
-    created: str | None = None
+    created: DateTime | None = None
 
 
 def resolve_sms_files(info: Info) -> Iterable[SmsFile]:

--- a/spike/strawberry_poc/models/strong_motion_station.py
+++ b/spike/strawberry_poc/models/strong_motion_station.py
@@ -12,7 +12,7 @@ from strawberry.types import Info
 from data.dynamo import create_thing, get_thing, list_things
 from data.models import StrongMotionStationData
 
-from .common import SmsSiteClass, SmsSiteClassBasis, _try_enum
+from .common import DateTime, SmsSiteClass, SmsSiteClassBasis, _try_enum
 from .relations import FileRelation, FileRelationsConnection, build_file_relations_for_thing
 
 
@@ -29,8 +29,8 @@ class StrongMotionStation(relay.Node):
     liquefiable: bool | None = None
     bedrock_encountered: bool | None = None
     soft_clay_or_peat: bool | None = None
-    created: str | None = None
-    updated: str | None = None
+    created: DateTime | None = None
+    updated: DateTime | None = None
 
     files_raw: strawberry.Private[list | None] = None
 
@@ -72,8 +72,8 @@ class CreateStrongMotionStationInput:
     liquefiable: bool | None = None
     bedrock_encountered: bool | None = None
     soft_clay_or_peat: bool | None = None
-    created: str | None = None
-    updated: str | None = None
+    created: DateTime | None = None
+    updated: DateTime | None = None
 
 
 def resolve_strong_motion_stations(info: Info) -> Iterable[StrongMotionStation]:

--- a/spike/strawberry_poc/models/table.py
+++ b/spike/strawberry_poc/models/table.py
@@ -9,7 +9,7 @@ from strawberry.types import Info
 from data.dynamo import create_table, get_table
 from data.models import TableData
 
-from .common import KeyValueListPair, KeyValueListPairInput, KeyValuePair, KeyValuePairInput, TableType, _try_enum
+from .common import DateTime, KeyValueListPair, KeyValueListPairInput, KeyValuePair, KeyValuePairInput, TableType, _try_enum
 
 
 @strawberry.type
@@ -17,7 +17,7 @@ class Table(relay.Node):
     pk: relay.NodeID[str]
     object_id: strawberry.ID | None = None
     name: str | None = None
-    created: str | None = None
+    created: DateTime | None = None
     column_headers: list[str] | None = None
     column_types: list[str] | None = None
     rows: list[list[str]] | None = None
@@ -52,7 +52,7 @@ class Table(relay.Node):
 class CreateTableInput:
     object_id: strawberry.ID
     name: str | None = None
-    created: str | None = None
+    created: DateTime | None = None
     column_headers: list[str] | None = None
     column_types: list[str] | None = None
     rows: list[list[str]] | None = None

--- a/spike/strawberry_poc/models/time_dependent_inversion_solution.py
+++ b/spike/strawberry_poc/models/time_dependent_inversion_solution.py
@@ -11,7 +11,7 @@ from strawberry.types import Info
 from data.dynamo import create_file, get_file, list_files
 from data.models import TimeDependentInversionSolutionData
 
-from .common import BigInt, KeyValuePair, KeyValuePairInput
+from .common import BigInt, DateTime, KeyValuePair, KeyValuePairInput
 from .file_interface import FileInterface
 from .inversion_solution import InversionSolution, LabelledTableRelation, _ltr_from_dict
 from .inversion_solution_interface import InversionSolutionInterface
@@ -76,7 +76,7 @@ class CreateTimeDependentInversionSolutionInput:
     md5_digest: str | None = None
     file_size: BigInt | None = None
     meta: list[KeyValuePairInput] | None = None
-    created: str | None = None
+    created: DateTime | None = None
     predecessors: list[PredecessorInput] | None = None
 
 


### PR DESCRIPTION
## Summary

First slice of ADR-001 Phase 1 — restoring the typed scalars (`DateTime`, `JSONString`) that the POC had silently regressed from. Wire format is unchanged; SDL boundary is now type-named like legacy, which means typed-client codegen produces proper wrapper types instead of plain \`string\`.

## Why

The legacy schema has `DateTime` (ISO 8601 datetime string) and `JSONString` (JSON-encoded string) as named GraphQL scalars. Both are still community-standard custom scalars in 2026 — Strawberry has them too. The POC chose plain `String` as a simplification, which:

- ✅ Is wire-equivalent (same JSON returned to clients)
- ❌ Breaks typed-client codegen (sgqlc / Apollo Codegen / graphql-codegen emit `string` instead of `DateTime` / `JSONString`)
- ❌ Diverges from the legacy SDL in 40+ places

ADR-001 calls this out specifically: *\"this is one place legacy got it right and the POC regressed (using plain String).\"* This PR fixes the regression.

## Changes

- **`models/common.py`** — define `DateTime` and `JSONString` alongside `BigInt`. Same `NewType`-based `strawberry.scalar` pattern; identity `serialize` / `parse_value`. Python type stays `str` so resolvers don't need to construct typed values — the change is purely at the SDL boundary.
- **17 model files** — import the new scalars from `.common` and switch:
  - `created: str | None` → `created: DateTime | None` (every Type class and CreateInput)
  - `updated: str | None` → `updated: DateTime | None` (`GeneralTask`, `StrongMotionStation`)
  - `srm_logic_tree` / `gmcm_logic_tree` / `openquake_config` `str` → `JSONString` (on `OpenquakeHazardTask` Type + CreateInput)
  - `post_data_v2` on `FileInterface` `str` → `JSONString`

## Parity impact

Measured via `tools/schema_parity.py` from #301:

| | Before | After | Δ |
|---|---|---|---|
| Report length (lines) | 657 | 611 | **-46** |
| Field type mismatches | 257 | 200 | **-57** |
| `DateTime ↔ String` mismatches | 38 | **0** | -38 |
| `JSONString ↔ String` mismatches | 8 | **0** | -8 |

## Wire compatibility

Wire format unchanged. Every test sending `\"2024-01-01T00:00:00Z\"` as a `created` value still works — Python type is still `str` underneath. Clients receiving the same JSON in responses keep working unchanged.

## Test plan

- [x] `uv run pytest tests/` — 151 passed, 1 skipped (no change vs spike base)
- [x] Schema loads cleanly: `from schema import schema` succeeds
- [x] SDL contains `scalar DateTime` and `scalar JSONString`
- [x] Zero remaining `DateTime ↔ String` or `JSONString ↔ String` mismatches in parity diff

## Phase 1 remaining sub-tasks (separate PRs to follow)

This is the easy slice. The wire-breaking ones come next:

1. **PageInfo camelCase aliases** — cursor pagination clients query \`pageInfo { hasNextPage }\` and currently get null. Needs a custom \`PageInfo\` with both naming forms and a custom \`ListConnection\` subclass.
2. **\`clientMutationId\` on every mutation input/payload** — Relay 1 clients send and expect it. Mechanical addition to ~30 inputs and ~30 payloads.
3. **Connection naming alignment** — \`FileRelationsConnection\` → \`FileRelationConnection\`, etc. Codegen-breaking; needs careful refactor to avoid the duplicate-name conflict that motivated the rename in the first place.

See [ADR-001](https://github.com/GNS-Science/nshm-toshi-api/blob/strawberry-poc-adrs/docs/adrs/ADR-001-graphql-schema-evolution-strategy.md) for the full strategy.

## Stacking

Targets \`strawberry-poc-spike\`. After #296 merges to \`deploy-test\`, retarget to \`deploy-test\`.

**Depends on:** #296.

## Stack now

```
deploy-test
   └── strawberry-poc-spike       (#296)
        ├── strawberry-poc-deploy        (#297)
        ├── strawberry-poc-ci            (#298)
        ├── strawberry-poc-compression   (#299)
        ├── strawberry-poc-s3-fallback   (#300)
        ├── strawberry-poc-schema-parity (#301)
        ├── strawberry-poc-adrs          (#302)
        └── strawberry-poc-phase1-scalars (this PR)
```