### PR TITLE
feat: rename Query/Mutation roots + align payload type names (ADR-001 Phase 2)

### DIFF
--- a/spike/strawberry_poc/schema.py
+++ b/spike/strawberry_poc/schema.py
@@ -154,7 +154,7 @@ class SearchResultConnection:
     edges: list[SearchResultEdge] = strawberry.field(default_factory=list)
 
 
-@strawberry.type
+@strawberry.type(name="Search")
 class SearchPayload:
     search_result: SearchResultConnection | None = None
 
@@ -200,125 +200,125 @@ def _dispatch_search(hit: dict) -> SearchResult | None:  # noqa: C901
 # ── Payload wrapper types (mirrors Graphene's ClientIDMutation Output pattern) ─
 
 
-@strawberry.type
+@strawberry.type(name="CreateGeneralTaskPayload")
 class CreateGeneralTaskPayload:
     general_task: GeneralTask | None = None
 
 
-@strawberry.type
+@strawberry.type(name="UpdateGeneralTaskPayload")
 class UpdateGeneralTaskPayload:
     general_task: GeneralTask | None = None
 
 
-@strawberry.type
+@strawberry.type(name="CreateRuptureGenerationTask")
 class CreateRuptureGenerationTaskPayload:
     task_result: RuptureGenerationTask | None = None
 
 
-@strawberry.type
+@strawberry.type(name="UpdateRuptureGenerationTask")
 class UpdateRuptureGenerationTaskPayload:
     task_result: RuptureGenerationTask | None = None
 
 
-@strawberry.type
+@strawberry.type(name="CreateAutomationTask")
 class CreateAutomationTaskPayload:
     task_result: AutomationTask | None = None
 
 
-@strawberry.type
+@strawberry.type(name="UpdateAutomationTask")
 class UpdateAutomationTaskPayload:
     task_result: AutomationTask | None = None
 
 
-@strawberry.type
+@strawberry.type(name="CreateFile")
 class CreateFilePayload:
     ok: bool | None = None
     file_result: ToshiFile | None = None
 
 
-@strawberry.type
+@strawberry.type(name="CreateSmsFile")
 class CreateSmsFilePayload:
     ok: bool | None = None
     file_result: SmsFile | None = None
 
 
-@strawberry.type
+@strawberry.type(name="CreateStrongMotionStationPayload")
 class CreateStrongMotionStationPayload:
     strong_motion_station: StrongMotionStation | None = None
 
 
-@strawberry.type
+@strawberry.type(name="CreateRuptureSetPayload")
 class CreateRuptureSetPayload:
     ok: bool | None = None
     rupture_set: RuptureSet | None = None
 
 
-@strawberry.type
+@strawberry.type(name="CreateFileRelation")
 class CreateFileRelationPayload:
     ok: bool | None = None
 
 
-@strawberry.type
+@strawberry.type(name="CreateTaskTaskRelation")
 class CreateTaskRelationPayload:
     ok: bool | None = None
     thing_relation: TaskTaskRelation | None = None
 
 
-@strawberry.type
+@strawberry.type(name="CreateInversionSolutionPayload")
 class CreateInversionSolutionPayload:
     ok: bool | None = None
     inversion_solution: InversionSolution | None = None
 
 
-@strawberry.type
+@strawberry.type(name="AppendInversionSolutionTablesPayload")
 class AppendInversionSolutionTablesPayload:
     ok: bool | None = None
     inversion_solution: InversionSolution | None = None
 
 
-@strawberry.type
+@strawberry.type(name="CreateScaledInversionSolutionPayload")
 class CreateScaledInversionSolutionPayload:
     ok: bool | None = None
     solution: ScaledInversionSolution | None = None
 
 
-@strawberry.type
+@strawberry.type(name="CreateAggregateInversionSolutionPayload")
 class CreateAggregateInversionSolutionPayload:
     ok: bool | None = None
     solution: AggregateInversionSolution | None = None
 
 
-@strawberry.type
+@strawberry.type(name="CreateTimeDependentInversionSolutionPayload")
 class CreateTimeDependentInversionSolutionPayload:
     ok: bool | None = None
     solution: TimeDependentInversionSolution | None = None
 
 
