### PR TITLE
docs: ADR-002 — schema interface hierarchy and input naming

### DIFF
--- a/docs/adrs/ADR-001-graphql-schema-evolution-strategy.md
+++ b/docs/adrs/ADR-001-graphql-schema-evolution-strategy.md
@@ -276,12 +276,18 @@ alias.
 
 ## Related decisions
 
-- (Future) ADR-002: Custom scalar policy — naming, behaviour, and
-  on-disk representation for `DateTime`, `JSONString`, `BigInt`, and
-  any future scalars.
-- (Future) ADR-003: Schema interface hierarchy — `Thing` and
-  `AutomationTaskInterface` adoption in POC.
+- [ADR-002](ADR-002-schema-interface-hierarchy-and-input-naming.md):
+  Schema interface hierarchy and input naming conventions — covers
+  the remaining divergences after Phase 1+2 (`Thing` /
+  `AutomationTaskInterface` adoption, input type naming style,
+  auto-generated Edge types).
+- (Future) ADR-003: Custom scalar policy — naming, behaviour, and
+  on-disk representation conventions for `DateTime`, `JSONString`,
+  `BigInt`, and any future scalars (the specific decisions in this
+  ADR cover the existing scalars; an ADR is owed when we add the next).
 - (Future) ADR-004: Deprecation logging and sunset policy — how we
