### PR TITLE
feat: PageInfo camelCase aliases (ADR-001 Phase 1)

### DIFF
--- a/spike/strawberry_poc/models/object_identity.py
+++ b/spike/strawberry_poc/models/object_identity.py
@@ -22,14 +22,39 @@ class ObjectIdentitiesEdge:
 
 @strawberry.type
 class ObjectIdentitiesPageInfo:
-    has_next_page: bool = False
-    end_cursor: str | None = None
+    # Modern Relay-spec camelCase (preferred)
+    has_next_page: bool = strawberry.field(name="hasNextPage", default=False)
+    end_cursor: str | None = strawberry.field(name="endCursor", default=None)
+
+    @strawberry.field(
+        name="has_next_page",
+        deprecation_reason="Use hasNextPage instead (Relay Cursor Connections Spec normative).",
+    )
+    def deprecated_has_next_page(self) -> bool:
+        return self.has_next_page
+
+    @strawberry.field(
+        name="end_cursor",
+        deprecation_reason="Use endCursor instead (Relay Cursor Connections Spec normative).",
+    )
+    def deprecated_end_cursor(self) -> str | None:
+        return self.end_cursor
 
 
 @strawberry.type
 class ObjectIdentitiesConnection:
     edges: list[ObjectIdentitiesEdge] = strawberry.field(default_factory=list)
-    page_info: ObjectIdentitiesPageInfo = strawberry.field(default_factory=ObjectIdentitiesPageInfo)
+    # Modern Relay-spec camelCase (preferred)
+    page_info: ObjectIdentitiesPageInfo = strawberry.field(
+        name="pageInfo", default_factory=ObjectIdentitiesPageInfo
+    )
+
+    @strawberry.field(
+        name="page_info",
+        deprecation_reason="Use pageInfo instead (Relay Cursor Connections Spec normative).",
+    )
+    def deprecated_page_info(self) -> ObjectIdentitiesPageInfo:
+        return self.page_info
 
 
 def encode_cursor(object_id: str) -> str:

--- a/spike/strawberry_poc/models/page_info.py
+++ b/spike/strawberry_poc/models/page_info.py
@@ -1,0 +1,105 @@
+"""
+PageInfo + ListConnection with both Relay-spec camelCase (preferred) and
+POC snake_case (deprecated aliases).
+
+The POC schema runs with `auto_camel_case=False` to match the broader
+snake_case convention of the legacy API. But the Relay Cursor
+Connections Spec is normative camelCase for `PageInfo` — every client
+that follows the spec (Apollo Client, urql, Relay 2) writes
+`pageInfo { hasNextPage ... }`. Without these compat fields the POC
+silently returns `null` for those queries.
+
+See ADR-001 (Specific Decisions table, PageInfo row): both forms ship,
+camelCase is preferred, snake_case is marked `@deprecated`. Sunset is
+driven by usage logs once Phase 3 introspection instrumentation lands.
+"""
+
+import strawberry
+from strawberry import relay
+from strawberry.relay.types import NodeType  # noqa: F401 — re-used as our generic param
+
+
+@strawberry.type(name="PageInfo")
+class CompatPageInfo:
+    """PageInfo with Relay-spec camelCase (preferred) + snake_case deprecated aliases.
+
+    Replaces `strawberry.relay.PageInfo` on every connection that uses
+    `CompatListConnection` (below).
+    """
+
+    # Modern, preferred — Relay Connection spec normative
+    has_next_page: bool = strawberry.field(name="hasNextPage")
+    has_previous_page: bool = strawberry.field(name="hasPreviousPage")
+    start_cursor: str | None = strawberry.field(name="startCursor", default=None)
+    end_cursor: str | None = strawberry.field(name="endCursor", default=None)
+
+    # Legacy snake_case aliases — deprecated, kept for drop-in client compat
+    @strawberry.field(
+        name="has_next_page",
+        deprecation_reason="Use hasNextPage instead (Relay Cursor Connections Spec normative).",
+    )
+    def deprecated_has_next_page(self) -> bool:
+        return self.has_next_page
+
+    @strawberry.field(
+        name="has_previous_page",
+        deprecation_reason="Use hasPreviousPage instead (Relay Cursor Connections Spec normative).",
+    )
+    def deprecated_has_previous_page(self) -> bool:
+        return self.has_previous_page
+
+    @strawberry.field(
+        name="start_cursor",
+        deprecation_reason="Use startCursor instead (Relay Cursor Connections Spec normative).",
+    )
+    def deprecated_start_cursor(self) -> str | None:
+        return self.start_cursor
+
+    @strawberry.field(
+        name="end_cursor",
+        deprecation_reason="Use endCursor instead (Relay Cursor Connections Spec normative).",
+    )
+    def deprecated_end_cursor(self) -> str | None:
+        return self.end_cursor
+
+
+@strawberry.type(name="Connection")
+class CompatListConnection(relay.ListConnection[NodeType]):
+    """ListConnection with Relay-spec camelCase pageInfo (preferred) + snake_case deprecated alias.
+
+    Overrides the inherited `page_info: relay.PageInfo` field so the
+    SDL name is `pageInfo` and the type is `CompatPageInfo` (the legacy
+    snake_case `page_info` alias is added as a deprecated field below).
+
+    `resolve_connection` is overridden to substitute the relay PageInfo
+    instance with our CompatPageInfo so the subclass field annotation
+    matches the runtime value Strawberry serialises.
+    """
+
+    page_info: CompatPageInfo = strawberry.field(
+        name="pageInfo",
+        description="Relay Cursor Connections Spec normative pagination info.",
+    )
+
+    @strawberry.field(
+        name="page_info",
+        deprecation_reason="Use pageInfo instead (Relay Cursor Connections Spec normative).",
+    )
+    def deprecated_page_info(self) -> CompatPageInfo:
+        return self.page_info
+
+    @classmethod
+    def resolve_connection(cls, nodes, *, info, **kwargs):
+        conn = super().resolve_connection(nodes, info=info, **kwargs)
+        # super() returns a connection whose .page_info is a relay.PageInfo.
+        # Replace it with our CompatPageInfo so the subclass field annotation
+        # matches the actual instance type — otherwise Strawberry's serialiser
+        # sees a relay.PageInfo where the schema expects CompatPageInfo.
+        old_pi = conn.page_info
+        conn.page_info = CompatPageInfo(
+            has_next_page=old_pi.has_next_page,
+            has_previous_page=old_pi.has_previous_page,
+            start_cursor=old_pi.start_cursor,
+            end_cursor=old_pi.end_cursor,
+        )
+        return conn

--- a/spike/strawberry_poc/models/relations.py
+++ b/spike/strawberry_poc/models/relations.py
@@ -22,6 +22,7 @@ from strawberry.types import Info
 from data.dynamo import create_file_relation, create_task_relation, get_file, get_thing
 
 from .common import FileRole
+from .page_info import CompatListConnection
 
 # ── Lazy forward references (break circular deps) ─────────────────────────────
 
@@ -154,8 +155,8 @@ class TaskTaskRelation:
 
 
 @strawberry.type
-class FileRelationsConnection(relay.ListConnection[FileRelation]):
-    """Relay connection for FileRelation that exposes total_count."""
+class FileRelationsConnection(CompatListConnection[FileRelation]):
+    """Relay connection for FileRelation that exposes total_count + camelCase PageInfo."""
 
     _total: strawberry.Private[int] = 0
 
@@ -172,8 +173,8 @@ class FileRelationsConnection(relay.ListConnection[FileRelation]):
 
 
 @strawberry.type