-@strawberry.type
+@strawberry.type(name="CreateInversionSolutionNrmlPayload")
 class CreateInversionSolutionNrmlPayload:
     ok: bool | None = None
     inversion_solution_nrml: InversionSolutionNrml | None = None
 
 
-@strawberry.type
+@strawberry.type(name="CreateOpenquakeHazardConfigPayload")
 class CreateOpenquakeHazardConfigPayload:
     ok: bool | None = None
     config: OpenquakeHazardConfig | None = None
 
 
-@strawberry.type
+@strawberry.type(name="CreateOpenquakeHazardSolutionPayload")
 class CreateOpenquakeHazardSolutionPayload:
     ok: bool | None = None
     openquake_hazard_solution: OpenquakeHazardSolution | None = None
 
 
-@strawberry.type
+@strawberry.type(name="CreateOpenquakeHazardTask")
 class CreateOpenquakeHazardTaskPayload:
     ok: bool | None = None
     task_result: OpenquakeHazardTask | None = None
 
 
-@strawberry.type
+@strawberry.type(name="UpdateOpenquakeHazardTask")
 class UpdateOpenquakeHazardTaskPayload:
     ok: bool | None = None
     task_result: OpenquakeHazardTask | None = None
@@ -330,7 +330,7 @@ class NodeFilterPayload:
     result: SearchResultConnection = strawberry.field(default_factory=SearchResultConnection)
 
 
-@strawberry.type
+@strawberry.type(name="CreateTablePayload")
 class CreateTablePayload:
     ok: bool | None = None
     table: Table | None = None
@@ -345,7 +345,7 @@ class ReindexPayload:
 # ── Query ──────────────────────────────────────────────────────────────────────
 
 
-@strawberry.type
+@strawberry.type(name="QueryRoot")
 class Query:
     node: relay.Node = relay.node()
 
@@ -471,7 +471,7 @@ class Query:
 # ── Mutation ───────────────────────────────────────────────────────────────────
 
 