-  measure deprecated-field usage and when we remove.
+  measure deprecated-field usage and when we remove (Phase 3 of
+  this ADR's migration path).
 - (Future) ADR-005: snake_case vs camelCase for client-facing
-  fields — strategic call on whether to undertake the migration.
+  fields — strategic call on whether to undertake the broader
+  migration.

--- a/docs/adrs/ADR-002-schema-interface-hierarchy-and-input-naming.md
+++ b/docs/adrs/ADR-002-schema-interface-hierarchy-and-input-naming.md
@@ -1,0 +1,332 @@
+# ADR-002: Schema Interface Hierarchy and Input Naming Conventions
+
+## Status
+
+Proposed.
+
+## Context
+
+ADR-001 Phase 1+2 closed the wire-breaking and codegen-breaking
+divergences between the legacy Graphene schema and the Strawberry
+POC. The schema parity diff (`tools/schema_parity.py`) dropped from
+657 lines / 257 field mismatches at the spike baseline to ~280 field
+mismatches after Phase 1+2. The remaining divergences cluster into
+four distinct categories:
+
+| Category | Examples | Wire-impacting? |
+|---|---|---|
+| 1. Missing interfaces | `Thing`, `AutomationTaskInterface` | **Yes** — fragment queries break |
+| 2. Input type naming | `AutomationTaskInput` (legacy) vs `CreateAutomationTaskInput` (POC) | No — codegen only |
+| 3. Auto-generated Edge types | `GeneralTaskEdge`, `RuptureSetEdge`, etc. one per node | No — wire-equivalent |
+| 4. Custom Connection types | `FileRelationsConnection` (POC) vs `FileRelationConnection` (legacy) | No — already decided in ADR-001 |
+
+Each category needs its own decision: fix, alias, accept as
+divergence, or document for a separate ADR. ADR-001's principles
+(wire compat is the contract; modernise where standard has hardened;
+use `@deprecated` to bridge) apply directly to (1) and (2), and
+inform the accept/defer calls for (3) and (4).
+
+### The four categories in detail
+
+**1. Missing interfaces** — Legacy declares `Thing` and
+`AutomationTaskInterface` and has concrete types implement them.
+weka uses both via fragment queries:
+
+```graphql
+... on Thing { children { edges { node { ... } } } }
+... on AutomationTaskInterface { parents { edges { ... } } }
+```
+
+POC has neither. The concrete types (`GeneralTask`, `AutomationTask`,
+etc.) already declare equivalent fields directly — the structural
+information is there, just not the interface declaration that lets
+fragment queries resolve. The first `...AutomationTaskInterface`
+query against the POC fails with `Cannot spread fragment AutomationTaskInterface
+on AutomationTask` or similar at GraphQL-validation time. **This is a
+real wire-level break for any client using the fragment-via-interface
+pattern.**
+
+**2. Input type naming** — Legacy uses
+`<TypeName>Input` (for create) and `<TypeName>UpdateInput` (for update):
+
+```
+AutomationTaskInput          (legacy create input)
+AutomationTaskUpdateInput    (legacy update input)
+```
+
+POC uses Strawberry's modern convention:
+
+```
+CreateAutomationTaskInput
+UpdateAutomationTaskInput
+```
+
+Both work. Wire JSON is identical (`{ "input": { ... } }`). The
+difference shows up only in typed-client codegen: sgqlc emits one
+file per input type, and the file name changes.
+
+**3. Auto-generated Edge types** — Strawberry's relay layer emits
+one `XxxEdge` type per concrete node type:
+
+```
+GeneralTaskEdge
+RuptureSetEdge
+ToshiFileEdge
+... and so on for every node type
+```
+
+Legacy used a smaller set of shared connection/edge types:
+
+```
+FileEdge        (used by every File-typed connection)
+ThingEdge       (used by every Thing-typed connection)
+```
+
+Wire JSON is identical — clients see `{ edges: [{ node: {...} }] }`
+either way. The SDL difference is purely structural and affects only
+codegen tooling that generates one wrapper class per Edge type.
+
+**4. Custom Connection naming** — already decided in ADR-001
+(`FileRelationsConnection` vs legacy `FileRelationConnection`,
+`TaskRelationsConnection` vs `TaskTaskRelationConnection`). ADR-001's
+position: accept the small POC-side rename rather than fight
+Strawberry's auto-generation collision. Re-flagged here only to
+explain why these names appear in the diff without further action.
+
+## Decision
+
+### Principle (carried forward from ADR-001)
+
+Wire compat is the contract. SDL differences that don't change the
+JSON over the wire are tolerated; SDL differences that change runtime
+behaviour are fixed.
+
+### Per-category decisions
+
+#### Category 1 — Missing interfaces: **Adopt both**
+
+Both `Thing` and `AutomationTaskInterface` get added to the POC.
+This is a wire-impacting gap and the work is well-scoped because
+the concrete types already declare equivalent fields.
+
+#### Category 2 — Input type naming: **Accept the divergence**
+
+Keep the modern Strawberry-style `CreateXxxInput` /
+`UpdateXxxInput` naming. Wire format is identical; only codegen
+breaks. The ADR-001 principle "modernise where the community has
+hardened" applies: the `Create/Update`-prefixed convention is the
+norm in 2026 Strawberry / Apollo / Nexus schemas.
+
+Clients regenerating typed code against `/graphql-v2` will see
+different file names. This is documented behaviour, not a bug.
+
+#### Category 3 — Auto-generated Edge types: **Accept the divergence**
+
+Strawberry's relay layer generates one Edge per node type. Trying
+to consolidate them into shared `ThingEdge`/`FileEdge` types
+would require building a custom relay layer — non-trivial work
+for codegen-only parity. Wire is identical.
+
+#### Category 4 — Custom Connection naming: **Already resolved**
+
+Per ADR-001. No new action.
+
+## Specific decisions
+
+| Item | Legacy | POC | Decision |
+|---|---|---|---|
+| `Thing` interface | Declared, implemented by 7 concrete types | Missing | **Adopt** — declare in POC, attach to each concrete type |
+| `AutomationTaskInterface` | Declared, implemented by 3 concrete types | Missing | **Adopt** — same pattern |
+| Input naming `<Type>Input` | snake-Graphene convention | `Create<Type>Input` (Strawberry-modern) | **Accept divergence** — wire-equivalent, modern preferred |
+| Edge types per node | Shared `FileEdge` / `ThingEdge` etc. | Per-type `<Node>Edge` | **Accept divergence** — wire-equivalent, structural cost too high |
+| `FileRelationsConnection` etc. | `FileRelationConnection` | Already POC-named | **Already resolved** (ADR-001) |
+
+## Implementation plan for the interface adoptions
+
+### `Thing` interface
+
+**Fields (per legacy SDL):**
+
+```graphql
+interface Thing {
+  created: DateTime
+  files(before: String, after: String, first: Int, last: Int): FileRelationsConnection
+  parents(before: String, after: String, first: Int, last: Int): TaskRelationsConnection
+  children(before: String, after: String, first: Int, last: Int): TaskRelationsConnection
+}
+```
+
+(Connection field types use the POC-side naming
+`FileRelationsConnection` / `TaskRelationsConnection`, since
+ADR-001 ratified those. Clients querying via `... on Thing { ... }`
+don't reference the connection type name in their query — they
+spell `files { edges { ... } }`.)
+
+**Concrete types that implement `Thing` in legacy:**
+
+- `GeneralTask`
+- `AutomationTask`
+- `RuptureGenerationTask`
+- `OpenquakeHazardTask`
+- `OpenquakeHazardSolution`
+- `OpenquakeHazardConfig`
+- `StrongMotionStation`
+
+Each currently declares the four fields independently in the POC.
+Implementation:
+
+```python
+# models/thing.py (new)
+@strawberry.interface
+class Thing:
+    created: DateTime | None = None
+    # connection fields declared via @relay.connection on each
+    # concrete type — interface itself doesn't auto-resolve them
+```
+
+For Strawberry to surface `... on Thing { files { ... } }` queries,
+the interface must declare the field signatures matching the concrete
+types. Implementation will likely follow the same pattern as
+`InversionSolutionInterface` (added earlier in this iteration):
+declare field signatures on the interface, concrete types resolve.
+
+The pattern was non-trivial when we added `InversionSolutionInterface`
+— specifically the relay connection field collisions and the duplicate
+edge type generation. Same gotchas apply here. Estimated work: ~1 day
+of careful Strawberry plumbing + tests.
+
+### `AutomationTaskInterface`
+
+**Fields (per legacy SDL):**
+
+```graphql
+interface AutomationTaskInterface {
+  result: EventResult
+  state: EventState
+  created: DateTime
+  duration: Float
+  general_task_id: ID
+  task_type: TaskSubType
+  parents(...): TaskRelationsConnection
+  arguments: [KeyValuePair]
+  environment: [KeyValuePair]
+  metrics: [KeyValuePair]
+}
+```
+
+**Concrete types:**
+- `AutomationTask`
+- `RuptureGenerationTask`
+- `OpenquakeHazardTask`
+
+Same implementation pattern. Smaller scope because only 3 concrete
+types vs 7 for `Thing`.
+
+### Test plan
+
+Per interface:
+
+- Schema-level: `schema.as_str()` contains the `interface <Name>` block.
+- Introspection: `__type(name: "Thing")` returns the interface kind.
+- Fragment-resolution: `... on Thing { children { ... } }` against a
+  concrete `GeneralTask` resolves the children field correctly.
+- `nodes(id_in: [...]) { ... on AutomationTaskInterface { parents { ... } } }`
+  weka-style traversal works end-to-end.
+- Parity diff: `Thing` and `AutomationTaskInterface` disappear from
+  the "types only in legacy" list; the "interfaces only in legacy"
+  field mismatches for each concrete type also clear.
+
+### Phasing
+
+Both interfaces can land in a single PR (interface declaration +
+attach to concrete types + tests). Estimated ~150-300 lines plus
+tests.
+
+## Consequences
+
+### Positive
+
+- weka's `... on Thing { ... }` and `... on AutomationTaskInterface { ... }`
+  fragment queries work against `/graphql-v2`. This is the single
+  largest remaining wire-breaking divergence after Phase 1+2.
+- Parity diff drops further — these two interfaces and the field
+  mismatches they cause across 7+3 concrete types are all closed
+  with one set of changes.
+- The legacy `test_nodes_bugfix_220` weka pattern (deep traversal via
+  `AutomationTaskInterface.parents`) becomes reproducible against the
+  POC, completing the work hinted at in COVERAGE_GAPS.md gap 3.
+
+### Negative
+
+- The interface declarations must declare their connection fields
+  with matching arg signatures and types. Strawberry's relay layer
+  has known sharp edges when interfaces declare relay connections
+  (we hit some of these adding `InversionSolutionInterface`). Risk
+  of additional plumbing surfacing during implementation.
+- Each concrete type gains an `implements Thing` (and possibly
+  `implements AutomationTaskInterface`) declaration. That's
+  mechanical but touches 7 files.
+- Auto-generated Edge type count stays high (Strawberry per-node).
+  Documented divergence; no fix.
+
+### Neutral
+
+- The input naming and Edge type categories are explicitly accepted.
+  This is the ADR doing its job — naming a divergence as known and
+  intentional rather than letting it generate continuous review
+  noise.
+
+## Why the Edge / Input divergences are NOT worth fighting
+
+It's tempting to also align Edge types and input names for full
+"drop-in cosmetic parity". Why we don't:
+
+- **Cost**: each requires either a custom Strawberry layer
+  (Edge consolidation) or systematic Python-class renames + name=
+  decorators on every Input class (input renaming). Tens to hundreds
+  of lines plus testing, plus ongoing maintenance overhead.
+- **Benefit**: zero wire-format change. The only beneficiaries are
+  client codegen pipelines that were already breaking on the
+  Graphene→Strawberry transition for *other* reasons (custom scalar
+  changes, root type names, etc.).
+- **Risk**: maintainability — adding renames just to match legacy
+  inconsistencies (recall ADR-001's payload-naming surprise where
+  legacy mixed `Create*Payload` and `Create*` based on author whim)
+  imports legacy debt into POC.
+
+The cleaner stance is to document these as accepted divergences in
+this ADR and let consumers of the SDL know they're intentional.
+
+## Lessons captured (companion to ADR-001's)
+
+Two patterns from the Phase 1+2 implementation work that are worth
+preserving for future schema work:
+
+1. **Don't generalise from one type to the whole schema.** Phase 2's
+   payload rename script initially assumed "remove the Payload suffix
+   from all `Create*Payload` types" — turned out legacy was internally
+   inconsistent. The correct fix needed a per-type mapping derived
+   directly from the legacy SDL. Schema parity is full of legacy
+   inconsistencies; the only safe pattern is to map type-by-type.
+
+2. **Wire-equivalence is not SDL-equivalence.** Many of the most-noisy
+   divergences (`[X]` vs `[X!]`, `pageInfo` vs `page_info`, edge
+   nullability) produce identical JSON on the wire for the same data.
+   The schema parity tool surfaces all SDL differences; deciding
+   which are actually wire-breaking requires human judgement. This
+   ADR's Category 1 (interfaces) vs Categories 2-4 (SDL cosmetics)
+   illustrates the distinction.
+
+## Related decisions
+
+- [ADR-001](ADR-001-graphql-schema-evolution-strategy.md) — the
+  framework this ADR operates within (wire compat as contract,
+  modernise where standard has hardened, `@deprecated` to bridge).
+- (Future) ADR-003: Custom scalar policy — naming and on-disk
+  representation conventions for `DateTime`, `JSONString`, `BigInt`,
+  and any future scalars.
+- (Future) ADR-004: Deprecation logging and sunset policy — how we
+  measure deprecated-field usage and when we remove (ADR-001 Phase 3).
+- (Future) ADR-005: snake_case vs camelCase for client-facing
+  fields — strategic call on whether to undertake the broader
+  migration.

--- a/docs/adrs/ADR-002-schema-interface-hierarchy-and-input-naming.md
+++ b/docs/adrs/ADR-002-schema-interface-hierarchy-and-input-naming.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Proposed.
+Accepted. Implemented in PR #308 (interface adoption) and PR #309
+(additional client-divergence fixes surfaced by the post-implementation
+audit; see "Post-implementation audit" below).
 
 ## Context
 
@@ -30,21 +32,36 @@ inform the accept/defer calls for (3) and (4).
 
 **1. Missing interfaces** — Legacy declares `Thing` and
 `AutomationTaskInterface` and has concrete types implement them.
-weka uses both via fragment queries:
+At drafting time we assumed both were wire-impacting. A subsequent
+client audit (see "Post-implementation audit" below) refined the
+picture:
 
-```graphql
-... on Thing { children { edges { node { ... } } } }
-... on AutomationTaskInterface { parents { edges { ... } } }
-```
+- `AutomationTaskInterface` is **heavily used by weka**:
+  `views/GeneralTask/InversionSolutionDiagnosticContainer.tsx`,
+  `views/GeneralTask/tabs/GeneralTaskChildrenTab.tsx`,
+  `views/AutomationTask/AutomationTaskPage.tsx`,
+  `views/Favourites/Favourites.tsx`, plus generated Relay codegen
+  files for each. Pattern:
+  ```graphql
+  ... on AutomationTaskInterface { state result task_type
+    arguments { k v }
+    parents { edges { node { parent { ... on GeneralTask { id title } } } } }
+  }
+  ```
+  Without the interface, these queries fail GraphQL validation.
+  **Real wire-level break.**
+
+- `Thing` is **not used by any inspected client** (weka, nzshm-runzi,
+  nzshm-model). Clients reach for concrete fragments instead
+  (`... on GeneralTask`, `... on AutomationTask`). Adopting `Thing`
+  in the POC remains defensive SDL-parity work rather than a
+  load-bearing fix — useful for future-proofing and for the parity
+  diff signal-to-noise, but no observed client query depends on it.
 
 POC has neither. The concrete types (`GeneralTask`, `AutomationTask`,
 etc.) already declare equivalent fields directly — the structural
 information is there, just not the interface declaration that lets
-fragment queries resolve. The first `...AutomationTaskInterface`
-query against the POC fails with `Cannot spread fragment AutomationTaskInterface
-on AutomationTask` or similar at GraphQL-validation time. **This is a
-real wire-level break for any client using the fragment-via-interface
-pattern.**
+fragment queries resolve.
 
 **2. Input type naming** — Legacy uses
 `<TypeName>Input` (for create) and `<TypeName>UpdateInput` (for update):
@@ -106,8 +123,11 @@ behaviour are fixed.
 #### Category 1 — Missing interfaces: **Adopt both**
 
 Both `Thing` and `AutomationTaskInterface` get added to the POC.
-This is a wire-impacting gap and the work is well-scoped because
-the concrete types already declare equivalent fields.
+`AutomationTaskInterface` is wire-impacting and confirmed
+load-bearing for weka; `Thing` is defensive parity (no observed
+client query, but cheap to add alongside and keeps the parity diff
+clean). The work is well-scoped because the concrete types already
+declare equivalent fields.
 
 #### Category 2 — Input type naming: **Accept the divergence**
 
@@ -316,6 +336,55 @@ preserving for future schema work:
    which are actually wire-breaking requires human judgement. This
    ADR's Category 1 (interfaces) vs Categories 2-4 (SDL cosmetics)
    illustrates the distinction.
+
+## Post-implementation audit (client divergence)
+
+After PR #308 landed the interface adoption, we audited real
+production GraphQL queries across three clients to verify the
+remaining "POC-only types" in the parity diff were genuinely
+acceptable:
+
+- `weka` (UI) — `../UI/weka/src/`
+- `nzshm-runzi` (Python automation) — `../MISC/nzshm-runzi`
+- `nzshm-model` (Python library) — `../LIB/nzshm-model`
+
+The audit confirmed Categories 2–4 are safe to accept, but surfaced
+**four additional wire-breaking divergences** that ADR-002's original
+analysis missed. All four are fixed in PR #309.
+
+| # | Divergence | Client evidence | Fix |
+|---|---|---|---|
+| A | POC SDL type `ToshiFile` (POC-only rename of legacy `File`) | weka × 4 source files (`... on File`), nzshm-model × 1 | Revert SDL name to `File`; keep Python class as `ToshiFile` via `@strawberry.type(name="File")` |
+| B | POC SDL type `NodeFilterPayload` (legacy is `NodeFilter`) | weka generated Relay codegen × 2 views (`concreteType: "NodeFilter"`) | Rename SDL type via `@strawberry.type(name="NodeFilter")` decorator |
+| C | POC `Table.column_types: [String]` vs legacy `[RowItemType]` | weka × 1, runzi × 1 (`$column_types: [RowItemType]!` in mutation variables) | Add `RowItemType` enum (`integer`/`double`/`string`/`boolean`) and use on both `Table.column_types` and `CreateTableInput.column_types` |
+| D | POC `AutomationTask` / `RuptureGenerationTask` / `OpenquakeHazardTask` missing `inversion_solution: InversionSolutionUnion` field | weka `AutomationTaskPage`, `GeneralTaskChildrenTab` | Add `InversionSolutionUnion` and a resolver that picks the `WRITE`-related `InversionSolution` subtype from `files_raw` |
+
+### What the audit confirmed (no action)
+
+- **`InversionSolutionUnion` / `PredecessorUnion`** — no observed
+  client query exercises these union types other than via the
+  concrete `... on InversionSolution { ... }` fragments. The union
+  declarations exist in the POC and are wire-equivalent; no client
+  breaks from the SDL difference.
+- **Category 2 (input naming)** — no observed query references the
+  input type name directly. Wire format identical. Decision stands.
+- **Category 3 (auto-generated Edge types)** — no observed query
+  references an Edge type by name. Wire format identical. Decision
+  stands.
+
+### Lesson added
+
+3. **An ADR drafted from a parity-diff sample needs an audit
+   against real client queries before close-out.** ADR-002's
+   original Category 1 framing assumed both `Thing` and
+   `AutomationTaskInterface` were equally wire-impacting because
+   both appeared in the legacy SDL. The client audit refined that:
+   `AutomationTaskInterface` is load-bearing; `Thing` is defensive.
+   Worse, the audit also surfaced **four breaking divergences this
+   ADR didn't catch at all** — they were lurking in the
+   "POC-only types" half of the parity diff that we'd partially
+   characterised as cosmetic. For future schema ADRs, run the
+   client-query audit *before* drafting decisions, not after.
 
 ## Related decisions
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -81,3 +81,4 @@ leave the file in place).
 | # | Title | Status |
 |---|---|---|
 | [ADR-001](ADR-001-graphql-schema-evolution-strategy.md) | GraphQL Schema Evolution Strategy: Legacy Parity, Modern Defaults, Deprecation Aliases | Proposed |
