### PR TITLE
feat(strawberry-poc): client-divergence fixes for weka/runzi/nzshm-model

### DIFF
--- a/spike/strawberry_poc/models/automation_task.py
+++ b/spike/strawberry_poc/models/automation_task.py
@@ -20,6 +20,7 @@ from data.dynamo import create_thing, get_thing, list_things, update_thing
 from data.models import AutomationTaskData
 
 from .common import EventResult, EventState, KeyValuePair, KeyValuePairInput, ModelType, TaskSubType, _try_enum
+from .inversion_solution_union import InversionSolutionUnion, resolve_task_inversion_solution
 from .relations import (
     FileRelation,
     FileRelationsConnection,
@@ -72,6 +73,10 @@ class AutomationTask(relay.Node):
     @relay.connection(TaskRelationsConnection)
     def children(self, info: Info) -> list[TaskTaskRelation]:
         return build_task_children(self.pk, self.children_raw or [])
+
+    @strawberry.field
+    def inversion_solution(self, info: Info) -> InversionSolutionUnion | None:
+        return resolve_task_inversion_solution(info.context["dynamodb"], self.files_raw)
 
     @classmethod
     def resolve_node(cls, node_id: str, *, info: Info, **kwargs) -> Optional["AutomationTask"]:
@@ -132,6 +137,10 @@ class RuptureGenerationTask(relay.Node):
     @relay.connection(TaskRelationsConnection)
     def children(self, info: Info) -> list[TaskTaskRelation]:
         return build_task_children(self.pk, self.children_raw or [])
+
+    @strawberry.field
+    def inversion_solution(self, info: Info) -> InversionSolutionUnion | None:
+        return resolve_task_inversion_solution(info.context["dynamodb"], self.files_raw)
 
     @classmethod
     def resolve_node(cls, node_id: str, *, info: Info, **kwargs) -> Optional["RuptureGenerationTask"]:

--- a/spike/strawberry_poc/models/common.py
+++ b/spike/strawberry_poc/models/common.py
@@ -159,6 +159,14 @@ class TableType(enum.Enum):
 
 
 @strawberry.enum
+class RowItemType(enum.Enum):
+    integer = "INT"
+    double = "DBL"
+    string = "STR"
+    boolean = "BOO"
+
+
+@strawberry.enum
 class AncestryLabel(enum.Enum):
     SIBLING = 0
     PARENT = -1

--- a/spike/strawberry_poc/models/file.py
+++ b/spike/strawberry_poc/models/file.py
@@ -21,7 +21,7 @@ from .file_interface import FileInterface
 from .relations import FileRelation, FileRelationsConnection, build_file_relations_for_file
 
 
-@strawberry.type
+@strawberry.type(name="File")
 class ToshiFile(relay.Node, FileInterface):
     """A file stored in S3 and indexed in DynamoDB."""
 

--- a/spike/strawberry_poc/models/inversion_solution_union.py
+++ b/spike/strawberry_poc/models/inversion_solution_union.py
@@ -1,0 +1,69 @@
+"""InversionSolutionUnion — the IS produced by an AutomationTask family member.
+
+Mirrors legacy `inversion_solution_union.py`. Used by AutomationTask,
+RuptureGenerationTask, and OpenquakeHazardTask to expose the WRITE-related
+inversion solution file as a first-class field.
+"""
+
+from typing import Annotated
+
+import strawberry
+
+from data.dynamo import get_file
+
+from .common import FileRole
+
+_InversionSolution = Annotated["InversionSolution", strawberry.lazy("models.inversion_solution")]
+_ScaledInversionSolution = Annotated["ScaledInversionSolution", strawberry.lazy("models.scaled_inversion_solution")]
+_AggregateInversionSolution = Annotated[
+    "AggregateInversionSolution", strawberry.lazy("models.aggregate_inversion_solution")
+]
+_TimeDependentInversionSolution = Annotated[
+    "TimeDependentInversionSolution", strawberry.lazy("models.time_dependent_inversion_solution")
+]
+
+
+InversionSolutionUnion = Annotated[
+    _InversionSolution | _ScaledInversionSolution | _AggregateInversionSolution | _TimeDependentInversionSolution,
+    strawberry.union(name="InversionSolutionUnion"),
+]
+
+
+_IS_CLAZZ_DISPATCH = {
+    "InversionSolution": "models.inversion_solution",
+    "ScaledInversionSolution": "models.scaled_inversion_solution",
+    "AggregateInversionSolution": "models.aggregate_inversion_solution",
+    "TimeDependentInversionSolution": "models.time_dependent_inversion_solution",
+}
+
+
+def resolve_task_inversion_solution(dynamodb, files_raw: list | None):
+    """Find the InversionSolution produced (file_role=WRITE) by a task.
+
+    Mirrors legacy `AutomationTask.resolve_inversion_solution` traversal:
+    iterate file relations, pick the WRITE one whose file is an
+    InversionSolution subtype.
+    """
+    if not files_raw:
+        return None
+    import importlib  # noqa: PLC0415
+
+    for entry in files_raw:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("file_role") != FileRole.WRITE.value:
+            continue
+        file_id = entry.get("file_id")
+        if not file_id:
+            continue
+        data = get_file(dynamodb, file_id)
+        if not data:
+            continue
+        clazz = data.get("clazz_name", "")
+        module_path = _IS_CLAZZ_DISPATCH.get(clazz)
+        if not module_path:
+            continue
+        module = importlib.import_module(module_path)
+        cls = getattr(module, clazz)
+        return cls.from_dict(data)
+    return None

--- a/spike/strawberry_poc/models/openquake_hazard_task.py
+++ b/spike/strawberry_poc/models/openquake_hazard_task.py
@@ -12,6 +12,7 @@ from data.dynamo import create_thing, get_thing, list_things, update_thing
 from data.models import OpenquakeHazardTaskData
 
 from .common import EventResult, EventState, KeyValuePair, KeyValuePairInput, ModelType, TaskSubType, _try_enum
+from .inversion_solution_union import InversionSolutionUnion, resolve_task_inversion_solution
 from .relations import (
     FileRelation,
     FileRelationsConnection,
@@ -59,6 +60,10 @@ class OpenquakeHazardTask(relay.Node):
     @relay.connection(TaskRelationsConnection)
     def children(self, info: Info) -> list[TaskTaskRelation]:
         return build_task_children(self.pk, self.children_raw or [])
+
+    @strawberry.field
+    def inversion_solution(self, info: Info) -> InversionSolutionUnion | None:
+        return resolve_task_inversion_solution(info.context["dynamodb"], self.files_raw)
 
     @strawberry.field
     def hazard_solution(self, info: Info) -> _OpenquakeHazardSolution | None:

--- a/spike/strawberry_poc/models/table.py
+++ b/spike/strawberry_poc/models/table.py
@@ -9,7 +9,15 @@ from strawberry.types import Info
 from data.dynamo import create_table, get_table
 from data.models import TableData
 
-from .common import KeyValueListPair, KeyValueListPairInput, KeyValuePair, KeyValuePairInput, TableType, _try_enum
+from .common import (
+    KeyValueListPair,
+    KeyValueListPairInput,
+    KeyValuePair,
+    KeyValuePairInput,
+    RowItemType,
+    TableType,
+    _try_enum,
+)
 
 
 @strawberry.type
@@ -19,7 +27,7 @@ class Table(relay.Node):
     name: str | None = None
     created: str | None = None
     column_headers: list[str] | None = None
-    column_types: list[str] | None = None
+    column_types: list[RowItemType] | None = None
     rows: list[list[str]] | None = None
     meta: list[KeyValuePair] | None = None
     table_type: TableType | None = None
@@ -40,7 +48,9 @@ class Table(relay.Node):
             name=d.name,
             created=d.created,
             column_headers=d.column_headers,
-            column_types=d.column_types,
+            column_types=[RowItemType[v] for v in d.column_types if v in RowItemType.__members__]
+            if d.column_types
+            else None,
             rows=d.rows,
             meta=[KeyValuePair(k=i.k, v=i.v) for i in d.meta] if d.meta else None,
             table_type=table_type,
@@ -54,7 +64,7 @@ class CreateTableInput:
     name: str | None = None
     created: str | None = None
     column_headers: list[str] | None = None
-    column_types: list[str] | None = None
+    column_types: list[RowItemType] | None = None
     rows: list[list[str]] | None = None
     meta: list[KeyValuePairInput] | None = None
     table_type: TableType | None = None
@@ -69,7 +79,7 @@ def mutate_create_table(info: Info, input: CreateTableInput) -> Table:
         "name": input.name,
         "created": input.created,
         "column_headers": input.column_headers,
-        "column_types": input.column_types,
+        "column_types": [v.name for v in input.column_types] if input.column_types else None,
         "rows": input.rows,
         "meta": meta,
         "table_type": input.table_type.value if input.table_type else None,

--- a/spike/strawberry_poc/schema.py
+++ b/spike/strawberry_poc/schema.py
@@ -324,7 +324,7 @@ class UpdateOpenquakeHazardTaskPayload:
     task_result: OpenquakeHazardTask | None = None
 
 
-@strawberry.type
+@strawberry.type(name="NodeFilter")
 class NodeFilterPayload:
     ok: bool = False
     result: SearchResultConnection = strawberry.field(default_factory=SearchResultConnection)

--- a/spike/strawberry_poc/tests/test_file_relation.py
+++ b/spike/strawberry_poc/tests/test_file_relation.py
@@ -44,7 +44,7 @@ query GetTask($id: ID!) {
                     node {
                         role
                         file {
-                            ... on ToshiFile { id }
+                            ... on File { id }
                         }
                     }
                 }

--- a/spike/strawberry_poc/tests/test_inversion_solution.py
+++ b/spike/strawberry_poc/tests/test_inversion_solution.py
@@ -132,7 +132,7 @@ def _seed_toshi_file(gql_context, label="table.hdf5"):
         {"file_name": label},
     )
     raw_id = data["object_id"]
-    return base64.b64encode(f"ToshiFile:{raw_id}".encode()).decode()
+    return base64.b64encode(f"File:{raw_id}".encode()).decode()
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────

--- a/spike/strawberry_poc/tests/test_inversion_solution_interface.py
+++ b/spike/strawberry_poc/tests/test_inversion_solution_interface.py
@@ -112,7 +112,7 @@ def _seed_mfd_table(gql_context, rgt_id: str) -> str:
                 "table_type": "MFD_CURVES_V2",
                 "created": "2024-01-01T00:00:00Z",
                 "column_headers": ["mag", "rate"],
-                "column_types": ["float", "float"],
+                "column_types": ["double", "double"],
                 "rows": [["7.0", "1e-5"], ["7.5", "5e-6"]],
             }
         },

