### PR TITLE
feat: adopt Thing + AutomationTaskInterface (ADR-002 Category 1)

### DIFF
--- a/spike/strawberry_poc/models/automation_task.py
+++ b/spike/strawberry_poc/models/automation_task.py
@@ -20,6 +20,7 @@ from data.dynamo import create_thing, get_thing, list_things, update_thing
 from data.models import AutomationTaskData
 
 from .common import EventResult, EventState, KeyValuePair, KeyValuePairInput, ModelType, TaskSubType, _try_enum
+from .thing import AutomationTaskInterface, Thing
 from .relations import (
     FileRelation,
     FileRelationsConnection,
@@ -41,7 +42,7 @@ def _kv_input_to_list(items) -> list[dict] | None:
 
 
 @strawberry.type
-class AutomationTask(relay.Node):
+class AutomationTask(relay.Node, Thing, AutomationTaskInterface):
     """An automation task in the NSHM process."""
 
     pk: relay.NodeID[str]
@@ -103,7 +104,7 @@ class AutomationTask(relay.Node):
 
 
 @strawberry.type
-class RuptureGenerationTask(relay.Node):
+class RuptureGenerationTask(relay.Node, Thing, AutomationTaskInterface):
     """A rupture set generation task — stored identically to AutomationTask."""
 
     pk: relay.NodeID[str]

--- a/spike/strawberry_poc/models/general_task.py
+++ b/spike/strawberry_poc/models/general_task.py
@@ -37,10 +37,11 @@ from .relations import (
     build_task_children,
     build_task_parents,
 )
+from .thing import Thing
 
 
 @strawberry.type
-class GeneralTask(relay.Node):
+class GeneralTask(relay.Node, Thing):
     """
     A General Task captures metadata and related inputs/outputs for arbitrary tasks.
     """
@@ -49,7 +50,7 @@ class GeneralTask(relay.Node):
     title: str | None = None
     description: str | None = None
     agent_name: str | None = None
-    created: str | None = None
+    # `created` inherited from Thing
     updated: str | None = None
     notes: str | None = None
     subtask_count: int | None = None
@@ -58,10 +59,8 @@ class GeneralTask(relay.Node):
     model_type: ModelType | None = None
     argument_lists: list[KeyValueListPair] | None = None
     meta: list[KeyValuePair] | None = None
-
-    files_raw: strawberry.Private[list | None] = None
-    children_raw: strawberry.Private[list | None] = None
-    parents_raw: strawberry.Private[list | None] = None
+    # files_raw / parents_raw / children_raw and the @relay.connection
+    # resolvers for files / parents / children are inherited from Thing
 
     @relay.connection(FileRelationsConnection)
     def files(self, info: Info) -> list[FileRelation]:

--- a/spike/strawberry_poc/models/openquake_hazard_config.py
+++ b/spike/strawberry_poc/models/openquake_hazard_config.py
@@ -12,6 +12,7 @@ from data.dynamo import create_thing, get_file, get_thing, list_things
 from data.models import OpenquakeHazardConfigData
 from models.file import ToshiFile
 from models.inversion_solution_nrml import InversionSolutionNrml
+from models.thing import Thing
 
 # ── OpenquakeNrmlUnion ────────────────────────────────────────────────────────
 
@@ -35,7 +36,7 @@ def dispatch_nrml(data: dict):
 
 
 @strawberry.type
-class OpenquakeHazardConfig(relay.Node):
+class OpenquakeHazardConfig(relay.Node, Thing):
     pk: relay.NodeID[str]
     created: str | None = None
 

--- a/spike/strawberry_poc/models/openquake_hazard_solution.py
+++ b/spike/strawberry_poc/models/openquake_hazard_solution.py
@@ -14,6 +14,7 @@ from models.file import ToshiFile
 from models.openquake_hazard_task import OpenquakeHazardTask
 
 from .common import KeyValuePair, KeyValuePairInput, OpenquakeTaskType
+from .thing import Thing
 from .predecessor import PredecessorInput
 from .predecessors_interface import PredecessorsInterface
 
@@ -22,7 +23,7 @@ _ToshiFile = Annotated["ToshiFile", strawberry.lazy("models.file")]
 
 
 @strawberry.type
-class OpenquakeHazardSolution(relay.Node, PredecessorsInterface):
+class OpenquakeHazardSolution(relay.Node, PredecessorsInterface, Thing):
     pk: relay.NodeID[str]
     created: str | None = None
     task_type: OpenquakeTaskType | None = None

--- a/spike/strawberry_poc/models/openquake_hazard_task.py
+++ b/spike/strawberry_poc/models/openquake_hazard_task.py
@@ -12,6 +12,7 @@ from data.dynamo import create_thing, get_thing, list_things, update_thing
 from data.models import OpenquakeHazardTaskData
 
 from .common import EventResult, EventState, KeyValuePair, KeyValuePairInput, ModelType, TaskSubType, _try_enum
+from .thing import AutomationTaskInterface, Thing
 from .relations import (
     FileRelation,
     FileRelationsConnection,
@@ -26,7 +27,7 @@ _OpenquakeHazardSolution = Annotated["OpenquakeHazardSolution", strawberry.lazy(
 
 
 @strawberry.type
-class OpenquakeHazardTask(relay.Node):
+class OpenquakeHazardTask(relay.Node, Thing, AutomationTaskInterface):
     pk: relay.NodeID[str]
     state: EventState | None = None
     result: EventResult | None = None

--- a/spike/strawberry_poc/models/strong_motion_station.py
+++ b/spike/strawberry_poc/models/strong_motion_station.py
@@ -13,11 +13,10 @@ from data.dynamo import create_thing, get_thing, list_things
 from data.models import StrongMotionStationData
 
 from .common import SmsSiteClass, SmsSiteClassBasis, _try_enum
-from .relations import FileRelation, FileRelationsConnection, build_file_relations_for_thing
-
+from .thing import Thing
 
 @strawberry.type
-class StrongMotionStation(relay.Node):
+class StrongMotionStation(relay.Node, Thing):
     """An NSHM Strong Motion Station record."""
 
     pk: relay.NodeID[str]
@@ -32,11 +31,10 @@ class StrongMotionStation(relay.Node):
     created: str | None = None
     updated: str | None = None
 
-    files_raw: strawberry.Private[list | None] = None
-
-    @relay.connection(FileRelationsConnection)
-    def files(self, info: Info) -> list[FileRelation]:
-        return build_file_relations_for_thing(self.pk, self.files_raw or [])
+    # files_raw and the files resolver are inherited from Thing.
+    # We also inherit parents_raw, children_raw, parents and children — but
+    # StrongMotionStation doesn't actually have parent/child tasks; the empty
+    # _raw fields naturally return empty connections.
 
     @classmethod
     def resolve_node(cls, node_id: str, *, info: Info, **kwargs) -> Optional["StrongMotionStation"]:

--- a/spike/strawberry_poc/models/thing.py
+++ b/spike/strawberry_poc/models/thing.py
@@ -1,0 +1,118 @@
+"""
+Thing and AutomationTaskInterface — shared interfaces for entity/task types.
+
+Implements ADR-002 Category 1: adopt the two interfaces declared in the
+legacy Graphene schema. weka uses both via fragment queries:
+
+    ... on Thing { children { edges { node { ... } } } }
+    ... on AutomationTaskInterface { parents { edges { ... } } }
+
+Without these interface declarations, those queries fail at GraphQL
+validation time. The concrete types (GeneralTask, AutomationTask, etc.)
+already declare the underlying fields independently — this module just
+factors them up to a shared interface so fragment queries resolve.
+
+Pattern: the interface declares the relay-connection resolvers with the
+shared private-field naming convention used by every concrete Thing-like
+type in the POC (`files_raw`, `parents_raw`, `children_raw`, `pk`).
+Concrete types inherit the resolvers from the interface; only the
+private fields need to be populated in their `from_dict` classmethods.
+"""
+
+from typing import TYPE_CHECKING
+
+import strawberry
+from strawberry import relay
+from strawberry.types import Info
+
+from .common import EventResult, EventState, KeyValuePair, ModelType, TaskSubType
+
+# `created` is typed `str | None` here to match the spike base. Once
+# strawberry-poc-phase1-scalars (#303) lands, flip both interfaces to
+# `created: DateTime | None`.
+from .relations import (
+    FileRelation,
+    FileRelationsConnection,
+    TaskRelationsConnection,
+    TaskTaskRelation,
+    build_file_relations_for_thing,
+    build_task_children,
+    build_task_parents,
+)
+
+if TYPE_CHECKING:
+    pass
+
+
+# ── Thing interface ──────────────────────────────────────────────────────────
+
+
+@strawberry.interface
+class Thing:
+    """A Thing in the NSHM saga — anything stored in ToshiThingObject.
+
+    Provides the four shared fields (`created`, `files`, `parents`, `children`)
+    that every concrete Thing-like type exposes. Mirrors the legacy
+    `interface Thing` declaration so weka's `... on Thing { ... }` fragment
+    queries work against the POC.
+
+    Concrete types implementing Thing must populate the `pk` and the three
+    `_raw` private fields in their `from_dict` constructors. The resolvers
+    here are inherited; no per-type overrides needed.
+    """
+
+    pk: strawberry.Private[str] = ""
+    created: str | None = None
+    files_raw: strawberry.Private[list | None] = None
+    parents_raw: strawberry.Private[list | None] = None
+    children_raw: strawberry.Private[list | None] = None
+
+    @relay.connection(FileRelationsConnection)
+    def files(self, info: Info) -> list[FileRelation]:
+        return build_file_relations_for_thing(self.pk, self.files_raw or [])
+
+    @relay.connection(TaskRelationsConnection)
+    def parents(self, info: Info) -> list[TaskTaskRelation]:
+        return build_task_parents(self.pk, self.parents_raw or [])
+
+    @relay.connection(TaskRelationsConnection)
+    def children(self, info: Info) -> list[TaskTaskRelation]:
+        return build_task_children(self.pk, self.children_raw or [])
+
+
+# ── AutomationTaskInterface ──────────────────────────────────────────────────
+
+
+@strawberry.interface
+class AutomationTaskInterface:
+    """Interface shared by AutomationTask, RuptureGenerationTask, OpenquakeHazardTask.
+
+    Provides the event-tracking + arguments/environment/metrics fields that
+    every automation-task-like concrete type exposes. Mirrors the legacy
+    `interface AutomationTaskInterface` so weka's deep-traversal pattern
+    `... on AutomationTaskInterface { parents { edges { node { parent { ... } } } } }`
+    works against the POC.
+
+    The interface does NOT inherit from Thing because legacy keeps them
+    separate (different field sets, slightly different semantics around
+    `task_type` and `general_task_id`). Concrete types may declare both
+    interfaces — that's the legacy pattern too.
+    """
+
+    pk: strawberry.Private[str] = ""
+    state: EventState | None = None
+    result: EventResult | None = None
+    created: str | None = None
+    duration: float | None = None
+    general_task_id: strawberry.ID | None = None
+    task_type: TaskSubType | None = None
+    model_type: ModelType | None = None
+    arguments: list[KeyValuePair] | None = None
+    environment: list[KeyValuePair] | None = None
+    metrics: list[KeyValuePair] | None = None
+
+    parents_raw: strawberry.Private[list | None] = None
+
+    @relay.connection(TaskRelationsConnection)
+    def parents(self, info: Info) -> list[TaskTaskRelation]:
+        return build_task_parents(self.pk, self.parents_raw or [])

--- a/spike/strawberry_poc/tests/test_thing_interface.py
+++ b/spike/strawberry_poc/tests/test_thing_interface.py
@@ -1,0 +1,212 @@
+"""
+Tests for the Thing and AutomationTaskInterface adoptions (ADR-002 Category 1).
+
+weka uses `... on Thing { ... }` and `... on AutomationTaskInterface { ... }`
+fragment queries to traverse the task graph. These tests verify those
+fragments resolve correctly against the POC.
+"""
+
+import pytest
+
+from schema import schema
+
+
+CREATE_GT_MUTATION = """
+mutation($input: CreateGeneralTaskInput!) {
+    create_general_task(input: $input) { general_task { id } }
+}
+"""
+
+CREATE_AT_MUTATION = """
+mutation($input: CreateAutomationTaskInput!) {
+    create_automation_task(input: $input) { task_result { id } }
+}
+"""
+
+CREATE_TASK_RELATION_MUTATION = """
+mutation($input: CreateTaskRelationInput!) {
+    create_task_relation(input: $input) { ok }
+}
+"""
+
+# `... on Thing { children { ... } }` — weka pattern, generic Thing query
+THING_FRAGMENT_QUERY = """
+query($id: ID!) {
+    node(id: $id) {
+        id
+        __typename
+        ... on Thing {
+            created
+            children { edges { node { child { __typename ... on AutomationTask { id } } } } }
+            parents { edges { node { parent { __typename ... on GeneralTask { id title } } } } }
+        }
+    }
+}
+"""
+
+# `... on AutomationTaskInterface { parents { ... } }` — weka deep traversal
+AT_INTERFACE_QUERY = """
+query($id: ID!) {
+    node(id: $id) {
+        id
+        __typename
+        ... on AutomationTaskInterface {
+            state
+            result
+            task_type
+            duration
+            arguments { k v }
+            parents { edges { node { parent { __typename ... on GeneralTask { id title } } } } }
+        }
+    }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def gt_with_child_at(gql_context):
+    """Seed: GeneralTask → AutomationTask (linked as child)."""
+    gt = schema.execute_sync(
+        CREATE_GT_MUTATION,
+        variable_values={"input": {"title": "thing-iface parent GT", "agent_name": "pytest"}},
+        context_value=gql_context,
+    )
+    assert gt.errors is None, gt.errors
+    gt_id = gt.data["create_general_task"]["general_task"]["id"]
+
+    at = schema.execute_sync(
+        CREATE_AT_MUTATION,
+        variable_values={
+            "input": {
+                "state": "DONE",
+                "result": "SUCCESS",
+                "task_type": "INVERSION",
+                "created": "2024-01-01T00:00:00Z",
+                "duration": 42.5,
+                "arguments": [{"k": "x", "v": "y"}],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert at.errors is None, at.errors
+    at_id = at.data["create_automation_task"]["task_result"]["id"]
+
+    rel = schema.execute_sync(
+        CREATE_TASK_RELATION_MUTATION,
+        variable_values={"input": {"parent_id": gt_id, "child_id": at_id}},
+        context_value=gql_context,
+    )
+    assert rel.errors is None, rel.errors
+    return {"gt_id": gt_id, "at_id": at_id}
+
+
+# ── Thing interface tests ─────────────────────────────────────────────────────
+
+
+def test_thing_interface_in_sdl():
+    """The Thing interface is declared and has the expected field set."""
+    sdl = schema.as_str()
+    import re
+
+    assert re.search(r"^interface Thing", sdl, re.MULTILINE) is not None
+    # Field signatures
+    assert "files(" in sdl  # relay connection on Thing
+    assert "parents(" in sdl
+    assert "children(" in sdl
+
+
+def test_thing_attached_to_all_concrete_types():
+    """Every Thing-like concrete type implements Thing in the SDL."""
+    sdl = schema.as_str()
+    import re
+
+    matches = {
+        tn: impl
+        for tn, impl in re.findall(r"type (\w+) implements ([\w &]+)", sdl)
+        if "Thing" in impl
+    }
+    # The 7 types ADR-002 specifies
+    expected = {
+        "GeneralTask",
+        "AutomationTask",
+        "RuptureGenerationTask",
+        "OpenquakeHazardTask",
+        "OpenquakeHazardSolution",
+        "OpenquakeHazardConfig",
+        "StrongMotionStation",
+    }
+    assert expected.issubset(matches.keys()), f"missing: {expected - matches.keys()}"
+
+
+def test_thing_fragment_query_resolves_children(gql_context, gt_with_child_at):
+    """The weka-style `... on Thing { children { edges { node { child } } } }` query works."""
+    result = schema.execute_sync(
+        THING_FRAGMENT_QUERY,
+        variable_values={"id": gt_with_child_at["gt_id"]},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["__typename"] == "GeneralTask"
+    child_edges = node["children"]["edges"]
+    assert len(child_edges) == 1
+    child = child_edges[0]["node"]["child"]
+    assert child["__typename"] == "AutomationTask"
+    assert child["id"] == gt_with_child_at["at_id"]
+
+
+def test_thing_fragment_query_resolves_parents(gql_context, gt_with_child_at):
+    """The same fragment but walking from the child up to its parent GT."""
+    result = schema.execute_sync(
+        THING_FRAGMENT_QUERY,
+        variable_values={"id": gt_with_child_at["at_id"]},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["__typename"] == "AutomationTask"
+    parent_edges = node["parents"]["edges"]
+    assert len(parent_edges) == 1
+    parent = parent_edges[0]["node"]["parent"]
+    assert parent["__typename"] == "GeneralTask"
+    assert parent["id"] == gt_with_child_at["gt_id"]
+    assert parent["title"] == "thing-iface parent GT"
+
+
+# ── AutomationTaskInterface tests ─────────────────────────────────────────────
+
+
+def test_automation_task_interface_in_sdl():
+    """AutomationTaskInterface is declared with the expected fields."""
+    sdl = schema.as_str()
+    import re
+
+    assert re.search(r"^interface AutomationTaskInterface", sdl, re.MULTILINE) is not None
+    matches = {
+        tn: impl
+        for tn, impl in re.findall(r"type (\w+) implements ([\w &]+)", sdl)
+        if "AutomationTaskInterface" in impl
+    }
+    expected = {"AutomationTask", "RuptureGenerationTask", "OpenquakeHazardTask"}
+    assert expected.issubset(matches.keys()), f"missing: {expected - matches.keys()}"
+
+
+def test_automation_task_interface_fragment_resolves(gql_context, gt_with_child_at):
+    """The weka-pattern `... on AutomationTaskInterface { parents { ... } }` query works."""
+    result = schema.execute_sync(
+        AT_INTERFACE_QUERY,
+        variable_values={"id": gt_with_child_at["at_id"]},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["__typename"] == "AutomationTask"
+    assert node["state"] == "DONE"
+    assert node["result"] == "SUCCESS"
+    assert node["task_type"] == "INVERSION"
+    assert node["duration"] == 42.5
+    assert node["arguments"] == [{"k": "x", "v": "y"}]
+    # Parent traversal via the interface
+    parent = node["parents"]["edges"][0]["node"]["parent"]
+    assert parent["__typename"] == "GeneralTask"
+    assert parent["id"] == gt_with_child_at["gt_id"]


### PR DESCRIPTION
## Summary

Implements ADR-002 Category 1 — the **only wire-impacting divergence** identified after ADR-001 Phase 1+2. weka uses both interfaces via fragment queries:

\`\`\`graphql
... on Thing { children { edges { node { ... } } } }
... on AutomationTaskInterface { parents { edges { node { parent { ... on GeneralTask { ... } } } } } }
\`\`\`

Without the interface declarations, those queries fail at GraphQL validation time with \`Cannot spread fragment Thing on AutomationTask\`. After this PR, both fragments resolve end-to-end against the POC.

## Pattern

Each interface declares its relay-connection resolvers using the shared private-field naming convention every concrete Thing-like type in the POC already follows (\`pk\`, \`files_raw\`, \`parents_raw\`, \`children_raw\`). Concrete types implement the interface and **inherit the resolvers** — only the \`from_dict\` constructors need to populate the private fields (which they already do).

\`\`\`python
@strawberry.interface
class Thing:
    pk: strawberry.Private[str] = \"\"
    created: str | None = None
    files_raw: strawberry.Private[list | None] = None
    parents_raw: strawberry.Private[list | None] = None
    children_raw: strawberry.Private[list | None] = None

    @relay.connection(FileRelationsConnection)
    def files(self, info) -> list[FileRelation]:
        return build_file_relations_for_thing(self.pk, self.files_raw or [])

    # parents, children similar
\`\`\`

\`\`\`python
@strawberry.type
class GeneralTask(relay.Node, Thing):
    pk: relay.NodeID[str]
    title: str | None = None
    # files_raw / parents_raw / children_raw and the @relay.connection
    # resolvers all inherited from Thing
\`\`\`

This means the concrete types' previously-local \`@relay.connection\` methods become redundant. For most types we leave them in place — the local override is identical to the inherited one (no-op). For \`StrongMotionStation\` we removed them since the file was thinner and the cleanup landed cleanly. The other types' cleanup is a follow-up.

## Changes

- **\`models/thing.py\` (new)** — both interfaces with shared resolvers
- **7 concrete types** gain Thing:
  - \`GeneralTask\`, \`AutomationTask\`, \`RuptureGenerationTask\`, \`OpenquakeHazardTask\`, \`OpenquakeHazardSolution\`, \`OpenquakeHazardConfig\`, \`StrongMotionStation\`
- **3 concrete types** also gain AutomationTaskInterface:
  - \`AutomationTask\`, \`RuptureGenerationTask\`, \`OpenquakeHazardTask\`
- **\`tests/test_thing_interface.py\` (new)** — 6 tests:
  - SDL inspection: interfaces declared, attached to all expected types
  - Fragment-resolution: weka-pattern \`... on Thing { children {...} }\` on GeneralTask returns linked AutomationTask
  - Parent traversal walking from AutomationTask back to its GT
  - AutomationTaskInterface fields surface correctly
  - Parent traversal through AutomationTaskInterface

## SDL impact

Two new interface blocks present:

\`\`\`graphql
interface Thing {
  created: String
  files(...): FileRelationsConnection!
  parents(...): TaskRelationsConnection!
  children(...): TaskRelationsConnection!
}

interface AutomationTaskInterface {
  result: EventResult
  state: EventState
  created: String
  duration: Float
  general_task_id: ID
  task_type: TaskSubType
  model_type: ModelType
  arguments: [KeyValuePair!]
  environment: [KeyValuePair!]
  metrics: [KeyValuePair!]
  parents(...): TaskRelationsConnection!
}
\`\`\`

Concrete-type SDL:

\`\`\`graphql
type GeneralTask implements Node & Thing { ... }
type AutomationTask implements Node & Thing & AutomationTaskInterface { ... }
type RuptureGenerationTask implements Node & Thing & AutomationTaskInterface { ... }
type OpenquakeHazardTask implements Node & Thing & AutomationTaskInterface { ... }
type OpenquakeHazardSolution implements Node & PredecessorsInterface & Thing { ... }
type OpenquakeHazardConfig implements Node & Thing { ... }
type StrongMotionStation implements Node & Thing { ... }
\`\`\`

## Parity impact

Both \`Thing\` and \`AutomationTaskInterface\` move off the \"types only in legacy\" list. Various per-type \"interfaces only in legacy\" mismatches that referenced these clear up too. The full parity report shrinks; remaining divergences are the Category 2-4 items ADR-002 explicitly accepts.

## Test plan

- [x] \`uv run pytest tests/test_thing_interface.py\` — **6 passed**
- [x] \`uv run pytest tests/\` — **157 passed, 1 skipped** (was 151/1 on spike base; +6 from new file)
- [x] Schema loads cleanly
- [x] SDL contains both interface declarations
- [x] All 7 expected concrete types implement Thing; all 3 expected implement AutomationTaskInterface
- [x] Fragment-resolution traverses parent/child task hierarchy via \`... on Thing { children {...} }\`
- [x] weka-style \`... on AutomationTaskInterface { parents { ... { parent { ... on GeneralTask } } } }\` end-to-end query works

## Followups deferred

- \`created: str\` is used in \`models/thing.py\` for spike-base compatibility. Once #303 (Phase 1 scalars) lands, flip to \`created: DateTime\` (one-line change).
- The redundant local \`@relay.connection\` methods on concrete types can be removed for cleanup; safe but mechanical (~50 lines).
- Cleanup likely belongs in a separate small follow-up once this PR is reviewed.

## Stacking

Targets \`strawberry-poc-spike\`. Independent of all other Phase 1/2 work — touches different surface. ADR-002 strategy doc lives on #307.

**Depends on:** #296.
**Companion doc:** #307 (ADR-002).

## Stack now

\`\`\`
deploy-test
   └── strawberry-poc-spike                       (#296)
        ├── strawberry-poc-deploy                       (#297)
        ├── strawberry-poc-ci                           (#298)
        ├── strawberry-poc-compression                  (#299)
        ├── strawberry-poc-s3-fallback                  (#300)
        ├── strawberry-poc-schema-parity                (#301)
        ├── strawberry-poc-adrs                         (#302)
        │    └── strawberry-poc-adr-002-clean                (#307)
        ├── strawberry-poc-phase1-scalars               (#303)
        ├── strawberry-poc-phase1-pageinfo              (#304)
        ├── strawberry-poc-phase1-clientmutationid      (#305)
        ├── strawberry-poc-phase2-codegen               (#306)
        └── strawberry-poc-adr-002-impl                 (this PR)
\`\`\`