+| [ADR-002](ADR-002-schema-interface-hierarchy-and-input-naming.md) | Schema Interface Hierarchy and Input Naming Conventions | Proposed |


### PR DESCRIPTION
## Summary

Drafts the project's second ADR, covering the schema divergences that ADR-001 Phase 1+2 explicitly didn't address. After PRs #303 / #304 / #305 / #306 closed Phase 1+2, the schema parity diff still showed ~17 types only-in-legacy and ~42 only-in-POC. ADR-002 categorises these into four buckets and makes an explicit decision per bucket.

## Decisions

| # | Category | Decision | Why |
|---|---|---|---|
| 1 | Missing interfaces (\`Thing\`, \`AutomationTaskInterface\`) | **Adopt both** | Wire-impacting — weka writes \`... on Thing { ... }\` fragment queries; GraphQL validation fails without the interface declaration |
| 2 | Input type naming (\`<Type>Input\` vs \`Create<Type>Input\`) | **Accept divergence** | Codegen-only; ADR-001 principle 2 says modernise where community standard has hardened |
| 3 | Auto-generated Edge types | **Accept divergence** | Wire-equivalent; consolidating would require a custom Strawberry relay layer |
| 4 | Custom Connection naming | **Already resolved** (ADR-001) | Re-flagged for clarity |

## Implementation plan included

For the **interface adoption** (Category 1), the ADR sketches the concrete plan:

- \`Thing\` interface: 4 fields, 7 concrete types implement
- \`AutomationTaskInterface\`: 9 fields, 3 concrete types implement
- Pattern mirrors the \`InversionSolutionInterface\` work already in #296 — with the same Strawberry-relay-connection-on-interface gotchas
- One PR covers both. Estimated ~150-300 LOC + tests
- Test plan: schema-level (interface in SDL), introspection (\`__type\` returns interface kind), fragment-resolution (\`... on Thing { children }\` works), and weka-style deep traversal end-to-end

For Categories 2-4: documented as accepted divergences, no implementation.

## Lessons captured

Two patterns the ADR preserves from the Phase 1+2 implementation work:

1. **Don't generalise from one type to the whole schema.** The Phase 2 payload-rename script's first attempt assumed legacy was internally consistent; it wasn't. The correct pattern is to map type-by-type from the actual legacy SDL.

2. **Wire-equivalence is not SDL-equivalence.** The parity tool surfaces every SDL difference, but only a subset breaks clients. ADR-002's Category 1 (interfaces) vs Categories 2-4 (SDL-only) makes the distinction explicit so future ADRs can decide quickly which side they're on.

## Files

- \`docs/adrs/ADR-002-schema-interface-hierarchy-and-input-naming.md\` (new, 287 lines)
- \`docs/adrs/README.md\` — add ADR-002 to the index
- \`docs/adrs/ADR-001-graphql-schema-evolution-strategy.md\` — update Related decisions: ADR-002 link now points at the actual file, and the future-ADR placeholders (Custom scalar policy, deprecation logging, snake/camel migration) get renumbered to ADR-003+ to make room

## Status

**Proposed.** Discussion on the decisions belongs in this PR's review — once accepted, the interface-implementation PR follows directly from ADR-002's Implementation Plan section.

## Stacking

This PR targets \`strawberry-poc-adrs\` (PR #302). After #302 merges to \`deploy-test\`, retarget this PR to \`deploy-test\`.

**Depends on:** #302 (ADR-001 + the ADR convention).

## Stack now

\`\`\`
deploy-test
   └── strawberry-poc-spike                       (#296)
        ├── strawberry-poc-deploy                       (#297)
        ├── strawberry-poc-ci                           (#298)
        ├── strawberry-poc-compression                  (#299)
        ├── strawberry-poc-s3-fallback                  (#300)
        ├── strawberry-poc-schema-parity                (#301)
        ├── strawberry-poc-adrs                         (#302)  ← parent
        │    └── strawberry-poc-adr-002-clean                (this PR)
        ├── strawberry-poc-phase1-scalars               (#303)
        ├── strawberry-poc-phase1-pageinfo              (#304)
        ├── strawberry-poc-phase1-clientmutationid      (#305)
        └── strawberry-poc-phase2-codegen               (#306)
\`\`\`