### PR TITLE
feat: clientMutationId backwards-compat (ADR-001 Phase 1)

### DIFF
--- a/spike/strawberry_poc/models/aggregate_inversion_solution.py
+++ b/spike/strawberry_poc/models/aggregate_inversion_solution.py
@@ -11,7 +11,7 @@ from strawberry.types import Info
 from data.dynamo import create_file, get_file, list_files
 from data.models import AggregateInversionSolutionData
 
-from .common import AggregationFn, BigInt, KeyValuePair, KeyValuePairInput, _try_enum
+from .common import AggregationFn, BigInt, client_mutation_id_input_field, KeyValuePair, KeyValuePairInput, _try_enum
 from .file_interface import FileInterface
 from .inversion_solution import LabelledTableRelation, _ltr_from_dict
 from .inversion_solution_interface import InversionSolutionInterface
@@ -104,6 +104,7 @@ class CreateAggregateInversionSolutionInput:
     meta: list[KeyValuePairInput] | None = None
     created: str | None = None
     predecessors: list[PredecessorInput] | None = None
+    client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 def resolve_aggregate_inversion_solutions(info: Info) -> Iterable[AggregateInversionSolution]:

--- a/spike/strawberry_poc/models/automation_task.py
+++ b/spike/strawberry_poc/models/automation_task.py
@@ -19,7 +19,7 @@ from strawberry.types import Info
 from data.dynamo import create_thing, get_thing, list_things, update_thing
 from data.models import AutomationTaskData
 