-@strawberry.type
+@strawberry.type(name="MutationRoot")
 class Mutation:
     @strawberry.mutation
     def create_general_task(


### PR DESCRIPTION
## Summary

ADR-001 **Phase 2** — codegen alignment. SDL-only renames; **wire format and Python class names unchanged**.

## Why

Phase 1 (PRs #303 / #304 / #305) closed the wire-breaking divergences — clients querying \`pageInfo { hasNextPage }\` and sending Relay 1's \`clientMutationId\` now work correctly. Phase 2 is the codegen-side cleanup. Typed-client codegen (sgqlc, Apollo Codegen, graphql-codegen) keys off SDL type names. \`type CreateGeneralTaskPayload\` vs \`type CreateGeneralTask\` produces different file names in TypeScript/Python output. Existing client codegen pipelines breaking is a soft compat issue; we still want to close it for full drop-in.

## What's in it

### 1. Root type names

\`\`\`python
@strawberry.type(name=\"QueryRoot\")
class Query: ...

@strawberry.type(name=\"MutationRoot\")
class Mutation: ...
\`\`\`

SDL now declares:

\`\`\`graphql
schema { query: QueryRoot; mutation: MutationRoot }
\`\`\`

Matches legacy. Clients don't reference root types in queries (\`query { ... }\` works regardless of the SDL type name), so zero runtime impact.

### 2. Mutation payload type names

**Surprise finding while implementing: legacy is inconsistent.** Some payloads end in \`Payload\`, others don't — whoever wrote each Graphene mutation chose differently. The fix mirrors legacy **exactly** via \`@strawberry.type(name=\"...\")\` so on-the-wire type names match.

Python class names are unchanged — code still references \`CreateXPayload\` classes everywhere. Only the GraphQL SDL type name flips.

24 payload classes touched, mapping derived directly from the legacy SDL via \`grep\`, not inferred. Notable patterns:

- **Drop the \`Payload\` suffix in SDL** (legacy convention):
  - \`CreateAutomationTaskPayload\` → \`\"CreateAutomationTask\"\`
  - \`CreateRuptureGenerationTaskPayload\` → \`\"CreateRuptureGenerationTask\"\`
  - \`CreateOpenquakeHazardTaskPayload\` → \`\"CreateOpenquakeHazardTask\"\`
  - All three \`Update*Task*\` payloads similarly
  - \`CreateFilePayload\` → \`\"CreateFile\"\`, \`CreateSmsFilePayload\` → \`\"CreateSmsFile\"\`, \`CreateFileRelationPayload\` → \`\"CreateFileRelation\"\`

- **Keep the \`Payload\` suffix in SDL** (legacy convention):
  - \`CreateGeneralTaskPayload\` / \`UpdateGeneralTaskPayload\` — stay
  - \`CreateInversionSolution*Payload\` (all four IS variants + NRML + Append) — stay
  - \`CreateOpenquakeHazardConfig/Solution Payload\` — stay
  - \`CreateRuptureSetPayload\`, \`CreateStrongMotionStationPayload\`, \`CreateTablePayload\` — stay

- **Special cases**:
  - \`SearchPayload\` → \`\"Search\"\` (legacy uses \`Search\` for the query payload type)
  - \`CreateTaskRelationPayload\` → \`\"CreateTaskTaskRelation\"\` (legacy quirk — the **double Task** is intentional; mirrors the legacy \`CreateTaskTaskRelation\` Graphene class)

- **Deliberately not renamed**:
  - \`NodeFilterPayload\` — POC-side type with no exact legacy equivalent; legacy has \`NodeFilter\` but the underlying shape differs enough that aliasing is misleading
  - \`ReindexPayload\` — POC addition, no legacy equivalent

## Parity impact

Measured via \`tools/schema_parity.py\` from #301:

|  | Before | After | Δ |
|---|---|---|---|
| Types only in legacy | 30 | **17** | **-13** |
| Types only in POC | 55 | **42** | **-13** |

13 type pairs now match across legacy and POC. The remaining \"types only in legacy\" / \"types only in POC\" entries are:

- **Interface gaps** (\`Thing\`, \`AutomationTaskInterface\`) — substantial work, deserves its own ADR
- **Input naming conventions** (\`AutomationTaskInput\` vs \`CreateAutomationTaskInput\`) — another piece of legacy inconsistency
- **Auto-generated relay Edge types** — Strawberry generates one per node type; legacy used shared ones
- **Custom scalars** \`DateTime\`, \`JSONString\` show as legacy-only on this branch (added in #303 which lands separately)

All out of scope for Phase 2 codegen alignment.

## Test plan

- [x] \`uv run pytest tests/\` — 151 passed, 1 skipped (no change vs spike base)
- [x] Schema loads cleanly
- [x] SDL contains \`schema { query: QueryRoot; mutation: MutationRoot }\`
- [x] All 24 renamed payloads appear under their legacy-spec names in SDL

## ADR-001 status after this PR

- ✅ Phase 1 — wire-breaking fixes (PRs #303, #304, #305)
- ✅ Phase 2 — codegen alignment (this PR)
- ⏳ Phase 3 — deprecated-field usage logging + sunset measurement (post-deploy work)

## Stacking

Targets \`strawberry-poc-spike\`. Independent of #303 / #304 / #305 — touches a different surface. All four Phase 1+2 PRs can land in any order.

**Depends on:** #296.

## Stack now

\`\`\`
deploy-test
   └── strawberry-poc-spike                       (#296)
        ├── strawberry-poc-deploy                       (#297)
        ├── strawberry-poc-ci                           (#298)
        ├── strawberry-poc-compression                  (#299)
        ├── strawberry-poc-s3-fallback                  (#300)
        ├── strawberry-poc-schema-parity                (#301)
        ├── strawberry-poc-adrs                         (#302)
        ├── strawberry-poc-phase1-scalars               (#303)
        ├── strawberry-poc-phase1-pageinfo              (#304)
        ├── strawberry-poc-phase1-clientmutationid      (#305)
        └── strawberry-poc-phase2-codegen               (this PR)
\`\`\`