--- a/spike/strawberry_poc/tests/test_openquake.py
+++ b/spike/strawberry_poc/tests/test_openquake.py
@@ -82,7 +82,7 @@ mutation CreateOQConfig($input: CreateOpenquakeHazardConfigInput!) {
                 file_name
             }
             source_models {
-                ... on ToshiFile {
+                ... on File {
                     id
                     file_name
                 }
@@ -127,7 +127,7 @@ def _seed_toshi_file(gql_context, name="archive.zip"):
 
     data = create_file(gql_context["dynamodb"], "ToshiFile", {"file_name": name})
     raw_id = data["object_id"]
-    return base64.b64encode(f"ToshiFile:{raw_id}".encode()).decode()
+    return base64.b64encode(f"File:{raw_id}".encode()).decode()
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -463,9 +463,9 @@ mutation CreateSolutionFull($input: CreateOpenquakeHazardSolutionInput!) {
         openquake_hazard_solution {
             id
             task_type
-            csv_archive { ... on ToshiFile { id file_name } }
-            hdf5_archive { ... on ToshiFile { id file_name } }
-            task_args { ... on ToshiFile { id file_name } }
+            csv_archive { ... on File { id file_name } }
+            hdf5_archive { ... on File { id file_name } }
+            task_args { ... on File { id file_name } }
             predecessors { id depth relationship }
         }
     }

--- a/spike/strawberry_poc/tests/test_smoketest_ab.py
+++ b/spike/strawberry_poc/tests/test_smoketest_ab.py
@@ -339,7 +339,7 @@ def test_node_file_with_relations(ids, gql_context):
         """
         query GetFile($id: ID!) {
             node(id: $id) {
-                ... on ToshiFile {
+                ... on File {
                     file_name
                     file_size
                     meta { k v }
@@ -440,7 +440,7 @@ def test_node_general_task_children_and_files(ids, gql_context):
                                     role
                                     file {
                                         __typename
-                                        ... on ToshiFile { file_name file_size }
+                                        ... on File { file_name file_size }
                                         ... on SmsFile { file_name file_size file_type }
                                     }
                                 }
@@ -473,7 +473,7 @@ def test_node_general_task_children_and_files(ids, gql_context):
     assert "READ" in roles
     assert "UNDEFINED" in roles
     typenames = {e["node"]["file"]["__typename"] for e in file_edges}
-    assert "ToshiFile" in typenames
+    assert "File" in typenames
     assert "SmsFile" in typenames
 
 
@@ -490,7 +490,7 @@ def test_node_rgt_files_and_parents(ids, gql_context):
                             node {
                                 ... on FileRelation {
                                     role
-                                    file { ... on ToshiFile { file_name } }
+                                    file { ... on File { file_name } }
                                 }
                             }
                         }
@@ -641,7 +641,7 @@ def test_list_automation_tasks(ids, gql_context):
 SEARCH_FRAGMENT = """
 fragment sr on SearchResult {
     __typename
-    ... on ToshiFile {
+    ... on File {
         id
         file_name
         relations {
@@ -687,7 +687,7 @@ fragment sr on SearchResult {
                     ... on FileRelation {
                         role
                         file {
-                            ... on ToshiFile { id file_name file_size }
+                            ... on File { id file_name file_size }
                         }
                     }
                 }
@@ -744,7 +744,7 @@ fragment sr on SearchResult {
                         role
                         file {
                             __typename
-                            ... on ToshiFile { file_name file_size }
+                            ... on File { file_name file_size }
                             ... on SmsFile { file_name file_size file_type }
                         }
                     }

--- a/spike/strawberry_poc/tests/test_weka_parity.py
+++ b/spike/strawberry_poc/tests/test_weka_parity.py
@@ -1,0 +1,277 @@
+"""Weka client parity tests.
+
+Locks in three wire-format fixes that real production clients depend on:
+
+  1. The file type is named `File` in SDL (not `ToshiFile`) — weka and
+     nzshm-model query `... on File`.
+  2. `nodes(...)` returns a `NodeFilter` payload type (not `NodeFilterPayload`)
+     — weka's Relay codegen references `concreteType: "NodeFilter"`.
+  3. `column_types` is `[RowItemType]` — runzi mutations declare
+     `$column_types: [RowItemType]!`.
+
+Also covers the `inversion_solution` resolver on AutomationTask /
+RuptureGenerationTask / OpenquakeHazardTask, which weka queries on
+GeneralTask children pages.
+"""
+
+import base64
+
+import pytest
+
+from schema import schema
+
+
+def _gid(typename: str, raw_id: str) -> str:
+    return base64.b64encode(f"{typename}:{raw_id}".encode()).decode()
+
+
+# ── 1. File SDL name ──────────────────────────────────────────────────────────
+
+
+FILE_TYPENAME_QUERY = """
+query GetFile($id: ID!) {
+    node(id: $id) {
+        __typename
+        ... on File {
+            id
+            file_name
+        }
+    }
+}
+"""
+
+CREATE_FILE_MUTATION = """
+mutation CreateFile($input: CreateFileInput!) {
+    create_file(input: $input) {
+        ok
+        file_result { id file_name }
+    }
+}
+"""
+
+
+def test_file_sdl_typename(gql_context):
+    res = schema.execute_sync(
+        CREATE_FILE_MUTATION,
+        variable_values={"input": {"file_name": "weka.zip"}},
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    fid = res.data["create_file"]["file_result"]["id"]
+
+    res2 = schema.execute_sync(FILE_TYPENAME_QUERY, variable_values={"id": fid}, context_value=gql_context)
+    assert res2.errors is None, res2.errors
+    assert res2.data["node"]["__typename"] == "File"
+    assert res2.data["node"]["file_name"] == "weka.zip"
+
+
+def test_file_introspection_has_no_toshifile():
+    sdl = schema.as_str()
+    assert "type File implements" in sdl
+    assert "type ToshiFile " not in sdl
+    assert "type ToshiFile\n" not in sdl
+
+
+# ── 2. NodeFilter SDL name ────────────────────────────────────────────────────
+
+
+NODES_QUERY = """
+query Nodes($id_in: [ID!]!) {
+    nodes(id_in: $id_in) {
+        ok
+        result {
+            edges { node { __typename ... on Node { id } } }
+        }
+    }
+}
+"""
+
+
+def test_nodes_payload_sdl_name():
+    sdl = schema.as_str()
+    assert "type NodeFilter " in sdl or "type NodeFilter\n" in sdl
+    assert "type NodeFilterPayload" not in sdl
+
+
+def test_nodes_works(gql_context):
+    create_res = schema.execute_sync(
+        CREATE_FILE_MUTATION,
+        variable_values={"input": {"file_name": "nodes-test.zip"}},
+        context_value=gql_context,
+    )
+    fid = create_res.data["create_file"]["file_result"]["id"]
+    res = schema.execute_sync(NODES_QUERY, variable_values={"id_in": [fid]}, context_value=gql_context)
+    assert res.errors is None, res.errors
+    assert res.data["nodes"]["ok"] is True
+
+
+# ── 3. RowItemType enum ───────────────────────────────────────────────────────
+
+
+def test_rowitemtype_enum_in_sdl():
+    sdl = schema.as_str()
+    assert "enum RowItemType" in sdl
+    for v in ("integer", "double", "string", "boolean"):
+        assert v in sdl, f"{v} missing from RowItemType"
+
+
+CREATE_TABLE_WITH_TYPED_COLUMNS = """
+mutation CreateTable($input: CreateTableInput!) {
+    create_table(input: $input) {
+        table { id column_types }
+    }
+}
+"""
+
+
+@pytest.fixture
+def task_id(gql_context):
+    res = schema.execute_sync(
+        """
+        mutation Create($input: CreateAutomationTaskInput!) {
+            create_automation_task(input: $input) { task_result { id } }
+        }
+        """,
+        variable_values={
+            "input": {
+                "state": "UNDEFINED",
+                "result": "UNDEFINED",
+                "task_type": "INVERSION",
+                "created": "2026-01-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    return res.data["create_automation_task"]["task_result"]["id"]
+
+
+def test_column_types_accepts_rowitemtype_enum(gql_context, task_id):
+    res = schema.execute_sync(
+        CREATE_TABLE_WITH_TYPED_COLUMNS,
+        variable_values={
+            "input": {
+                "object_id": task_id,
+                "table_type": "MFD_CURVES_V2",
+                "column_headers": ["mag", "rate"],
+                "column_types": ["double", "double"],
+                "rows": [["7.0", "1e-5"]],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    assert res.data["create_table"]["table"]["column_types"] == ["double", "double"]
+
+
+def test_column_types_rejects_invalid_enum(gql_context, task_id):
+    res = schema.execute_sync(
+        CREATE_TABLE_WITH_TYPED_COLUMNS,
+        variable_values={
+            "input": {
+                "object_id": task_id,
+                "table_type": "MFD_CURVES_V2",
+                "column_headers": ["x"],
+                "column_types": ["float"],  # legacy/runzi never used this name
+                "rows": [["1.0"]],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert res.errors is not None
+    assert "RowItemType" in str(res.errors[0])
+
+
+# ── 4. inversion_solution on AutomationTask family ─────────────────────────────
+
+
+CREATE_IS_MUTATION = """
+mutation CreateIS($input: CreateInversionSolutionInput!) {
+    create_inversion_solution(input: $input) {
+        ok
+        inversion_solution { id }
+    }
+}
+"""
+
+CREATE_FILE_RELATION = """
+mutation CreateRel($input: CreateFileRelationInput!) {
+    create_file_relation(input: $input) { ok }
+}
+"""
+
+TASK_IS_QUERY = """
+query GetTask($id: ID!) {
+    node(id: $id) {
+        ... on AutomationTask {
+            inversion_solution {
+                __typename
+                ... on InversionSolution { id }
+            }
+        }
+    }
+}
+"""
+
+
+def test_automation_task_inversion_solution_resolves(gql_context, task_id):
+    is_res = schema.execute_sync(
+        CREATE_IS_MUTATION,
+        variable_values={
+            "input": {
+                "file_name": "is.zip",
+                "produced_by": task_id,
+                "created": "2026-01-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert is_res.errors is None, is_res.errors
+    is_id = is_res.data["create_inversion_solution"]["inversion_solution"]["id"]
+
+    rel_res = schema.execute_sync(
+        CREATE_FILE_RELATION,
+        variable_values={"input": {"thing_id": task_id, "file_id": is_id, "role": "WRITE"}},
+        context_value=gql_context,
+    )
+    assert rel_res.errors is None, rel_res.errors
+
+    q = schema.execute_sync(TASK_IS_QUERY, variable_values={"id": task_id}, context_value=gql_context)
+    assert q.errors is None, q.errors
+    sol = q.data["node"]["inversion_solution"]
+    assert sol is not None
+    assert sol["__typename"] == "InversionSolution"
+    assert sol["id"] == is_id
+
+
+def test_automation_task_inversion_solution_null_without_write_relation(gql_context):
+    # Brand-new task with no file relations → inversion_solution is None
+    create = schema.execute_sync(
+        """
+        mutation Create($input: CreateAutomationTaskInput!) {
+            create_automation_task(input: $input) { task_result { id } }
+        }
+        """,
+        variable_values={
+            "input": {
+                "state": "UNDEFINED",
+                "result": "UNDEFINED",
+                "task_type": "INVERSION",
+                "created": "2026-01-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    tid = create.data["create_automation_task"]["task_result"]["id"]
+    q = schema.execute_sync(TASK_IS_QUERY, variable_values={"id": tid}, context_value=gql_context)
+    assert q.errors is None, q.errors
+    assert q.data["node"]["inversion_solution"] is None
+
+
+def test_inversion_solution_union_in_sdl():
+    sdl = schema.as_str()
+    assert (
+        "union InversionSolutionUnion = "
+        "InversionSolution | ScaledInversionSolution | "
+        "AggregateInversionSolution | TimeDependentInversionSolution"
+    ) in sdl


### PR DESCRIPTION
## Summary

Closes four wire-format gaps where the Strawberry POC diverged from the
legacy schema in ways that **break real production clients**. Evidence
was gathered by inspecting actual GraphQL queries in:

- `weka` (UI) — `../UI/weka/src/`
- `nzshm-runzi` (Python automation) — `../MISC/nzshm-runzi`
- `nzshm-model` (Python library) — `../LIB/nzshm-model`

| # | Fix | Client evidence |
|---|---|---|
| 1 | Revert SDL `ToshiFile` → `File` (Python class stays `ToshiFile`) | weka × 4 source files (`... on File`), nzshm-model × 1 |
| 2 | Rename `NodeFilterPayload` SDL type → `NodeFilter` | weka generated Relay codegen × 2 views (`concreteType: "NodeFilter"`) |
| 3 | Add `RowItemType` enum; use on `Table.column_types` + `CreateTableInput.column_types` | weka × 1, runzi × 1 (`$column_types: [RowItemType]!`) |
| 4 | Add `inversion_solution: InversionSolutionUnion` to `AutomationTask`, `RuptureGenerationTask`, `OpenquakeHazardTask` | weka `AutomationTaskPage`, `GeneralTaskChildrenTab` |

The `inversion_solution` resolver mirrors the legacy traversal: scan
`files_raw`, pick the `WRITE`-related entry whose underlying file is an
`InversionSolution` subtype, dispatch by `clazz_name`.

## Test plan

- [x] `tests/test_weka_parity.py` — 10 new tests covering each fix
- [x] Full POC suite: 161 passed, 1 skipped (was 151, +10 new)
- [x] Manual SDL check — types/enums/fields all match legacy SDL via the
      schema parity diff tool
- [ ] CI to confirm (depends on merge of the shared-workflow PR)

## Notes for review

- `RowItemType` storage uses the enum **name** (e.g. `"integer"`),
  matching the wire-format value clients send. Read-side looks up by
  `__members__` to round-trip cleanly.
- `Table.column_types` still differs from legacy in list-item
  nullability (`[RowItemType!]` vs `[RowItemType]`). This was already
  accepted as not blocking for clients.
- `OpenquakeHazardTask` already had `hazard_solution`; `inversion_solution`
  is additive and matches legacy's mixed inheritance from
  `AutomationTaskInterface`.

## Stacking

Base: `strawberry-poc-spike` (target after the rest of the stack
merges to `deploy-test`).