-from .common import EventResult, EventState, KeyValuePair, KeyValuePairInput, ModelType, TaskSubType, _try_enum
+from .common import client_mutation_id_input_field, EventResult, EventState, KeyValuePair, KeyValuePairInput, ModelType, TaskSubType, _try_enum
 from .relations import (
     FileRelation,
     FileRelationsConnection,
@@ -172,6 +172,7 @@ class CreateAutomationTaskInput:
     arguments: list[KeyValuePairInput] | None = None
     environment: list[KeyValuePairInput] | None = None
     metrics: list[KeyValuePairInput] | None = None
+    client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 @strawberry.input
@@ -183,6 +184,7 @@ class UpdateAutomationTaskInput:
     arguments: list[KeyValuePairInput] | None = None
     environment: list[KeyValuePairInput] | None = None
     metrics: list[KeyValuePairInput] | None = None
+    client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 # ── Resolvers ─────────────────────────────────────────────────────────────────

--- a/spike/strawberry_poc/models/common.py
+++ b/spike/strawberry_poc/models/common.py
@@ -29,6 +29,48 @@ BigInt = strawberry.scalar(
 )
 
 
+# ADR-001 Phase 1: Relay 1 clientMutationId backwards-compatibility.
+# Every mutation input and payload exposes `clientMutationId: String` as a
+# deprecated field. Inputs accept it (legacy Relay 1 clients send it); payloads
+# echo it back (legacy clients read it). Modern Relay 2 / Apollo / urql clients
+# can omit it entirely. Helpers below return fresh strawberry.field metadata so
+# each class definition gets its own field instance (Strawberry's field()
+# returns mutable metadata, sharing it across classes confuses the framework).
+
+
+def client_mutation_id_input_field():
+    """Field metadata for `clientMutationId: String` on mutation INPUT types.
+
+    Accepted from Relay 1 clients; passed through to the payload unchanged.
+    Marked deprecated so introspection / IDE autocomplete shows a warning.
+    """
+    return strawberry.field(
+        name="clientMutationId",
+        default=None,
+        deprecation_reason=(
+            "Relay 1 ClientIDMutation holdover — modern Relay 2 / Apollo / urql clients "
+            "can omit this. When provided, the value is echoed back unchanged in the "
+            "mutation payload's clientMutationId field."
+        ),
+    )
+
+
+def client_mutation_id_payload_field():
+    """Field metadata for `clientMutationId: String` on mutation PAYLOAD types.
+
+    Echoes back the value from the input when provided. Marked deprecated.
+    """
+    return strawberry.field(
+        name="clientMutationId",
+        default=None,
+        deprecation_reason=(
+            "Relay 1 ClientIDMutation holdover — echoes the value passed to the input's "
+            "clientMutationId field, or null if none was sent. Modern Relay 2 / Apollo / "
+            "urql clients can ignore."
+        ),
+    )
+
+
 @strawberry.type
 class KeyValuePair:
     k: str

--- a/spike/strawberry_poc/models/file.py
+++ b/spike/strawberry_poc/models/file.py
@@ -16,7 +16,7 @@ from strawberry.types import Info
 from data.dynamo import create_file, get_file, list_files
 from data.models import ToshiFileData
 
-from .common import BigInt, KeyValuePair, KeyValuePairInput
+from .common import BigInt, client_mutation_id_input_field, KeyValuePair, KeyValuePairInput
 from .file_interface import FileInterface
 from .relations import FileRelation, FileRelationsConnection, build_file_relations_for_file
 
@@ -65,6 +65,7 @@ class CreateFileInput:
     file_size: BigInt | None = None
     meta: list[KeyValuePairInput] | None = None
     created: str | None = None
+    client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 def resolve_files(info: Info) -> Iterable[ToshiFile]:

--- a/spike/strawberry_poc/models/general_task.py
+++ b/spike/strawberry_poc/models/general_task.py
@@ -19,6 +19,7 @@ from data.dynamo import create_thing, get_thing, list_things, update_thing
 from data.models import GeneralTaskData
 
 from .common import (
+    client_mutation_id_input_field,
     EventResult,
     KeyValueListPair,
     KeyValueListPairInput,
@@ -129,6 +130,7 @@ class CreateGeneralTaskInput:
     model_type: ModelType | None = None
     argument_lists: list[KeyValueListPairInput] | None = None
     meta: list[KeyValuePairInput] | None = None
+    client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 @strawberry.input
@@ -145,6 +147,7 @@ class UpdateGeneralTaskInput:
     model_type: ModelType | None = None
     argument_lists: list[KeyValueListPairInput] | None = None
     meta: list[KeyValuePairInput] | None = None
+    client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 def resolve_general_tasks(info: Info) -> Iterable[GeneralTask]:

--- a/spike/strawberry_poc/models/inversion_solution.py
+++ b/spike/strawberry_poc/models/inversion_solution.py
@@ -21,6 +21,7 @@ from data.models import InversionSolutionData
 
 from .common import (
     BigInt,
+    client_mutation_id_input_field,
     KeyValueListPair,
     KeyValueListPairInput,
     KeyValuePair,
@@ -143,12 +144,14 @@ class CreateInversionSolutionInput:
     metrics: list[KeyValuePairInput] | None = None
     tables: list[LabelledTableRelationInput] | None = None
     predecessors: list[PredecessorInput] | None = None
+    client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 @strawberry.input
 class AppendInversionSolutionTablesInput:
     id: strawberry.ID
     tables: list[LabelledTableRelationInput]
+    client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 # ── Resolvers + mutations ─────────────────────────────────────────────────────

--- a/spike/strawberry_poc/models/inversion_solution_nrml.py
+++ b/spike/strawberry_poc/models/inversion_solution_nrml.py
@@ -11,7 +11,7 @@ from strawberry.types import Info
 from data.dynamo import create_file, get_file, list_files
 from data.models import InversionSolutionNrmlData
 
-from .common import BigInt, KeyValuePair, KeyValuePairInput
+from .common import BigInt, client_mutation_id_input_field, KeyValuePair, KeyValuePairInput
 from .file_interface import FileInterface
 from .predecessor import PredecessorInput
 from .predecessors_interface import PredecessorsInterface
@@ -65,6 +65,7 @@ class CreateInversionSolutionNrmlInput:
     meta: list[KeyValuePairInput] | None = None
     created: str | None = None
     predecessors: list[PredecessorInput] | None = None
+    client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 def resolve_inversion_solution_nrmls(info: Info) -> Iterable[InversionSolutionNrml]:

--- a/spike/strawberry_poc/models/openquake_hazard_config.py
+++ b/spike/strawberry_poc/models/openquake_hazard_config.py
@@ -10,6 +10,7 @@ from strawberry.types import Info
 
 from data.dynamo import create_thing, get_file, get_thing, list_things
 from data.models import OpenquakeHazardConfigData
+from models.common import client_mutation_id_input_field
 from models.file import ToshiFile
 from models.inversion_solution_nrml import InversionSolutionNrml
 
@@ -89,6 +90,7 @@ class CreateOpenquakeHazardConfigInput:
     template_archive: strawberry.ID
     source_models: list[strawberry.ID] | None = None
     created: str | None = None
+    client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 def resolve_openquake_hazard_configs(info: Info) -> Iterable[OpenquakeHazardConfig]:

--- a/spike/strawberry_poc/models/openquake_hazard_solution.py
+++ b/spike/strawberry_poc/models/openquake_hazard_solution.py
@@ -13,7 +13,7 @@ from data.models import OpenquakeHazardSolutionData
 from models.file import ToshiFile
 from models.openquake_hazard_task import OpenquakeHazardTask
 
-from .common import KeyValuePair, KeyValuePairInput, OpenquakeTaskType
+from .common import client_mutation_id_input_field, KeyValuePair, KeyValuePairInput, OpenquakeTaskType
 from .predecessor import PredecessorInput
 from .predecessors_interface import PredecessorsInterface
 
@@ -105,6 +105,7 @@ class CreateOpenquakeHazardSolutionInput:
     metrics: list[KeyValuePairInput] | None = None
     meta: list[KeyValuePairInput] | None = None
     predecessors: list[PredecessorInput] | None = None
+    client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 def resolve_openquake_hazard_solutions(info: Info) -> Iterable[OpenquakeHazardSolution]:

--- a/spike/strawberry_poc/models/openquake_hazard_task.py
+++ b/spike/strawberry_poc/models/openquake_hazard_task.py
@@ -11,7 +11,7 @@ from strawberry.types import Info
 from data.dynamo import create_thing, get_thing, list_things, update_thing
 from data.models import OpenquakeHazardTaskData
 
-from .common import EventResult, EventState, KeyValuePair, KeyValuePairInput, ModelType, TaskSubType, _try_enum
+from .common import client_mutation_id_input_field, EventResult, EventState, KeyValuePair, KeyValuePairInput, ModelType, TaskSubType, _try_enum
 from .relations import (
     FileRelation,
     FileRelationsConnection,
@@ -120,6 +120,7 @@ class CreateOpenquakeHazardTaskInput:
     gmcm_logic_tree: str | None = None
     openquake_config: str | None = None
     hazard_solution: strawberry.ID | None = None
+    client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 @strawberry.input
@@ -132,6 +133,7 @@ class UpdateOpenquakeHazardTaskInput:
     environment: list[KeyValuePairInput] | None = None
     metrics: list[KeyValuePairInput] | None = None
     hazard_solution: strawberry.ID | None = None
+    client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 def resolve_openquake_hazard_tasks(info: Info) -> Iterable[OpenquakeHazardTask]:

--- a/spike/strawberry_poc/models/relations.py
+++ b/spike/strawberry_poc/models/relations.py
@@ -21,7 +21,7 @@ from strawberry.types import Info
 
 from data.dynamo import create_file_relation, create_task_relation, get_file, get_thing
 
-from .common import FileRole
+from .common import client_mutation_id_input_field, FileRole
 
 # ── Lazy forward references (break circular deps) ─────────────────────────────
 
@@ -268,12 +268,14 @@ class CreateFileRelationInput:
     thing_id: strawberry.ID
     file_id: strawberry.ID
     role: FileRole
+    client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 @strawberry.input
 class CreateTaskRelationInput:
     parent_id: strawberry.ID
     child_id: strawberry.ID
+    client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 # ── Builder helpers (called from Thing/File from_dict) ────────────────────────

--- a/spike/strawberry_poc/models/rupture_set.py
+++ b/spike/strawberry_poc/models/rupture_set.py
@@ -18,7 +18,7 @@ from data.dynamo import create_file, get_file, get_thing, list_files
 from data.models import RuptureSetData
 
 from .automation_task import RuptureGenerationTask  # noqa: F401 — re-exported for schema.py
-from .common import BigInt, KeyValuePair, KeyValuePairInput
+from .common import BigInt, client_mutation_id_input_field, KeyValuePair, KeyValuePairInput
 from .file_interface import FileInterface
 
 # ── RuptureSet ────────────────────────────────────────────────────────────────
@@ -77,6 +77,7 @@ class CreateRuptureSetInput:
     created: str | None = None
     fault_models: list[str] | None = None
     metrics: list[KeyValuePairInput] | None = None
+    client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 def resolve_rupture_sets(info: Info) -> Iterable[RuptureSet]:

--- a/spike/strawberry_poc/models/scaled_inversion_solution.py
+++ b/spike/strawberry_poc/models/scaled_inversion_solution.py
@@ -11,7 +11,7 @@ from strawberry.types import Info
 from data.dynamo import create_file, get_file, list_files
 from data.models import ScaledInversionSolutionData
 
-from .common import BigInt, KeyValuePair, KeyValuePairInput
+from .common import BigInt, client_mutation_id_input_field, KeyValuePair, KeyValuePairInput
 from .file_interface import FileInterface
 from .inversion_solution import InversionSolution, LabelledTableRelation, _ltr_from_dict
 from .inversion_solution_interface import InversionSolutionInterface
@@ -110,6 +110,7 @@ class CreateScaledInversionSolutionInput:
     meta: list[KeyValuePairInput] | None = None
     created: str | None = None
     predecessors: list[PredecessorInput] | None = None
+    client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 def resolve_scaled_inversion_solutions(info: Info) -> Iterable[ScaledInversionSolution]:

--- a/spike/strawberry_poc/models/sms_file.py
+++ b/spike/strawberry_poc/models/sms_file.py
@@ -12,7 +12,7 @@ from strawberry.types import Info
 from data.dynamo import create_file, get_file, list_files
 from data.models import SmsFileData
 
-from .common import BigInt, KeyValuePair, SmsFileType, _try_enum
+from .common import BigInt, client_mutation_id_input_field, KeyValuePair, SmsFileType, _try_enum
 from .file_interface import FileInterface
 from .relations import FileRelation, FileRelationsConnection, build_file_relations_for_file
 
@@ -57,6 +57,7 @@ class CreateSmsFileInput:
     md5_digest: str | None = None
     file_size: BigInt | None = None
     created: str | None = None
+    client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 def resolve_sms_files(info: Info) -> Iterable[SmsFile]:

--- a/spike/strawberry_poc/models/strong_motion_station.py
+++ b/spike/strawberry_poc/models/strong_motion_station.py
@@ -12,7 +12,7 @@ from strawberry.types import Info
 from data.dynamo import create_thing, get_thing, list_things
 from data.models import StrongMotionStationData
 
-from .common import SmsSiteClass, SmsSiteClassBasis, _try_enum
+from .common import client_mutation_id_input_field, SmsSiteClass, SmsSiteClassBasis, _try_enum
 from .relations import FileRelation, FileRelationsConnection, build_file_relations_for_thing
 
 
@@ -74,6 +74,7 @@ class CreateStrongMotionStationInput:
     soft_clay_or_peat: bool | None = None
     created: str | None = None
     updated: str | None = None
+    client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 def resolve_strong_motion_stations(info: Info) -> Iterable[StrongMotionStation]:

--- a/spike/strawberry_poc/models/table.py
+++ b/spike/strawberry_poc/models/table.py
@@ -9,7 +9,7 @@ from strawberry.types import Info
 from data.dynamo import create_table, get_table
 from data.models import TableData
 
-from .common import KeyValueListPair, KeyValueListPairInput, KeyValuePair, KeyValuePairInput, TableType, _try_enum
+from .common import client_mutation_id_input_field, KeyValueListPair, KeyValueListPairInput, KeyValuePair, KeyValuePairInput, TableType, _try_enum
 
 
 @strawberry.type
@@ -59,6 +59,7 @@ class CreateTableInput:
     meta: list[KeyValuePairInput] | None = None
     table_type: TableType | None = None
     dimensions: list[KeyValueListPairInput] | None = None
+    client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 def mutate_create_table(info: Info, input: CreateTableInput) -> Table:

--- a/spike/strawberry_poc/models/time_dependent_inversion_solution.py
+++ b/spike/strawberry_poc/models/time_dependent_inversion_solution.py
@@ -11,7 +11,7 @@ from strawberry.types import Info
 from data.dynamo import create_file, get_file, list_files
 from data.models import TimeDependentInversionSolutionData
 
-from .common import BigInt, KeyValuePair, KeyValuePairInput
+from .common import BigInt, client_mutation_id_input_field, KeyValuePair, KeyValuePairInput
 from .file_interface import FileInterface
 from .inversion_solution import InversionSolution, LabelledTableRelation, _ltr_from_dict
 from .inversion_solution_interface import InversionSolutionInterface
@@ -78,6 +78,7 @@ class CreateTimeDependentInversionSolutionInput:
     meta: list[KeyValuePairInput] | None = None
     created: str | None = None
     predecessors: list[PredecessorInput] | None = None
+    client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 def resolve_time_dependent_inversion_solutions(info: Info) -> Iterable[TimeDependentInversionSolution]:

--- a/spike/strawberry_poc/schema.py
+++ b/spike/strawberry_poc/schema.py
@@ -22,6 +22,7 @@ import data.search as _data_search
 from data.dynamo import es_key_for, get_object, scan_objects_paginated
 from data.s3 import scan_s3_paginated
 from data.search import search as es_search
+from models.common import client_mutation_id_payload_field
 from models.aggregate_inversion_solution import (
     AggregateInversionSolution,
     CreateAggregateInversionSolutionInput,
@@ -203,125 +204,147 @@ def _dispatch_search(hit: dict) -> SearchResult | None:  # noqa: C901
 @strawberry.type
 class CreateGeneralTaskPayload:
     general_task: GeneralTask | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
 class UpdateGeneralTaskPayload:
     general_task: GeneralTask | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
 class CreateRuptureGenerationTaskPayload:
     task_result: RuptureGenerationTask | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
 class UpdateRuptureGenerationTaskPayload:
     task_result: RuptureGenerationTask | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
 class CreateAutomationTaskPayload:
     task_result: AutomationTask | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
 class UpdateAutomationTaskPayload:
     task_result: AutomationTask | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
 class CreateFilePayload:
     ok: bool | None = None
     file_result: ToshiFile | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
 class CreateSmsFilePayload:
     ok: bool | None = None
     file_result: SmsFile | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
 class CreateStrongMotionStationPayload:
     strong_motion_station: StrongMotionStation | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
 class CreateRuptureSetPayload:
     ok: bool | None = None
     rupture_set: RuptureSet | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
 class CreateFileRelationPayload:
     ok: bool | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
 class CreateTaskRelationPayload:
     ok: bool | None = None
     thing_relation: TaskTaskRelation | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
 class CreateInversionSolutionPayload:
     ok: bool | None = None
     inversion_solution: InversionSolution | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
 class AppendInversionSolutionTablesPayload:
     ok: bool | None = None
     inversion_solution: InversionSolution | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
 class CreateScaledInversionSolutionPayload:
     ok: bool | None = None
     solution: ScaledInversionSolution | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
 class CreateAggregateInversionSolutionPayload:
     ok: bool | None = None
     solution: AggregateInversionSolution | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
 class CreateTimeDependentInversionSolutionPayload:
     ok: bool | None = None
     solution: TimeDependentInversionSolution | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
 class CreateInversionSolutionNrmlPayload:
     ok: bool | None = None
     inversion_solution_nrml: InversionSolutionNrml | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
 class CreateOpenquakeHazardConfigPayload:
     ok: bool | None = None
     config: OpenquakeHazardConfig | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
 class CreateOpenquakeHazardSolutionPayload:
     ok: bool | None = None
     openquake_hazard_solution: OpenquakeHazardSolution | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
 class CreateOpenquakeHazardTaskPayload:
     ok: bool | None = None
     task_result: OpenquakeHazardTask | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
 class UpdateOpenquakeHazardTaskPayload:
     ok: bool | None = None
     task_result: OpenquakeHazardTask | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
@@ -334,6 +357,7 @@ class NodeFilterPayload:
 class CreateTablePayload:
     ok: bool | None = None
     table: Table | None = None
+    client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type
@@ -477,145 +501,133 @@ class Mutation:
     def create_general_task(
         self, info: strawberry.types.Info, input: CreateGeneralTaskInput
     ) -> CreateGeneralTaskPayload:
-        return CreateGeneralTaskPayload(general_task=mutate_create_general_task(info, input))
+        return CreateGeneralTaskPayload(general_task=mutate_create_general_task(info, input), client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def update_general_task(
         self, info: strawberry.types.Info, input: UpdateGeneralTaskInput
     ) -> UpdateGeneralTaskPayload:
-        return UpdateGeneralTaskPayload(general_task=mutate_update_general_task(info, input))
+        return UpdateGeneralTaskPayload(general_task=mutate_update_general_task(info, input), client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def create_rupture_set(self, info: strawberry.types.Info, input: CreateRuptureSetInput) -> CreateRuptureSetPayload:
-        return CreateRuptureSetPayload(ok=True, rupture_set=mutate_create_rupture_set(info, input))
+        return CreateRuptureSetPayload(ok=True, rupture_set=mutate_create_rupture_set(info, input), client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def create_file(self, info: strawberry.types.Info, input: CreateFileInput) -> CreateFilePayload:
-        return CreateFilePayload(ok=True, file_result=mutate_create_file(info, input))
+        return CreateFilePayload(ok=True, file_result=mutate_create_file(info, input), client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def create_sms_file(self, info: strawberry.types.Info, input: CreateSmsFileInput) -> CreateSmsFilePayload:
-        return CreateSmsFilePayload(ok=True, file_result=mutate_create_sms_file(info, input))
+        return CreateSmsFilePayload(ok=True, file_result=mutate_create_sms_file(info, input), client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def create_strong_motion_station(
         self, info: strawberry.types.Info, input: CreateStrongMotionStationInput
     ) -> CreateStrongMotionStationPayload:
-        return CreateStrongMotionStationPayload(strong_motion_station=mutate_create_strong_motion_station(info, input))
+        return CreateStrongMotionStationPayload(strong_motion_station=mutate_create_strong_motion_station(info, input), client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def create_automation_task(
         self, info: strawberry.types.Info, input: CreateAutomationTaskInput
     ) -> CreateAutomationTaskPayload:
-        return CreateAutomationTaskPayload(task_result=mutate_create_automation_task(info, input))
+        return CreateAutomationTaskPayload(task_result=mutate_create_automation_task(info, input), client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def create_rupture_generation_task(
         self, info: strawberry.types.Info, input: CreateAutomationTaskInput
     ) -> CreateRuptureGenerationTaskPayload:
-        return CreateRuptureGenerationTaskPayload(task_result=mutate_create_rupture_generation_task(info, input))
+        return CreateRuptureGenerationTaskPayload(task_result=mutate_create_rupture_generation_task(info, input), client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def update_rupture_generation_task(
         self, info: strawberry.types.Info, input: UpdateAutomationTaskInput
     ) -> UpdateRuptureGenerationTaskPayload:
-        return UpdateRuptureGenerationTaskPayload(task_result=mutate_update_rupture_generation_task(info, input))
+        return UpdateRuptureGenerationTaskPayload(task_result=mutate_update_rupture_generation_task(info, input), client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def update_automation_task(
         self, info: strawberry.types.Info, input: UpdateAutomationTaskInput
     ) -> UpdateAutomationTaskPayload:
-        return UpdateAutomationTaskPayload(task_result=mutate_update_automation_task(info, input))
+        return UpdateAutomationTaskPayload(task_result=mutate_update_automation_task(info, input), client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def create_inversion_solution(
         self, info: strawberry.types.Info, input: CreateInversionSolutionInput
     ) -> CreateInversionSolutionPayload:
-        return CreateInversionSolutionPayload(ok=True, inversion_solution=mutate_create_inversion_solution(info, input))
+        return CreateInversionSolutionPayload(ok=True, inversion_solution=mutate_create_inversion_solution(info, input), client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def create_table(self, info: strawberry.types.Info, input: CreateTableInput) -> CreateTablePayload:
-        return CreateTablePayload(ok=True, table=mutate_create_table(info, input))
+        return CreateTablePayload(ok=True, table=mutate_create_table(info, input), client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def append_inversion_solution_tables(
         self, info: strawberry.types.Info, input: AppendInversionSolutionTablesInput
     ) -> AppendInversionSolutionTablesPayload:
-        return AppendInversionSolutionTablesPayload(
-            ok=True, inversion_solution=mutate_append_inversion_solution_tables(info, input)
-        )
+        return AppendInversionSolutionTablesPayload(ok=True, inversion_solution=mutate_append_inversion_solution_tables(info, input), client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def create_scaled_inversion_solution(
         self, info: strawberry.types.Info, input: CreateScaledInversionSolutionInput
     ) -> CreateScaledInversionSolutionPayload:
-        return CreateScaledInversionSolutionPayload(
-            ok=True, solution=mutate_create_scaled_inversion_solution(info, input)
-        )
+        return CreateScaledInversionSolutionPayload(ok=True, solution=mutate_create_scaled_inversion_solution(info, input), client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def create_aggregate_inversion_solution(
         self, info: strawberry.types.Info, input: CreateAggregateInversionSolutionInput
     ) -> CreateAggregateInversionSolutionPayload:
-        return CreateAggregateInversionSolutionPayload(
-            ok=True, solution=mutate_create_aggregate_inversion_solution(info, input)
-        )
+        return CreateAggregateInversionSolutionPayload(ok=True, solution=mutate_create_aggregate_inversion_solution(info, input), client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def create_time_dependent_inversion_solution(
         self, info: strawberry.types.Info, input: CreateTimeDependentInversionSolutionInput
     ) -> CreateTimeDependentInversionSolutionPayload:
-        return CreateTimeDependentInversionSolutionPayload(
-            ok=True, solution=mutate_create_time_dependent_inversion_solution(info, input)
-        )
+        return CreateTimeDependentInversionSolutionPayload(ok=True, solution=mutate_create_time_dependent_inversion_solution(info, input), client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def create_inversion_solution_nrml(
         self, info: strawberry.types.Info, input: CreateInversionSolutionNrmlInput
     ) -> CreateInversionSolutionNrmlPayload:
-        return CreateInversionSolutionNrmlPayload(
-            ok=True, inversion_solution_nrml=mutate_create_inversion_solution_nrml(info, input)
-        )
+        return CreateInversionSolutionNrmlPayload(ok=True, inversion_solution_nrml=mutate_create_inversion_solution_nrml(info, input), client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def create_openquake_hazard_config(
         self, info: strawberry.types.Info, input: CreateOpenquakeHazardConfigInput
     ) -> CreateOpenquakeHazardConfigPayload:
-        return CreateOpenquakeHazardConfigPayload(ok=True, config=mutate_create_openquake_hazard_config(info, input))
+        return CreateOpenquakeHazardConfigPayload(ok=True, config=mutate_create_openquake_hazard_config(info, input), client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def create_openquake_hazard_solution(
         self, info: strawberry.types.Info, input: CreateOpenquakeHazardSolutionInput
     ) -> CreateOpenquakeHazardSolutionPayload:
-        return CreateOpenquakeHazardSolutionPayload(
-            ok=True, openquake_hazard_solution=mutate_create_openquake_hazard_solution(info, input)
-        )
+        return CreateOpenquakeHazardSolutionPayload(ok=True, openquake_hazard_solution=mutate_create_openquake_hazard_solution(info, input), client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def create_openquake_hazard_task(
         self, info: strawberry.types.Info, input: CreateOpenquakeHazardTaskInput
     ) -> CreateOpenquakeHazardTaskPayload:
-        return CreateOpenquakeHazardTaskPayload(ok=True, task_result=mutate_create_openquake_hazard_task(info, input))
+        return CreateOpenquakeHazardTaskPayload(ok=True, task_result=mutate_create_openquake_hazard_task(info, input), client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def update_openquake_hazard_task(
         self, info: strawberry.types.Info, input: UpdateOpenquakeHazardTaskInput
     ) -> UpdateOpenquakeHazardTaskPayload:
-        return UpdateOpenquakeHazardTaskPayload(ok=True, task_result=mutate_update_openquake_hazard_task(info, input))
+        return UpdateOpenquakeHazardTaskPayload(ok=True, task_result=mutate_update_openquake_hazard_task(info, input), client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def create_file_relation(
         self, info: strawberry.types.Info, input: CreateFileRelationInput
     ) -> CreateFileRelationPayload:
         mutate_create_file_relation(info, input)
-        return CreateFileRelationPayload(ok=True)
+        return CreateFileRelationPayload(ok=True, client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def create_task_relation(
         self, info: strawberry.types.Info, input: CreateTaskRelationInput
     ) -> CreateTaskRelationPayload:
         relation = mutate_create_task_relation(info, input)
-        return CreateTaskRelationPayload(ok=True, thing_relation=relation)
+        return CreateTaskRelationPayload(ok=True, thing_relation=relation, client_mutation_id=input.client_mutation_id)
 
     @strawberry.mutation
     def reindex(self, info: strawberry.types.Info, id_in: list[strawberry.ID]) -> ReindexPayload:

--- a/spike/strawberry_poc/tests/test_client_mutation_id_compat.py
+++ b/spike/strawberry_poc/tests/test_client_mutation_id_compat.py
@@ -1,0 +1,160 @@
+"""
+Tests for the Relay 1 clientMutationId backwards-compatibility layer.
+
+ADR-001 Phase 1: every mutation input/payload exposes `clientMutationId`
+as a deprecated alias. Legacy Relay 1 clients sending it get their value
+echoed back unchanged in the payload. Modern Relay 2 / Apollo clients can
+omit it entirely.
+"""
+
+import pytest
+
+from schema import schema
+
+
+CREATE_WITH_CMI_MUTATION = """
+mutation CreateWithCMI($input: CreateGeneralTaskInput!) {
+    create_general_task(input: $input) {
+        general_task { id title }
+        clientMutationId
+    }
+}
+"""
+
+CREATE_WITHOUT_CMI_MUTATION = """
+mutation CreateWithoutCMI($input: CreateGeneralTaskInput!) {
+    create_general_task(input: $input) {
+        general_task { id title }
+        clientMutationId
+    }
+}
+"""
+
+CREATE_FILE_WITH_CMI_MUTATION = """
+mutation CreateFileWithCMI($input: CreateFileInput!) {
+    create_file(input: $input) {
+        ok
+        file_result { id file_name }
+        clientMutationId
+    }
+}
+"""
+
+
+def test_input_accepts_client_mutation_id_and_payload_echoes(gql_context):
+    """A clientMutationId passed in the input is echoed back in the payload."""
+    cmi = "client-id-12345"
+    result = schema.execute_sync(
+        CREATE_WITH_CMI_MUTATION,
+        variable_values={"input": {"title": "task with CMI", "clientMutationId": cmi}},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    payload = result.data["create_general_task"]
+    assert payload["general_task"]["title"] == "task with CMI"
+    assert payload["clientMutationId"] == cmi
+
+
+def test_omitted_client_mutation_id_yields_null_in_payload(gql_context):
+    """Modern Relay 2 / Apollo clients omit clientMutationId — payload returns null."""
+    result = schema.execute_sync(
+        CREATE_WITHOUT_CMI_MUTATION,
+        variable_values={"input": {"title": "task without CMI"}},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    payload = result.data["create_general_task"]
+    assert payload["general_task"]["title"] == "task without CMI"
+    assert payload["clientMutationId"] is None
+
+
+def test_round_trip_works_on_other_mutations(gql_context):
+    """The CMI compat field works on more than just GeneralTask mutations."""
+    cmi = "file-create-cmi"
+    result = schema.execute_sync(
+        CREATE_FILE_WITH_CMI_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "cmi-test.zip",
+                "md5_digest": "abc",
+                "file_size": 1024,
+                "clientMutationId": cmi,
+            }
+        },
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    payload = result.data["create_file"]
+    assert payload["ok"] is True
+    assert payload["clientMutationId"] == cmi
+
+
+def test_sdl_has_client_mutation_id_on_every_mutation_input():
+    """All Create*/Update*/Append*Input types must expose clientMutationId."""
+    sdl = schema.as_str()
+    import re
+
+    inputs = re.findall(r"input ((?:Create|Update|Append)\w+Input) \{[^}]+\}", sdl, re.DOTALL)
+    assert len(inputs) > 15, f"expected many inputs, found {len(inputs)}"
+    blocks = re.findall(
+        r"input (?:Create|Update|Append)\w+Input \{[^}]+\}", sdl, re.DOTALL
+    )
+    for block in blocks:
+        assert "clientMutationId: String" in block, f"missing clientMutationId in:\n{block}"
+
+
+def test_sdl_has_client_mutation_id_on_every_mutation_payload():
+    """All Create*/Update*/Append*Payload types must expose clientMutationId."""
+    sdl = schema.as_str()
+    import re
+
+    payloads = re.findall(r"type ((?:Create|Update|Append)\w+Payload) \{[^}]+\}", sdl, re.DOTALL)
+    assert len(payloads) > 15, f"expected many payloads, found {len(payloads)}"
+    blocks = re.findall(
+        r"type (?:Create|Update|Append)\w+Payload \{[^}]+\}", sdl, re.DOTALL
+    )
+    for block in blocks:
+        assert "clientMutationId: String" in block, f"missing clientMutationId in:\n{block}"
+
+
+def test_introspection_marks_client_mutation_id_deprecated():
+    """The clientMutationId fields must surface as deprecated in introspection."""
+    result = schema.execute_sync(
+        """
+        {
+            __type(name: "CreateGeneralTaskInput") {
+                inputFields(includeDeprecated: true) {
+                    name
+                    isDeprecated
+                    deprecationReason
+                }
+            }
+        }
+        """
+    )
+    assert result.errors is None, result.errors
+    fields = {f["name"]: f for f in result.data["__type"]["inputFields"]}
+    assert "clientMutationId" in fields
+    cmi = fields["clientMutationId"]
+    assert cmi["isDeprecated"] is True
+    assert "Relay 1" in cmi["deprecationReason"]
+
+
+def test_introspection_marks_payload_field_deprecated():
+    """Payload-side clientMutationId is also deprecated."""
+    result = schema.execute_sync(
+        """
+        {
+            __type(name: "CreateGeneralTaskPayload") {
+                fields(includeDeprecated: true) {
+                    name
+                    isDeprecated
+                }
+            }
+        }
+        """
+    )
+    assert result.errors is None, result.errors
+    fields = {f["name"]: f for f in result.data["__type"]["fields"]}
+    assert "clientMutationId" in fields
+    assert fields["clientMutationId"]["isDeprecated"] is True


### PR DESCRIPTION
## Summary

Third slice of ADR-001 Phase 1. Every mutation input and payload now exposes \`clientMutationId: String\` as a deprecated alias. Legacy Relay 1 clients can keep sending their \`clientMutationId\` and get it echoed back unchanged; modern Relay 2 / Apollo / urql clients can omit it entirely.

## Why

The legacy Graphene schema follows the Relay 1 ClientIDMutation pattern: every mutation input has \`clientMutationId: String\` and every payload echoes it back. Relay 2 dropped this convention and the POC followed Strawberry's modern default — which broke wire compat for clients still on Relay 1 or any framework that mirrors it (sgqlc, some Apollo Client configs, etc.).

ADR-001's deprecation-alias strategy says: accept and echo, mark deprecated, sunset after measuring usage.

## Changes

### \`models/common.py\`

Two helper functions — \`client_mutation_id_input_field()\` and \`client_mutation_id_payload_field()\` — that return fresh \`strawberry.field\` metadata with \`name=\"clientMutationId\"\`, \`default=None\`, and a deprecation_reason explaining the Relay 1 history.

Helpers return fresh field instances per call because Strawberry's \`field()\` returns mutable metadata that can't be shared across class definitions.

### Inputs (16 model files, 21 input classes)

Each \`Create*\` / \`Update*\` Input class gains a final field:

\`\`\`python
client_mutation_id: str | None = client_mutation_id_input_field()
\`\`\`

\`LabelledTableRelationInput\` is deliberately excluded — nested input shape, not a mutation top-level input.

### Payloads (schema.py, 23 payload classes)

Same pattern via \`client_mutation_id_payload_field()\`. \`NodeFilterPayload\` (a query result type) and \`ReindexPayload\` (whose mutation takes \`id_in: [ID]\` directly, no input class) are deliberately excluded.

### Mutation resolvers (schema.py, 23 resolvers)

Each resolver now threads \`client_mutation_id=input.client_mutation_id\` into the payload constructor so the value round-trips correctly.

### Tests

\`tests/test_client_mutation_id_compat.py\` (new) — 7 tests:

- \`test_input_accepts_client_mutation_id_and_payload_echoes\` — round-trip
- \`test_omitted_client_mutation_id_yields_null_in_payload\` — modern clients
- \`test_round_trip_works_on_other_mutations\` — pattern works on \`CreateFile\` too, not just \`CreateGeneralTask\`
- \`test_sdl_has_client_mutation_id_on_every_mutation_input\` — exhaustive SDL inspection
- \`test_sdl_has_client_mutation_id_on_every_mutation_payload\` — same for payloads
- \`test_introspection_marks_client_mutation_id_deprecated\` — input field
- \`test_introspection_marks_payload_field_deprecated\` — payload field

## SDL impact

Every mutation input now contains:

\`\`\`graphql
input CreateGeneralTaskInput {
  ...existing fields...
  clientMutationId: String = null
    @deprecated(reason: \"Relay 1 ClientIDMutation holdover — modern Relay 2 / Apollo / urql clients can omit this. When provided, the value is echoed back unchanged in the mutation payload's clientMutationId field.\")
}
\`\`\`

Every mutation payload mirrors:

\`\`\`graphql
type CreateGeneralTaskPayload {
  general_task: GeneralTask
  clientMutationId: String
    @deprecated(reason: \"Relay 1 ClientIDMutation holdover — echoes the value passed to the input's clientMutationId field, or null if none was sent. Modern Relay 2 / Apollo / urql clients can ignore.\")
}
\`\`\`

## Test plan

- [x] \`uv run pytest tests/test_client_mutation_id_compat.py\` — 7 passed
- [x] \`uv run pytest tests/\` — **158 passed, 1 skipped** (was 151/1 on spike base; +7 new)
- [x] All existing mutation tests continue to pass — wire format unchanged for clients that don't send \`clientMutationId\`
- [x] Introspection surfaces deprecation_reason for IDE warnings

## Phase 1 status after this PR

- ✅ Typed scalars (\`DateTime\`, \`JSONString\`) — done in #303
- ✅ PageInfo camelCase aliases — done in #304
- ✅ \`clientMutationId\` aliases — done in this PR
- ⚠️ Connection naming alignment — partial via #304 (auto-generated \`XxxConnection\` types are back on the legacy names; \`SearchResultConnection\` is the only non-relay holdout, but it lacks pageInfo in legacy either — separate concern)

**Phase 1 is effectively complete.** Phase 2 (codegen alignment: payload type renames \`CreateXPayload\` → \`CreateX\`, root type names \`Query\`/\`Mutation\` → \`QueryRoot\`/\`MutationRoot\`) follows next per ADR-001.

## Stacking

Targets \`strawberry-poc-spike\`. Independent of #303 (scalars) and #304 (PageInfo) — they touch different surfaces, can land in any order.

**Depends on:** #296.

## Stack now

\`\`\`
deploy-test
   └── strawberry-poc-spike                  (#296)
        ├── strawberry-poc-deploy                  (#297)
        ├── strawberry-poc-ci                      (#298)
        ├── strawberry-poc-compression             (#299)
        ├── strawberry-poc-s3-fallback             (#300)
        ├── strawberry-poc-schema-parity           (#301)
        ├── strawberry-poc-adrs                    (#302)
        ├── strawberry-poc-phase1-scalars          (#303)
        ├── strawberry-poc-phase1-pageinfo         (#304)
        └── strawberry-poc-phase1-clientmutationid (this PR)
\`\`\`