-class TaskRelationsConnection(relay.ListConnection[TaskTaskRelation]):
-    """Relay connection for TaskTaskRelation that exposes total_count."""
+class TaskRelationsConnection(CompatListConnection[TaskTaskRelation]):
+    """Relay connection for TaskTaskRelation that exposes total_count + camelCase PageInfo."""
 
     _total: strawberry.Private[int] = 0
 

--- a/spike/strawberry_poc/schema.py
+++ b/spike/strawberry_poc/schema.py
@@ -22,6 +22,7 @@ import data.search as _data_search
 from data.dynamo import es_key_for, get_object, scan_objects_paginated
 from data.s3 import scan_s3_paginated
 from data.search import search as es_search
+from models.page_info import CompatListConnection
 from models.aggregate_inversion_solution import (
     AggregateInversionSolution,
     CreateAggregateInversionSolutionInput,
@@ -353,65 +354,65 @@ class Query:
     def about(self) -> str:
         return "Hello, I am nshm_toshi_api (Strawberry POC)! [AUTH]"
 
-    @relay.connection(relay.ListConnection[GeneralTask])
+    @relay.connection(CompatListConnection[GeneralTask])
     def general_tasks(self, info: strawberry.types.Info) -> Iterable[GeneralTask]:
         return resolve_general_tasks(info)
 
-    @relay.connection(relay.ListConnection[RuptureSet])
+    @relay.connection(CompatListConnection[RuptureSet])
     def rupture_sets(self, info: strawberry.types.Info) -> Iterable[RuptureSet]:
         return resolve_rupture_sets(info)
 
-    @relay.connection(relay.ListConnection[ToshiFile])
+    @relay.connection(CompatListConnection[ToshiFile])
     def files(self, info: strawberry.types.Info) -> Iterable[ToshiFile]:
         return resolve_files(info)
 
-    @relay.connection(relay.ListConnection[SmsFile])
+    @relay.connection(CompatListConnection[SmsFile])
     def sms_files(self, info: strawberry.types.Info) -> Iterable[SmsFile]:
         return resolve_sms_files(info)
 
-    @relay.connection(relay.ListConnection[StrongMotionStation])
+    @relay.connection(CompatListConnection[StrongMotionStation])
     def strong_motion_stations(self, info: strawberry.types.Info) -> Iterable[StrongMotionStation]:
         return resolve_strong_motion_stations(info)
 
-    @relay.connection(relay.ListConnection[AutomationTask])
+    @relay.connection(CompatListConnection[AutomationTask])
     def automation_tasks(self, info: strawberry.types.Info) -> Iterable[AutomationTask]:
         return resolve_automation_tasks(info)
 
-    @relay.connection(relay.ListConnection[RuptureGenerationTask])
+    @relay.connection(CompatListConnection[RuptureGenerationTask])
     def rupture_generation_tasks(self, info: strawberry.types.Info) -> Iterable[RuptureGenerationTask]:
         return resolve_rupture_generation_tasks(info)
 
-    @relay.connection(relay.ListConnection[InversionSolution])
+    @relay.connection(CompatListConnection[InversionSolution])
     def inversion_solutions(self, info: strawberry.types.Info) -> Iterable[InversionSolution]:
         return resolve_inversion_solutions(info)
 
-    @relay.connection(relay.ListConnection[ScaledInversionSolution])
+    @relay.connection(CompatListConnection[ScaledInversionSolution])
     def scaled_inversion_solutions(self, info: strawberry.types.Info) -> Iterable[ScaledInversionSolution]:
         return resolve_scaled_inversion_solutions(info)
 
-    @relay.connection(relay.ListConnection[AggregateInversionSolution])
+    @relay.connection(CompatListConnection[AggregateInversionSolution])
     def aggregate_inversion_solutions(self, info: strawberry.types.Info) -> Iterable[AggregateInversionSolution]:
         return resolve_aggregate_inversion_solutions(info)
 
-    @relay.connection(relay.ListConnection[TimeDependentInversionSolution])
+    @relay.connection(CompatListConnection[TimeDependentInversionSolution])
     def time_dependent_inversion_solutions(
         self, info: strawberry.types.Info
     ) -> Iterable[TimeDependentInversionSolution]:
         return resolve_time_dependent_inversion_solutions(info)
 
-    @relay.connection(relay.ListConnection[InversionSolutionNrml])
+    @relay.connection(CompatListConnection[InversionSolutionNrml])
     def inversion_solution_nrmls(self, info: strawberry.types.Info) -> Iterable[InversionSolutionNrml]:
         return resolve_inversion_solution_nrmls(info)
 
-    @relay.connection(relay.ListConnection[OpenquakeHazardConfig])
+    @relay.connection(CompatListConnection[OpenquakeHazardConfig])
     def openquake_hazard_configs(self, info: strawberry.types.Info) -> Iterable[OpenquakeHazardConfig]:
         return resolve_openquake_hazard_configs(info)
 
-    @relay.connection(relay.ListConnection[OpenquakeHazardSolution])
+    @relay.connection(CompatListConnection[OpenquakeHazardSolution])
     def openquake_hazard_solutions(self, info: strawberry.types.Info) -> Iterable[OpenquakeHazardSolution]:
         return resolve_openquake_hazard_solutions(info)
 
-    @relay.connection(relay.ListConnection[OpenquakeHazardTask])
+    @relay.connection(CompatListConnection[OpenquakeHazardTask])
     def openquake_hazard_tasks(self, info: strawberry.types.Info) -> Iterable[OpenquakeHazardTask]:
         return resolve_openquake_hazard_tasks(info)
 

--- a/spike/strawberry_poc/tests/test_page_info_compat.py
+++ b/spike/strawberry_poc/tests/test_page_info_compat.py
@@ -1,0 +1,189 @@
+"""
+Tests for the PageInfo backwards-compatibility layer.
+
+ADR-001 Phase 1: expose the Relay Connection spec's camelCase PageInfo
+field names (`pageInfo`, `hasNextPage`, etc.) as the preferred form on
+every connection, with the legacy snake_case forms as `@deprecated`
+aliases. Existing clients continue to work; new clients see the
+modern names in autocomplete and codegen.
+"""
+
+import pytest
+
+from schema import schema
+
+
+CREATE_TASK_MUTATION = """
+mutation CreateTask($input: CreateGeneralTaskInput!) {
+    create_general_task(input: $input) { general_task { id } }
+}
+"""
+
+# Both query forms should work — camelCase preferred, snake_case deprecated alias
+GENERAL_TASKS_CAMEL_QUERY = """
+query GeneralTasksCamel {
+    general_tasks(first: 2) {
+        pageInfo {
+            hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
+        }
+        edges { node { id title } }
+    }
+}
+"""
+
+GENERAL_TASKS_SNAKE_QUERY = """
+query GeneralTasksSnake {
+    general_tasks(first: 2) {
+        page_info {
+            has_next_page
+            has_previous_page
+            start_cursor
+            end_cursor
+        }
+        edges { node { id title } }
+    }
+}
+"""
+
+GENERAL_TASKS_MIXED_QUERY = """
+query GeneralTasksMixed {
+    general_tasks(first: 2) {
+        pageInfo {
+            has_next_page
+            endCursor
+        }
+        edges { node { id } }
+    }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def seeded_tasks(gql_context):
+    """Create a handful of GeneralTasks so pagination has something to page through."""
+    ids = []
+    for i in range(5):
+        result = schema.execute_sync(
+            CREATE_TASK_MUTATION,
+            variable_values={"input": {"title": f"pageinfo-task-{i}", "agent_name": "pytest"}},
+            context_value=gql_context,
+        )
+        assert result.errors is None, result.errors
+        ids.append(result.data["create_general_task"]["general_task"]["id"])
+    return ids
+
+
+def test_camel_case_page_info_works(gql_context, seeded_tasks):
+    """The Relay-spec camelCase form (pageInfo + hasNextPage etc.) works."""
+    result = schema.execute_sync(GENERAL_TASKS_CAMEL_QUERY, context_value=gql_context)
+    assert result.errors is None, result.errors
+    pi = result.data["general_tasks"]["pageInfo"]
+    assert pi["hasNextPage"] is True  # we seeded >2, requested first 2
+    assert pi["hasPreviousPage"] is False
+    assert isinstance(pi["startCursor"], str)
+    assert isinstance(pi["endCursor"], str)
+
+
+def test_snake_case_page_info_works_as_deprecated_alias(gql_context, seeded_tasks):
+    """The legacy snake_case form (page_info + has_next_page etc.) still works."""
+    result = schema.execute_sync(GENERAL_TASKS_SNAKE_QUERY, context_value=gql_context)
+    assert result.errors is None, result.errors
+    pi = result.data["general_tasks"]["page_info"]
+    assert pi["has_next_page"] is True
+    assert pi["has_previous_page"] is False
+    assert isinstance(pi["start_cursor"], str)
+    assert isinstance(pi["end_cursor"], str)
+
+
+def test_both_forms_return_consistent_data(gql_context, seeded_tasks):
+    """camelCase and snake_case forms must return the same values."""
+    camel = schema.execute_sync(GENERAL_TASKS_CAMEL_QUERY, context_value=gql_context)
+    snake = schema.execute_sync(GENERAL_TASKS_SNAKE_QUERY, context_value=gql_context)
+    assert camel.errors is None
+    assert snake.errors is None
+    camel_pi = camel.data["general_tasks"]["pageInfo"]
+    snake_pi = snake.data["general_tasks"]["page_info"]
+    assert camel_pi["hasNextPage"] == snake_pi["has_next_page"]
+    assert camel_pi["hasPreviousPage"] == snake_pi["has_previous_page"]
+    assert camel_pi["startCursor"] == snake_pi["start_cursor"]
+    assert camel_pi["endCursor"] == snake_pi["end_cursor"]
+
+
+def test_mixed_naming_query_works(gql_context, seeded_tasks):
+    """Mixed-naming queries (pageInfo.has_next_page) work — the aliases compose."""
+    result = schema.execute_sync(GENERAL_TASKS_MIXED_QUERY, context_value=gql_context)
+    assert result.errors is None, result.errors
+    pi = result.data["general_tasks"]["pageInfo"]
+    assert pi["has_next_page"] is True
+    assert isinstance(pi["endCursor"], str)
+
+
+# ── Introspection: deprecation_reason is surfaced ─────────────────────────────
+
+
+def test_page_info_type_has_both_naming_forms_in_schema():
+    """The PageInfo SDL contains camelCase (no deprecation) AND snake_case (deprecated)."""
+    sdl = schema.as_str()
+    # PageInfo type block
+    import re
+
+    match = re.search(r"type PageInfo \{[^}]+\}", sdl, re.DOTALL)
+    assert match is not None
+    block = match.group(0)
+    # Modern Relay-spec camelCase form, no deprecation marker on these lines
+    assert "hasNextPage: Boolean!" in block
+    assert "hasPreviousPage: Boolean!" in block
+    assert "startCursor: String" in block
+    assert "endCursor: String" in block
+    # Legacy snake_case aliases, marked deprecated
+    assert 'has_next_page: Boolean! @deprecated(reason: "Use hasNextPage' in block
+    assert 'has_previous_page: Boolean! @deprecated(reason: "Use hasPreviousPage' in block
+    assert 'start_cursor: String @deprecated(reason: "Use startCursor' in block
+    assert 'end_cursor: String @deprecated(reason: "Use endCursor' in block
+
+
+def test_connection_pageinfo_field_has_alias_and_deprecation():
+    """Each connection's `pageInfo` field is the primary; `page_info` is deprecated."""
+    sdl = schema.as_str()
+    # Check a relay-derived connection (GeneralTaskConnection auto-generated from
+    # @relay.connection(CompatListConnection[GeneralTask]))
+    import re
+
+    match = re.search(r"type GeneralTaskConnection \{[^}]+\}", sdl, re.DOTALL)
+    assert match is not None
+    block = match.group(0)
+    assert "pageInfo: PageInfo!" in block
+    assert 'page_info: PageInfo! @deprecated(reason: "Use pageInfo' in block
+
+
+def test_introspection_marks_deprecation_reason():
+    """GraphQL introspection surfaces the deprecation reason — that's what
+    powers IDE warnings in Apollo Studio / GraphiQL."""
+    result = schema.execute_sync(
+        """
+        {
+            __type(name: "PageInfo") {
+                fields(includeDeprecated: true) {
+                    name
+                    isDeprecated
+                    deprecationReason
+                }
+            }
+        }
+        """
+    )
+    assert result.errors is None, result.errors
+    fields = {f["name"]: f for f in result.data["__type"]["fields"]}
+
+    # camelCase forms are NOT deprecated
+    assert fields["hasNextPage"]["isDeprecated"] is False
+    assert fields["endCursor"]["isDeprecated"] is False
+
+    # snake_case forms ARE deprecated with a reason
+    assert fields["has_next_page"]["isDeprecated"] is True
+    assert "hasNextPage" in fields["has_next_page"]["deprecationReason"]
+    assert fields["end_cursor"]["isDeprecated"] is True
+    assert "endCursor" in fields["end_cursor"]["deprecationReason"]


### PR DESCRIPTION
## Summary

Closes the highest-impact wire-breaking slice of ADR-001 Phase 1.

Cursor-pagination clients querying \`pageInfo { hasNextPage ... }\` — which is the [Relay Cursor Connections Spec](https://relay.dev/graphql/connections.htm) normative form — used to silently get \`null\` against the POC because the schema runs with \`auto_camel_case=False\` and so exposed PageInfo as snake_case only.

Per ADR-001: expose both forms, camelCase preferred, snake_case as \`@deprecated\` aliases. Existing clients keep working; new clients see the modern names in autocomplete with deprecation warnings on the legacy ones.

## What this adds

### `models/page_info.py` (new)

- **`CompatPageInfo`** — replaces relay's PageInfo. Primary fields are \`hasNextPage\`/\`hasPreviousPage\`/\`startCursor\`/\`endCursor\` (camelCase, Relay spec normative). Deprecated alias methods expose the snake_case forms.
- **`CompatListConnection`** — subclasses \`relay.ListConnection\`, overrides:
  - The inherited \`page_info\` field with the same Python attribute name but SDL field name \`pageInfo\` and \`CompatPageInfo\` type
  - A \`page_info\` deprecated method alongside
  - \`resolve_connection\` to substitute the relay PageInfo instance with a CompatPageInfo so the field annotation matches the runtime value
- Class has \`name=\"Connection\"\` so auto-generated \`XxxConnection\` types (e.g. \`GeneralTaskConnection\` from \`@relay.connection(CompatListConnection[GeneralTask])\`) get the legacy parity naming instead of \`GeneralTaskCompatListConnection\`.

### Replacements

- **\`models/relations.py\`** — \`FileRelationsConnection\` and \`TaskRelationsConnection\` now subclass \`CompatListConnection\` so they inherit pageInfo + deprecated page_info alias.
- **\`schema.py\`** — all 16 inline \`@relay.connection(relay.ListConnection[X])\` usages switched to \`@relay.connection(CompatListConnection[X])\`. Single-line import added; everything else mechanical.
- **\`models/object_identity.py\`** — \`ObjectIdentitiesPageInfo\` and \`ObjectIdentitiesConnection\` (custom non-relay types) updated to expose both naming forms manually, matching the same pattern.

### Tests

- **\`tests/test_page_info_compat.py\`** (new) — 7 tests:
  - \`test_camel_case_page_info_works\` — \`pageInfo { hasNextPage }\` returns real data
  - \`test_snake_case_page_info_works_as_deprecated_alias\` — \`page_info { has_next_page }\` returns the same data
  - \`test_both_forms_return_consistent_data\` — camelCase and snake_case agree
  - \`test_mixed_naming_query_works\` — \`pageInfo { has_next_page endCursor }\` composes correctly
  - \`test_page_info_type_has_both_naming_forms_in_schema\` — SDL inspection
  - \`test_connection_pageinfo_field_has_alias_and_deprecation\` — Connection-level field
  - \`test_introspection_marks_deprecation_reason\` — \`{ __type(name: \"PageInfo\") { fields(includeDeprecated: true) { isDeprecated deprecationReason } } }\` works

## SDL impact

Every relay-derived connection in POC now has the **legacy parity name** (\`GeneralTaskConnection\`, \`RuptureSetConnection\`, etc.) instead of the previous \`GeneralTaskCompatListConnection\` auto-naming.

PageInfo type:

\`\`\`graphql
type PageInfo {
  hasNextPage: Boolean!
  hasPreviousPage: Boolean!
  startCursor: String
  endCursor: String
  has_next_page: Boolean! @deprecated(reason: \"Use hasNextPage instead (Relay Cursor Connections Spec normative).\")
  has_previous_page: Boolean! @deprecated(reason: \"Use hasPreviousPage instead (Relay Cursor Connections Spec normative).\")
  start_cursor: String @deprecated(reason: \"Use startCursor instead (Relay Cursor Connections Spec normative).\")
  end_cursor: String @deprecated(reason: \"Use endCursor instead (Relay Cursor Connections Spec normative).\")
}
\`\`\`

Every relay-derived connection:

\`\`\`graphql
type GeneralTaskConnection {
  pageInfo: PageInfo!
  edges: [GeneralTaskEdge!]!
  page_info: PageInfo! @deprecated(reason: \"Use pageInfo instead (Relay Cursor Connections Spec normative).\")
}
\`\`\`

\`SearchResultConnection\` (custom non-relay type with no pageInfo at all in either schema) is left untouched — separate concern.

## Test plan

- [x] \`uv run pytest tests/test_page_info_compat.py\` — 7 passed
- [x] \`uv run pytest tests/\` — **158 passed, 1 skipped** (was 151/1 on spike base; +7 from new tests)
- [x] Both \`pageInfo\` and \`page_info\` queries return consistent data
- [x] Introspection surfaces deprecation_reason for IDE warnings
- [x] All 16 existing inline \`relay.ListConnection[X]\` usages replaced

## Stacking

Targets \`strawberry-poc-spike\`. After #296 merges to \`deploy-test\`, retarget to \`deploy-test\`. Independent of #303 (scalars) — they touch different surfaces and can land in either order.

**Depends on:** #296.

## Phase 1 remaining (after this)

- \`clientMutationId\` on every mutation input/payload — mechanical addition to ~30 inputs + ~30 payloads (separate PR)
- Naming alignment for the remaining custom non-relay Connection types (\`SearchResultConnection\`)

See [ADR-001](https://github.com/GNS-Science/nshm-toshi-api/blob/strawberry-poc-adrs/docs/adrs/ADR-001-graphql-schema-evolution-strategy.md) for the full strategy.

## Stack now

\`\`\`
deploy-test
   └── strawberry-poc-spike          (#296)
        ├── strawberry-poc-deploy          (#297)
        ├── strawberry-poc-ci              (#298)
        ├── strawberry-poc-compression     (#299)
        ├── strawberry-poc-s3-fallback     (#300)
        ├── strawberry-poc-schema-parity   (#301)
        ├── strawberry-poc-adrs            (#302)
        ├── strawberry-poc-phase1-scalars  (#303)
        └── strawberry-poc-phase1-pageinfo (this PR)
\`\`\`