### PR TITLE
chore(strawberry-poc): deploy + CI + parity tooling + ADRs

### DIFF
--- a/.github/workflows/strawberry-poc-tests.yaml
+++ b/.github/workflows/strawberry-poc-tests.yaml
@@ -17,8 +17,7 @@ on:
       - 'spike/strawberry_poc/**'
       - '.github/workflows/strawberry-poc-tests.yaml'
   push:
-    branches:
-      - chore/strawberry-fields
+    branches: [deploy-test, main]
     paths:
       - 'spike/strawberry_poc/**'
       - '.github/workflows/strawberry-poc-tests.yaml'

--- a/.github/workflows/strawberry-poc-tests.yaml
+++ b/.github/workflows/strawberry-poc-tests.yaml
@@ -1,0 +1,43 @@
+# Runs the Strawberry POC test suite via the GNS-Science shared workflow.
+#
+# Delegates to nshm-github-actions/python-run-tests-uv.yml, which handles
+# uv install + tox + Codecov upload + Slack alerts. The shared workflow
+# expects a tox config at the working-directory root — see
+# spike/strawberry_poc/setup.cfg.
+#
+# Scope: only triggers on changes under spike/strawberry_poc/** so it
+# doesn't slow PRs that touch only legacy graphql_api code. Legacy CI
+# (run-tests-on-pull-request.yaml) is unaffected.
+name: Strawberry POC Tests
+
+on:
+  pull_request:
+    branches: [deploy-test, main]
+    paths:
+      - 'spike/strawberry_poc/**'
+      - '.github/workflows/strawberry-poc-tests.yaml'
+  push:
+    branches:
+      - chore/strawberry-fields
+    paths:
+      - 'spike/strawberry_poc/**'
+      - '.github/workflows/strawberry-poc-tests.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: strawberry-poc-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  call-test-workflow:
+    uses: GNS-Science/nshm-github-actions/.github/workflows/python-run-tests-uv.yml@main
+    with:
+      operating-systems: "['ubuntu-latest']"
+      python-versions: "['3.12']"
+      working-directory: spike/strawberry_poc
+      optional-dependency-groups: dev
+      timeout-minutes: 20
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+junit.xml
 *.cover
 *.py,cover
 .hypothesis/

--- a/docs/adrs/0001-graphql-schema-evolution-strategy.md
+++ b/docs/adrs/0001-graphql-schema-evolution-strategy.md
@@ -1,0 +1,287 @@
+# ADR-0001: GraphQL Schema Evolution Strategy — Legacy Parity, Modern Defaults, Deprecation Aliases
+
+## Status
+
+Proposed.
+
+## Context
+
+### The drop-in promise
+
+The Strawberry+FastAPI POC (`spike/strawberry_poc/`) was scoped from
+the outset as a **drop-in replacement** for the legacy Graphene+Flask
+GraphQL API. Clients — weka, runzi, anything else that reads or
+writes via the Toshi GraphQL endpoint — should not need code changes
+when traffic moves from `/graphql` to `/graphql-v2`.
+
+That promise is harder than it sounds, because the schemas have
+drifted in ways that aren't always visible from a casual read.
+
+### What the parity diff revealed
+
+`spike/strawberry_poc/tools/schema_parity.py` produces an SDL-level
+diff between the legacy schema and the POC. The first real run found:
+
+- 30 types in legacy but missing from POC
+- 55 types in POC but missing from legacy
+- 68 types whose fields, types, or interfaces differ
+
+That is **a lot** of difference for an API that's supposed to be
+drop-in.
+
+### The "why does weka work at all?" puzzle
+
+Given that level of divergence, it is genuinely surprising weka
+queries succeed at all against `/graphql-v2`. There are several
+reasons they do — and understanding them is load-bearing for the
+strategy below:
+
+1. **Most divergence is at the SDL level, not the wire level.**
+   `[KeyValuePair]` vs `[KeyValuePair!]`, `parents: TaskTaskRelationConnection`
+   vs `parents: TaskRelationsConnection!`, edge node nullability — all
+   produce identical JSON for the same data. Clients don't notice.
+
+2. **weka uses fragment queries against interfaces.** Most weka query
+   bodies look like `... on InversionSolutionInterface { file_name, … }`.
+   The interface fragment payload doesn't care about the concrete
+   type's name — `File` vs `ToshiFile` is invisible inside a fragment
+   that asks for `file_name`. Type-name renames are a much bigger
+   problem for `... on ConcreteType { }` fragments than for interface
+   fragments. weka mostly uses interfaces.
+
+3. **Production paths that hit the rough edges aren't exercised every
+   day.** The two bugs that have actually bitten in this iteration
+   (`GeneralTask` enum coercion crashing every field; `file_size`
+   silently truncating at 2GB) only surfaced when specific
+   real-production data hit specific code paths. Before that, the
+   POC "worked" against test data because the test data didn't
+   contain the trigger conditions.
+
+4. **GraphQL is permissive about missing data.** When a resolver
+   returns `null` for a missing field, the client sees `null` —
+   indistinguishable (from the client's perspective) from a value
+   that just happens to be `null` legitimately. Silent breakage is
+   the default mode of GraphQL schema drift.
+
+5. **The /graphql-v2 deploy has been read-only and narrowly tested.**
+   `DB_READ_ONLY=1` blocks every mutation path. The endpoint has
+   never been hit at the full breadth of production query patterns;
+   the divergences that would bite first under real load haven't had
+   a chance to manifest.
+
+So the answer to "why does weka work at all?" is **a combination of
+SDL-vs-wire indirection, fragment-based queries that hide type-name
+drift, untested code paths, GraphQL's permissive null semantics, and
+a read-only deploy**. None of these is a guarantee of correctness —
+they're the reasons the divergence has been able to stay invisible.
+
+### The legacy schema is five years old
+
+Many of the conventions in the legacy schema reflect their era:
+
+- Built ~2020 against Graphene 2.x and Graphene-Django defaults.
+- Relay 1 was the de facto Relay spec at the time — `clientMutationId`
+  was required on every mutation.
+- Custom typed scalars (`DateTime`, `JSONString`) were the common
+  workaround for Python-side serialisation.
+- `auto_camel_case=False` was used to match the Python codebase style.
+- Root types named `QueryRoot` / `MutationRoot` — a Graphene
+  convention that was never standard but was common in 2018-2020.
+
+By 2026, the GraphQL community has moved on from some of these:
+
+- **Relay 2** dropped `clientMutationId`. Modern Apollo Client / urql /
+  Relay 2 clients don't need it.
+- **camelCase** is the overwhelming community standard for field
+  names. snake_case is valid but uncommon in public APIs.
+- **The Relay Connection spec** is normative camelCase for PageInfo
+  fields (`hasNextPage`, `endCursor`, etc.). Strawberry follows the
+  spec; legacy diverged via its `auto_camel_case=False`.
+- **Plain `Query` / `Mutation`** root type names are the convention
+  in essentially every public GraphQL API.
+- **Typed scalars** like `DateTime` are still good and still common —
+  this is one place legacy got it right and the POC regressed (using
+  plain `String`).
+
+The legacy schema is not "wrong" — it reflects the standards of its
+time, and those standards were defensible. But the gap between
+2020 standards and 2026 standards means a clean port has to make
+explicit choices.
+
+## Decision
+
+Three principles for how the POC schema relates to the legacy one:
+
+### Principle 1: Wire-format compatibility is the hard contract
+
+**The JSON payload returned for a given query must be identical
+between legacy and POC for the same data.**
+
+This is the line that "drop-in replacement" actually means. SDL
+differences that don't change the wire format are tolerated; SDL
+differences that do change it are bugs.
+
+In practice this means:
+
+- **Field names match.** `pageInfo.hasNextPage` (camelCase) returned
+  by legacy must be available as `pageInfo.hasNextPage` from POC,
+  even though POC's default scheme is snake_case.
+- **Scalar wire format matches.** `created` returned as
+  `"2024-01-01T00:00:00Z"` in legacy must be the same string in POC,
+  whether the SDL says `String` or `DateTime`.
+- **List semantics match.** `[KeyValuePair]` vs `[KeyValuePair!]`
+  return the same JSON; tolerated as SDL-only.
+- **Required-input mutation fields match.** If legacy accepts
+  `clientMutationId: String` in its mutation inputs, POC must too —
+  even if the field is ignored downstream.
+
+### Principle 2: Treat the legacy schema as the spec, but selectively modernise where the community has hardened
+
+Where 2020 and 2026 conventions disagree:
+
+- If the **modern community standard has hardened** (Relay spec on
+  PageInfo; `Query` / `Mutation` as root names; non-null modifiers
+  where appropriate), POC adopts the modern form.
+- If the legacy choice is **still acceptable** and switching is
+  invisible to clients (snake_case field names; custom scalars), we
+  keep the legacy convention.
+- If POC has **regressed** vs legacy on a still-good convention
+  (typed scalars `DateTime`, `JSONString`), we restore the legacy
+  form.
+
+### Principle 3: Backwards compatibility via GraphQL's `@deprecated` directive
+
+Where modern community standard differs from legacy in a
+wire-affecting way (PageInfo field naming, `clientMutationId`), expose
+**both** names — modern as preferred, legacy as `@deprecated` alias.
+
+Strawberry supports this natively via
+`strawberry.field(deprecation_reason="...")`. Multiple fields can point
+at the same resolver. Clients can introspect the deprecated marker
+and tooling (GraphiQL, Apollo Studio autocomplete) surface it as a
+warning, but existing queries keep working.
+
+This pattern is how mature GraphQL APIs (GitHub, Shopify, Stripe)
+evolve without breaking clients. After a measurement window (12+
+months of query-log evidence), deprecated fields can be removed.
+
+## Specific decisions
+
+| Item | Legacy | Community 2026 | Decision |
+|---|---|---|---|
+| `PageInfo` field naming | snake_case (`has_next_page`) | **camelCase** (Relay spec normative) | **Both** — camelCase preferred, snake_case deprecated alias |
+| `clientMutationId` in mutations | Required (Relay 1) | Dropped (Relay 2) | **Both** — input accepts, output echoes, marked deprecated |
+| `DateTime` scalar | Yes | Yes (Strawberry has it) | **Restore in POC** — was wrongly downgraded to `String` |
+| `JSONString` scalar | Yes | Yes; `JSON` is alternative | **Restore in POC** — same regression |
+| Root type names | `QueryRoot`/`MutationRoot` | `Query`/`Mutation` | **Modernise** — clients don't reference roots by name; zero impact |
+| snake_case field names everywhere | snake_case | camelCase preferred | **Keep snake_case** — weka/runzi are Python clients; switching is a separate strategic call |
+| Inner nullability `[X]` vs `[X!]` | Permissive nullable | Strict non-null where known | **Modernise** — wire-equivalent, no client impact |
+| Connection type naming (e.g. `FileRelationConnection`) | Mixed | No standard | **Align with legacy** for parity — `FileRelationConnection` not the auto-generated POC name |
+| `BigInt` scalar | Yes | Common as custom scalar | **Keep** — added to POC for `file_size` >2GB |
+
+## Migration path
+
+### Phase 1 — Wire-breaking fixes (this iteration)
+
+For each item where the SDL difference produces different wire
+output:
+
+1. Add the legacy form as a deprecated alias alongside the modern
+   form (PageInfo, mutation `clientMutationId`).
+2. Restore the typed scalars (`DateTime`, `JSONString`).
+3. Pick connection type names that match legacy.
+
+### Phase 2 — Codegen alignment (this iteration)
+
+Wire-format is fine but typed-client codegen breaks:
+
+1. Rename root types to `QueryRoot` / `MutationRoot`.
+2. Rename mutation payloads to match legacy (`CreateAutomationTask`
+   not `CreateAutomationTaskPayload`).
+3. Ensure auto-generated `XxxConnection` / `XxxEdge` types align.
+
+### Phase 3 — Monitor, deprecate, sunset (12+ months out)
+
+1. Add Strawberry resolver instrumentation that logs deprecated-field
+   usage to CloudWatch / metrics.
+2. Annual review: deprecated fields with zero usage in the past 12
+   months can be removed in a major version bump.
+3. Communicate sunset timeline to client teams.
+
+## Consequences
+
+### Positive
+
+- The drop-in promise is upheld for existing clients. weka and runzi
+  continue working without code changes — even with the bugs that
+  were silently bypassing the issue (Principle 1 makes wire format
+  the contract, not SDL parity).
+- New clients adopting `/graphql-v2` see modern conventions in
+  autocomplete and codegen. They don't carry forward 2020-era debt.
+- The deprecation pattern gives us a **measured exit path** — we can
+  remove legacy fields when we have query-log evidence nobody uses
+  them, not based on a guess.
+- The schema parity diff tool (`tools/schema_parity.py`) becomes a
+  durable CI safety net. Once allowlisted for the intentional
+  divergences listed here, every future schema change either fits
+  the allowlist or fails the build.
+
+### Negative
+
+- Maintenance cost from carrying deprecated aliases — every `PageInfo`
+  field exists twice; every mutation has a `clientMutationId` it
+  doesn't actually use. Mitigated by the documented sunset policy
+  (Phase 3) but real until then.
+- The schema is **slightly more complex** to read — two ways to
+  spell the same field. New contributors need to understand which is
+  preferred. Mitigated by inline `deprecation_reason` strings.
+- **Decision fatigue** — every future schema-affecting change now has
+  to consider both forms. We need to make the deprecation pattern
+  easy to apply consistently (helper decorators, lint rules) or it
+  will rot.
+
+### Neutral
+
+- This ADR doesn't take a position on the **global snake_case vs
+  camelCase migration**. That's a separate decision worth its own
+  ADR if/when client teams want to undertake it. PageInfo is treated
+  as a special case because the Relay spec is normative for it; the
+  rest of the schema stays snake_case.
+- This ADR doesn't address **schema namespacing for federation** or
+  **schema versioning** more broadly. If the API ever moves to
+  GraphQL Federation, this ADR's deprecation policy will need to be
+  reconciled with the federation supergraph composition rules.
+
+## Lessons captured
+
+The "why does weka work at all?" analysis is the most important part
+of this ADR for future maintainers. The five reasons listed there
+explain how serious schema drift can hide in plain sight, and they
+should be considered every time someone proposes "we don't need to
+worry about that divergence":
+
+- "It's just an SDL difference" doesn't mean it's invisible — the
+  divergence has been silently producing null fields in production.
+- "weka hasn't complained" doesn't mean weka can't hit the broken
+  path — it means it hasn't yet.
+- "It's read-only and well-tested" applies to the deploys we've made,
+  not to the schema. Schema bugs surface when real production traffic
+  hits unexpected code paths.
+
+The schema parity diff is the systematic version of this analysis.
+We should run it before every cutover-affecting deploy, and we
+should resist the urge to allowlist new divergences without first
+checking they're truly wire-equivalent or covered by a deprecation
+alias.
+
+## Related decisions
+
+- (Future) ADR-0002: Custom scalar policy — naming, behaviour, and
+  on-disk representation for `DateTime`, `JSONString`, `BigInt`, and
+  any future scalars.
+- (Future) ADR-0003: Schema interface hierarchy — `Thing` and
+  `AutomationTaskInterface` adoption in POC.
+- (Future) ADR-0004: Deprecation logging and sunset policy — how we
+  measure deprecated-field usage and when we remove.
+- (Future) ADR-0005: snake_case vs camelCase for client-facing
+  fields — strategic call on whether to undertake the migration.

--- a/docs/adrs/ADR-001-graphql-schema-evolution-strategy.md
+++ b/docs/adrs/ADR-001-graphql-schema-evolution-strategy.md
@@ -276,12 +276,18 @@ alias.
 
 ## Related decisions
 
-- (Future) ADR-002: Custom scalar policy — naming, behaviour, and
-  on-disk representation for `DateTime`, `JSONString`, `BigInt`, and
-  any future scalars.
-- (Future) ADR-003: Schema interface hierarchy — `Thing` and
-  `AutomationTaskInterface` adoption in POC.
+- [ADR-002](ADR-002-schema-interface-hierarchy-and-input-naming.md):
+  Schema interface hierarchy and input naming conventions — covers
+  the remaining divergences after Phase 1+2 (`Thing` /
+  `AutomationTaskInterface` adoption, input type naming style,
+  auto-generated Edge types).
+- (Future) ADR-003: Custom scalar policy — naming, behaviour, and
+  on-disk representation conventions for `DateTime`, `JSONString`,
+  `BigInt`, and any future scalars (the specific decisions in this
+  ADR cover the existing scalars; an ADR is owed when we add the next).
 - (Future) ADR-004: Deprecation logging and sunset policy — how we
-  measure deprecated-field usage and when we remove.
+  measure deprecated-field usage and when we remove (Phase 3 of
+  this ADR's migration path).
 - (Future) ADR-005: snake_case vs camelCase for client-facing
-  fields — strategic call on whether to undertake the migration.
+  fields — strategic call on whether to undertake the broader
+  migration.

--- a/docs/adrs/ADR-001-graphql-schema-evolution-strategy.md
+++ b/docs/adrs/ADR-001-graphql-schema-evolution-strategy.md
@@ -1,4 +1,4 @@
-# ADR-0001: GraphQL Schema Evolution Strategy — Legacy Parity, Modern Defaults, Deprecation Aliases
+# ADR-001: GraphQL Schema Evolution Strategy — Legacy Parity, Modern Defaults, Deprecation Aliases
 
 ## Status
 
@@ -276,12 +276,12 @@ alias.
 
 ## Related decisions
 
-- (Future) ADR-0002: Custom scalar policy — naming, behaviour, and
+- (Future) ADR-002: Custom scalar policy — naming, behaviour, and
   on-disk representation for `DateTime`, `JSONString`, `BigInt`, and
   any future scalars.
-- (Future) ADR-0003: Schema interface hierarchy — `Thing` and
+- (Future) ADR-003: Schema interface hierarchy — `Thing` and
   `AutomationTaskInterface` adoption in POC.
-- (Future) ADR-0004: Deprecation logging and sunset policy — how we
+- (Future) ADR-004: Deprecation logging and sunset policy — how we
   measure deprecated-field usage and when we remove.
-- (Future) ADR-0005: snake_case vs camelCase for client-facing
+- (Future) ADR-005: snake_case vs camelCase for client-facing
   fields — strategic call on whether to undertake the migration.

--- a/docs/adrs/ADR-002-schema-interface-hierarchy-and-input-naming.md
+++ b/docs/adrs/ADR-002-schema-interface-hierarchy-and-input-naming.md
@@ -1,0 +1,332 @@
+# ADR-002: Schema Interface Hierarchy and Input Naming Conventions
+
+## Status
+
+Proposed.
+
+## Context
+
+ADR-001 Phase 1+2 closed the wire-breaking and codegen-breaking
+divergences between the legacy Graphene schema and the Strawberry
+POC. The schema parity diff (`tools/schema_parity.py`) dropped from
+657 lines / 257 field mismatches at the spike baseline to ~280 field
+mismatches after Phase 1+2. The remaining divergences cluster into
+four distinct categories:
+
+| Category | Examples | Wire-impacting? |
+|---|---|---|
+| 1. Missing interfaces | `Thing`, `AutomationTaskInterface` | **Yes** — fragment queries break |
+| 2. Input type naming | `AutomationTaskInput` (legacy) vs `CreateAutomationTaskInput` (POC) | No — codegen only |
+| 3. Auto-generated Edge types | `GeneralTaskEdge`, `RuptureSetEdge`, etc. one per node | No — wire-equivalent |
+| 4. Custom Connection types | `FileRelationsConnection` (POC) vs `FileRelationConnection` (legacy) | No — already decided in ADR-001 |
+
+Each category needs its own decision: fix, alias, accept as
+divergence, or document for a separate ADR. ADR-001's principles
+(wire compat is the contract; modernise where standard has hardened;
+use `@deprecated` to bridge) apply directly to (1) and (2), and
+inform the accept/defer calls for (3) and (4).
+
+### The four categories in detail
+
+**1. Missing interfaces** — Legacy declares `Thing` and
+`AutomationTaskInterface` and has concrete types implement them.
+weka uses both via fragment queries:
+
+```graphql
+... on Thing { children { edges { node { ... } } } }
+... on AutomationTaskInterface { parents { edges { ... } } }
+```
+
+POC has neither. The concrete types (`GeneralTask`, `AutomationTask`,
+etc.) already declare equivalent fields directly — the structural
+information is there, just not the interface declaration that lets
+fragment queries resolve. The first `...AutomationTaskInterface`
+query against the POC fails with `Cannot spread fragment AutomationTaskInterface
+on AutomationTask` or similar at GraphQL-validation time. **This is a
+real wire-level break for any client using the fragment-via-interface
+pattern.**
+
+**2. Input type naming** — Legacy uses
+`<TypeName>Input` (for create) and `<TypeName>UpdateInput` (for update):
+
+```
+AutomationTaskInput          (legacy create input)
+AutomationTaskUpdateInput    (legacy update input)
+```
+
+POC uses Strawberry's modern convention:
+
+```
+CreateAutomationTaskInput
+UpdateAutomationTaskInput
+```
+
+Both work. Wire JSON is identical (`{ "input": { ... } }`). The
+difference shows up only in typed-client codegen: sgqlc emits one
+file per input type, and the file name changes.
+
+**3. Auto-generated Edge types** — Strawberry's relay layer emits
+one `XxxEdge` type per concrete node type:
+
+```
+GeneralTaskEdge
+RuptureSetEdge
+ToshiFileEdge
+... and so on for every node type
+```
+
+Legacy used a smaller set of shared connection/edge types:
+
+```
+FileEdge        (used by every File-typed connection)
+ThingEdge       (used by every Thing-typed connection)
+```
+
+Wire JSON is identical — clients see `{ edges: [{ node: {...} }] }`
+either way. The SDL difference is purely structural and affects only
+codegen tooling that generates one wrapper class per Edge type.
+
+**4. Custom Connection naming** — already decided in ADR-001
+(`FileRelationsConnection` vs legacy `FileRelationConnection`,
+`TaskRelationsConnection` vs `TaskTaskRelationConnection`). ADR-001's
+position: accept the small POC-side rename rather than fight
+Strawberry's auto-generation collision. Re-flagged here only to
+explain why these names appear in the diff without further action.
+
+## Decision
+
+### Principle (carried forward from ADR-001)
+
+Wire compat is the contract. SDL differences that don't change the
+JSON over the wire are tolerated; SDL differences that change runtime
+behaviour are fixed.
+
+### Per-category decisions
+
+#### Category 1 — Missing interfaces: **Adopt both**
+
+Both `Thing` and `AutomationTaskInterface` get added to the POC.
+This is a wire-impacting gap and the work is well-scoped because
+the concrete types already declare equivalent fields.
+
+#### Category 2 — Input type naming: **Accept the divergence**
+
+Keep the modern Strawberry-style `CreateXxxInput` /
+`UpdateXxxInput` naming. Wire format is identical; only codegen
+breaks. The ADR-001 principle "modernise where the community has
+hardened" applies: the `Create/Update`-prefixed convention is the
+norm in 2026 Strawberry / Apollo / Nexus schemas.
+
+Clients regenerating typed code against `/graphql-v2` will see
+different file names. This is documented behaviour, not a bug.
+
+#### Category 3 — Auto-generated Edge types: **Accept the divergence**
+
+Strawberry's relay layer generates one Edge per node type. Trying
+to consolidate them into shared `ThingEdge`/`FileEdge` types
+would require building a custom relay layer — non-trivial work
+for codegen-only parity. Wire is identical.
+
+#### Category 4 — Custom Connection naming: **Already resolved**
+
+Per ADR-001. No new action.
+
+## Specific decisions
+
+| Item | Legacy | POC | Decision |
+|---|---|---|---|
+| `Thing` interface | Declared, implemented by 7 concrete types | Missing | **Adopt** — declare in POC, attach to each concrete type |
+| `AutomationTaskInterface` | Declared, implemented by 3 concrete types | Missing | **Adopt** — same pattern |
+| Input naming `<Type>Input` | snake-Graphene convention | `Create<Type>Input` (Strawberry-modern) | **Accept divergence** — wire-equivalent, modern preferred |
+| Edge types per node | Shared `FileEdge` / `ThingEdge` etc. | Per-type `<Node>Edge` | **Accept divergence** — wire-equivalent, structural cost too high |
+| `FileRelationsConnection` etc. | `FileRelationConnection` | Already POC-named | **Already resolved** (ADR-001) |
+
+## Implementation plan for the interface adoptions
+
+### `Thing` interface
+
+**Fields (per legacy SDL):**
+
+```graphql
+interface Thing {
+  created: DateTime
+  files(before: String, after: String, first: Int, last: Int): FileRelationsConnection
+  parents(before: String, after: String, first: Int, last: Int): TaskRelationsConnection
+  children(before: String, after: String, first: Int, last: Int): TaskRelationsConnection
+}
+```
+
+(Connection field types use the POC-side naming
+`FileRelationsConnection` / `TaskRelationsConnection`, since
+ADR-001 ratified those. Clients querying via `... on Thing { ... }`
+don't reference the connection type name in their query — they
+spell `files { edges { ... } }`.)
+
+**Concrete types that implement `Thing` in legacy:**
+
+- `GeneralTask`
+- `AutomationTask`
+- `RuptureGenerationTask`
+- `OpenquakeHazardTask`
+- `OpenquakeHazardSolution`
+- `OpenquakeHazardConfig`
+- `StrongMotionStation`
+
+Each currently declares the four fields independently in the POC.
+Implementation:
+
+```python
+# models/thing.py (new)
+@strawberry.interface
+class Thing:
+    created: DateTime | None = None
+    # connection fields declared via @relay.connection on each
+    # concrete type — interface itself doesn't auto-resolve them
+```
+
+For Strawberry to surface `... on Thing { files { ... } }` queries,
+the interface must declare the field signatures matching the concrete
+types. Implementation will likely follow the same pattern as
+`InversionSolutionInterface` (added earlier in this iteration):
+declare field signatures on the interface, concrete types resolve.
+
+The pattern was non-trivial when we added `InversionSolutionInterface`
+— specifically the relay connection field collisions and the duplicate
+edge type generation. Same gotchas apply here. Estimated work: ~1 day
+of careful Strawberry plumbing + tests.
+
+### `AutomationTaskInterface`
+
+**Fields (per legacy SDL):**
+
+```graphql
+interface AutomationTaskInterface {
+  result: EventResult
+  state: EventState
+  created: DateTime
+  duration: Float
+  general_task_id: ID
+  task_type: TaskSubType
+  parents(...): TaskRelationsConnection
+  arguments: [KeyValuePair]
+  environment: [KeyValuePair]
+  metrics: [KeyValuePair]
+}
+```
+
+**Concrete types:**
+- `AutomationTask`
+- `RuptureGenerationTask`
+- `OpenquakeHazardTask`
+
+Same implementation pattern. Smaller scope because only 3 concrete
+types vs 7 for `Thing`.
+
+### Test plan
+
+Per interface:
+
+- Schema-level: `schema.as_str()` contains the `interface <Name>` block.
+- Introspection: `__type(name: "Thing")` returns the interface kind.
+- Fragment-resolution: `... on Thing { children { ... } }` against a
+  concrete `GeneralTask` resolves the children field correctly.
+- `nodes(id_in: [...]) { ... on AutomationTaskInterface { parents { ... } } }`
+  weka-style traversal works end-to-end.
+- Parity diff: `Thing` and `AutomationTaskInterface` disappear from
+  the "types only in legacy" list; the "interfaces only in legacy"
+  field mismatches for each concrete type also clear.
+
+### Phasing
+
+Both interfaces can land in a single PR (interface declaration +
+attach to concrete types + tests). Estimated ~150-300 lines plus
+tests.
+
+## Consequences
+
+### Positive
+
+- weka's `... on Thing { ... }` and `... on AutomationTaskInterface { ... }`
+  fragment queries work against `/graphql-v2`. This is the single
+  largest remaining wire-breaking divergence after Phase 1+2.
+- Parity diff drops further — these two interfaces and the field
+  mismatches they cause across 7+3 concrete types are all closed
+  with one set of changes.
+- The legacy `test_nodes_bugfix_220` weka pattern (deep traversal via
+  `AutomationTaskInterface.parents`) becomes reproducible against the
+  POC, completing the work hinted at in COVERAGE_GAPS.md gap 3.
+
+### Negative
+
+- The interface declarations must declare their connection fields
+  with matching arg signatures and types. Strawberry's relay layer
+  has known sharp edges when interfaces declare relay connections
+  (we hit some of these adding `InversionSolutionInterface`). Risk
+  of additional plumbing surfacing during implementation.
+- Each concrete type gains an `implements Thing` (and possibly
+  `implements AutomationTaskInterface`) declaration. That's
+  mechanical but touches 7 files.
+- Auto-generated Edge type count stays high (Strawberry per-node).
+  Documented divergence; no fix.
+
+### Neutral
+
+- The input naming and Edge type categories are explicitly accepted.
+  This is the ADR doing its job — naming a divergence as known and
+  intentional rather than letting it generate continuous review
+  noise.
+
+## Why the Edge / Input divergences are NOT worth fighting
+
+It's tempting to also align Edge types and input names for full
+"drop-in cosmetic parity". Why we don't:
+
+- **Cost**: each requires either a custom Strawberry layer
+  (Edge consolidation) or systematic Python-class renames + name=
+  decorators on every Input class (input renaming). Tens to hundreds
+  of lines plus testing, plus ongoing maintenance overhead.
+- **Benefit**: zero wire-format change. The only beneficiaries are
+  client codegen pipelines that were already breaking on the
+  Graphene→Strawberry transition for *other* reasons (custom scalar
+  changes, root type names, etc.).
+- **Risk**: maintainability — adding renames just to match legacy
+  inconsistencies (recall ADR-001's payload-naming surprise where
+  legacy mixed `Create*Payload` and `Create*` based on author whim)
+  imports legacy debt into POC.
+
+The cleaner stance is to document these as accepted divergences in
+this ADR and let consumers of the SDL know they're intentional.
+
+## Lessons captured (companion to ADR-001's)
+
+Two patterns from the Phase 1+2 implementation work that are worth
+preserving for future schema work:
+
+1. **Don't generalise from one type to the whole schema.** Phase 2's
+   payload rename script initially assumed "remove the Payload suffix
+   from all `Create*Payload` types" — turned out legacy was internally
+   inconsistent. The correct fix needed a per-type mapping derived
+   directly from the legacy SDL. Schema parity is full of legacy
+   inconsistencies; the only safe pattern is to map type-by-type.
+
+2. **Wire-equivalence is not SDL-equivalence.** Many of the most-noisy
+   divergences (`[X]` vs `[X!]`, `pageInfo` vs `page_info`, edge
+   nullability) produce identical JSON on the wire for the same data.
+   The schema parity tool surfaces all SDL differences; deciding
+   which are actually wire-breaking requires human judgement. This
+   ADR's Category 1 (interfaces) vs Categories 2-4 (SDL cosmetics)
+   illustrates the distinction.
+
+## Related decisions
+
+- [ADR-001](ADR-001-graphql-schema-evolution-strategy.md) — the
+  framework this ADR operates within (wire compat as contract,
+  modernise where standard has hardened, `@deprecated` to bridge).
+- (Future) ADR-003: Custom scalar policy — naming and on-disk
+  representation conventions for `DateTime`, `JSONString`, `BigInt`,
+  and any future scalars.
+- (Future) ADR-004: Deprecation logging and sunset policy — how we
+  measure deprecated-field usage and when we remove (ADR-001 Phase 3).
+- (Future) ADR-005: snake_case vs camelCase for client-facing
+  fields — strategic call on whether to undertake the broader
+  migration.

--- a/docs/adrs/ADR-002-schema-interface-hierarchy-and-input-naming.md
+++ b/docs/adrs/ADR-002-schema-interface-hierarchy-and-input-naming.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Proposed.
+Accepted. Implemented in PR #308 (interface adoption) and PR #309
+(additional client-divergence fixes surfaced by the post-implementation
+audit; see "Post-implementation audit" below).
 
 ## Context
 
@@ -30,21 +32,36 @@ inform the accept/defer calls for (3) and (4).
 
 **1. Missing interfaces** — Legacy declares `Thing` and
 `AutomationTaskInterface` and has concrete types implement them.
-weka uses both via fragment queries:
+At drafting time we assumed both were wire-impacting. A subsequent
+client audit (see "Post-implementation audit" below) refined the
+picture:
 
-```graphql
-... on Thing { children { edges { node { ... } } } }
-... on AutomationTaskInterface { parents { edges { ... } } }
-```
+- `AutomationTaskInterface` is **heavily used by weka**:
+  `views/GeneralTask/InversionSolutionDiagnosticContainer.tsx`,
+  `views/GeneralTask/tabs/GeneralTaskChildrenTab.tsx`,
+  `views/AutomationTask/AutomationTaskPage.tsx`,
+  `views/Favourites/Favourites.tsx`, plus generated Relay codegen
+  files for each. Pattern:
+  ```graphql
+  ... on AutomationTaskInterface { state result task_type
+    arguments { k v }
+    parents { edges { node { parent { ... on GeneralTask { id title } } } } }
+  }
+  ```
+  Without the interface, these queries fail GraphQL validation.
+  **Real wire-level break.**
+
+- `Thing` is **not used by any inspected client** (weka, nzshm-runzi,
+  nzshm-model). Clients reach for concrete fragments instead
+  (`... on GeneralTask`, `... on AutomationTask`). Adopting `Thing`
+  in the POC remains defensive SDL-parity work rather than a
+  load-bearing fix — useful for future-proofing and for the parity
+  diff signal-to-noise, but no observed client query depends on it.
 
 POC has neither. The concrete types (`GeneralTask`, `AutomationTask`,
 etc.) already declare equivalent fields directly — the structural
 information is there, just not the interface declaration that lets
-fragment queries resolve. The first `...AutomationTaskInterface`
-query against the POC fails with `Cannot spread fragment AutomationTaskInterface
-on AutomationTask` or similar at GraphQL-validation time. **This is a
-real wire-level break for any client using the fragment-via-interface
-pattern.**
+fragment queries resolve.
 
 **2. Input type naming** — Legacy uses
 `<TypeName>Input` (for create) and `<TypeName>UpdateInput` (for update):
@@ -106,8 +123,11 @@ behaviour are fixed.
 #### Category 1 — Missing interfaces: **Adopt both**
 
 Both `Thing` and `AutomationTaskInterface` get added to the POC.
-This is a wire-impacting gap and the work is well-scoped because
-the concrete types already declare equivalent fields.
+`AutomationTaskInterface` is wire-impacting and confirmed
+load-bearing for weka; `Thing` is defensive parity (no observed
+client query, but cheap to add alongside and keeps the parity diff
+clean). The work is well-scoped because the concrete types already
+declare equivalent fields.
 
 #### Category 2 — Input type naming: **Accept the divergence**
 
@@ -316,6 +336,55 @@ preserving for future schema work:
    which are actually wire-breaking requires human judgement. This
    ADR's Category 1 (interfaces) vs Categories 2-4 (SDL cosmetics)
    illustrates the distinction.
+
+## Post-implementation audit (client divergence)
+
+After PR #308 landed the interface adoption, we audited real
+production GraphQL queries across three clients to verify the
+remaining "POC-only types" in the parity diff were genuinely
+acceptable:
+
+- `weka` (UI) — `../UI/weka/src/`
+- `nzshm-runzi` (Python automation) — `../MISC/nzshm-runzi`
+- `nzshm-model` (Python library) — `../LIB/nzshm-model`
+
+The audit confirmed Categories 2–4 are safe to accept, but surfaced
+**four additional wire-breaking divergences** that ADR-002's original
+analysis missed. All four are fixed in PR #309.
+
+| # | Divergence | Client evidence | Fix |
+|---|---|---|---|
+| A | POC SDL type `ToshiFile` (POC-only rename of legacy `File`) | weka × 4 source files (`... on File`), nzshm-model × 1 | Revert SDL name to `File`; keep Python class as `ToshiFile` via `@strawberry.type(name="File")` |
+| B | POC SDL type `NodeFilterPayload` (legacy is `NodeFilter`) | weka generated Relay codegen × 2 views (`concreteType: "NodeFilter"`) | Rename SDL type via `@strawberry.type(name="NodeFilter")` decorator |
+| C | POC `Table.column_types: [String]` vs legacy `[RowItemType]` | weka × 1, runzi × 1 (`$column_types: [RowItemType]!` in mutation variables) | Add `RowItemType` enum (`integer`/`double`/`string`/`boolean`) and use on both `Table.column_types` and `CreateTableInput.column_types` |
+| D | POC `AutomationTask` / `RuptureGenerationTask` / `OpenquakeHazardTask` missing `inversion_solution: InversionSolutionUnion` field | weka `AutomationTaskPage`, `GeneralTaskChildrenTab` | Add `InversionSolutionUnion` and a resolver that picks the `WRITE`-related `InversionSolution` subtype from `files_raw` |
+
+### What the audit confirmed (no action)
+
+- **`InversionSolutionUnion` / `PredecessorUnion`** — no observed
+  client query exercises these union types other than via the
+  concrete `... on InversionSolution { ... }` fragments. The union
+  declarations exist in the POC and are wire-equivalent; no client
+  breaks from the SDL difference.
+- **Category 2 (input naming)** — no observed query references the
+  input type name directly. Wire format identical. Decision stands.
+- **Category 3 (auto-generated Edge types)** — no observed query
+  references an Edge type by name. Wire format identical. Decision
+  stands.
+
+### Lesson added
+
+3. **An ADR drafted from a parity-diff sample needs an audit
+   against real client queries before close-out.** ADR-002's
+   original Category 1 framing assumed both `Thing` and
+   `AutomationTaskInterface` were equally wire-impacting because
+   both appeared in the legacy SDL. The client audit refined that:
+   `AutomationTaskInterface` is load-bearing; `Thing` is defensive.
+   Worse, the audit also surfaced **four breaking divergences this
+   ADR didn't catch at all** — they were lurking in the
+   "POC-only types" half of the parity diff that we'd partially
+   characterised as cosmetic. For future schema ADRs, run the
+   client-query audit *before* drafting decisions, not after.
 
 ## Related decisions
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -81,3 +81,4 @@ leave the file in place).
 | # | Title | Status |
 |---|---|---|
 | [ADR-001](ADR-001-graphql-schema-evolution-strategy.md) | GraphQL Schema Evolution Strategy: Legacy Parity, Modern Defaults, Deprecation Aliases | Proposed |
+| [ADR-002](ADR-002-schema-interface-hierarchy-and-input-naming.md) | Schema Interface Hierarchy and Input Naming Conventions | Proposed |

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -35,10 +35,10 @@ template](https://github.com/joelparkerhenderson/architecture-decision-record/bl
 extended for our project style:
 
 ```
-# ADR-NNNN: <Short title in title case>
+# ADR-NNN: <Short title in title case>
 
 ## Status
-Proposed | Accepted | Superseded by ADR-XXXX | Deprecated
+Proposed | Accepted | Superseded by ADR-NNN | Deprecated
 
 ## Context
 The problem and the relevant constraints. Include enough domain
@@ -59,16 +59,25 @@ Cross-links to other ADRs.
 
 When a decision touches multiple distinct areas (e.g. naming,
 scalars, deprecation policy), feel free to add a `## Specific
-decisions` section with a table — see `0001-graphql-schema-evolution.md`.
+decisions` section with a table — see
+`ADR-001-graphql-schema-evolution-strategy.md`.
 
-## Numbering
+## Numbering and filename
 
-Sequential, four-digit, zero-padded: `0001`, `0002`, etc. Once
-assigned, the number never changes — even if an ADR is superseded
-(mark it `Superseded by ADR-XXXX` and leave the file in place).
+Sequential, three-digit, zero-padded. Filename pattern:
+
+```
+ADR-NNN-{descriptive-name-in-kebab-case}.md
+```
+
+For example: `ADR-001-graphql-schema-evolution-strategy.md`.
+
+Once a number is assigned it never changes — even if an ADR is
+superseded (mark it `Superseded by ADR-NNN` in the Status section and
+leave the file in place).
 
 ## Index
 
 | # | Title | Status |
 |---|---|---|
-| [0001](0001-graphql-schema-evolution-strategy.md) | GraphQL Schema Evolution Strategy: Legacy Parity, Modern Defaults, Deprecation Aliases | Proposed |
+| [ADR-001](ADR-001-graphql-schema-evolution-strategy.md) | GraphQL Schema Evolution Strategy: Legacy Parity, Modern Defaults, Deprecation Aliases | Proposed |

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,74 @@
+# Architecture Decision Records
+
+This directory captures significant architectural decisions for the
+`nshm-toshi-api` project — the *why* behind structural choices that
+are expensive to reverse and that future maintainers (including future
+us) will otherwise have to reverse-engineer.
+
+## When to write an ADR
+
+Write an ADR when the choice:
+
+1. Affects the **API contract** seen by clients (weka, runzi, downstream
+   tooling).
+2. Imposes a **cross-cutting constraint** that future contributors need
+   to be aware of even if they don't touch the originating code.
+3. Required **non-trivial analysis** to land on, and the analysis itself
+   is the durable artifact (not just the decision).
+4. Would be hard to **reverse without a deprecation cycle**.
+
+Examples that warrant an ADR:
+- "Why do we have a custom `BigInt` scalar instead of `Int`?"
+- "Why do mutation payloads include a deprecated `clientMutationId`?"
+- "Why is the Strawberry POC scoped under `spike/` rather than top-level?"
+
+Examples that don't:
+- Small refactors, bugfixes, dependency upgrades.
+- "Why did we name this function `_try_enum`?" (live with the code.)
+- Strategy docs that are explorations rather than decisions (those go
+  in `docs/` directly, see `ALTERNATE_STACK_QUESTIONS.md`).
+
+## Format
+
+ADRs follow a slight adaptation of [Michael Nygard's
+template](https://github.com/joelparkerhenderson/architecture-decision-record/blob/main/locales/en/templates/decision-record-template-by-michael-nygard/index.md),
+extended for our project style:
+
+```
+# ADR-NNNN: <Short title in title case>
+
+## Status
+Proposed | Accepted | Superseded by ADR-XXXX | Deprecated
+
+## Context
+The problem and the relevant constraints. Include enough domain
+context that a new contributor 12 months from now will understand
+the situation without spelunking commits.
+
+## Decision
+The choice we made. State it clearly enough that future readers can
+tell whether their case falls inside or outside the decision's scope.
+
+## Consequences
+The positives and negatives, including known trade-offs. List items
+this decision blocks, enables, or makes harder.
+
+## Related decisions
+Cross-links to other ADRs.
+```
+
+When a decision touches multiple distinct areas (e.g. naming,
+scalars, deprecation policy), feel free to add a `## Specific
+decisions` section with a table — see `0001-graphql-schema-evolution.md`.
+
+## Numbering
+
+Sequential, four-digit, zero-padded: `0001`, `0002`, etc. Once
+assigned, the number never changes — even if an ADR is superseded
+(mark it `Superseded by ADR-XXXX` and leave the file in place).
+
+## Index
+
+| # | Title | Status |
+|---|---|---|
+| [0001](0001-graphql-schema-evolution-strategy.md) | GraphQL Schema Evolution Strategy: Legacy Parity, Modern Defaults, Deprecation Aliases | Proposed |

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -81,4 +81,4 @@ leave the file in place).
 | # | Title | Status |
 |---|---|---|
 | [ADR-001](ADR-001-graphql-schema-evolution-strategy.md) | GraphQL Schema Evolution Strategy: Legacy Parity, Modern Defaults, Deprecation Aliases | Proposed |
-| [ADR-002](ADR-002-schema-interface-hierarchy-and-input-naming.md) | Schema Interface Hierarchy and Input Naming Conventions | Proposed |
+| [ADR-002](ADR-002-schema-interface-hierarchy-and-input-naming.md) | Schema Interface Hierarchy and Input Naming Conventions | Accepted |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ license = "AGPL-3.0-or-later"
 dependencies = [
     "backoff",
     "boto3>=1.24.57",
+    "mangum>=0.17",
+    "strawberry-graphql[fastapi]>=0.243.0",
     "elasticsearch>=9",
     "elasticsearch7-compatible",
     "flask>=3.0.3",

--- a/serverless.yml
+++ b/serverless.yml
@@ -257,6 +257,15 @@ functions:
       DB_READ_ONLY: "1"
       DEPLOYMENT_STAGE: ${self:custom.stage}
       GRAPHQL_PATH: /graphql-v2
+      # REGION + S3_BUCKET_NAME inherit from provider.environment but we set
+      # S3_BUCKET_NAME explicitly so the dependency for _from_s3 / S3 fallback
+      # paths in data/dynamo.py + data/s3.py is visible at function scope.
+      S3_BUCKET_NAME: ${self:custom.s3_bucket}
+      # Watermark for legacy_object_identities — IDs below this are S3-only.
+      # Tracks custom.first_dynamo_id so the POC and legacy stay in lockstep.
+      FIRST_DYNAMO_ID: ${self:custom.first_dynamo_id}
+      # S3 IAM (s3:*) is inherited from provider.iamRoleStatements — covers
+      # the s3:GetObject + s3:ListBucket needed by the read fallback paths.
     warmup:
       lowConcurrencyWarmer:
         enabled: false

--- a/serverless.yml
+++ b/serverless.yml
@@ -12,6 +12,9 @@ plugins:
   - serverless-plugin-ifelse
 package:
   individually: false
+  include:
+    - spike/strawberry_poc/**
+    - strawberry_poc_handler.py
   exclude:
     - .env
     - .env.*
@@ -224,6 +227,39 @@ functions:
         enabled:
           - test
           - prod
+
+  strawberry-poc:
+    description: Strawberry/FastAPI POC at /graphql-v2 (read-only)
+    handler: strawberry_poc_handler.handler
+    memorySize: 1024
+    timeout: 30
+    events:
+      - http:
+          path: graphql-v2
+          method: OPTIONS
+      - http:
+          path: graphql-v2
+          method: GET
+          authorizer:
+            name: jwtAuthorizer
+            resultTtlInSeconds: 0
+            identitySource: ''
+            type: request
+      - http:
+          path: graphql-v2
+          method: POST
+          authorizer:
+            name: jwtAuthorizer
+            resultTtlInSeconds: 0
+            identitySource: ''
+            type: request
+    environment:
+      DB_READ_ONLY: "1"
+      DEPLOYMENT_STAGE: ${self:custom.stage}
+      GRAPHQL_PATH: /graphql-v2
+    warmup:
+      lowConcurrencyWarmer:
+        enabled: false
 
 resources:
   Resources:

--- a/spike/strawberry_poc/tests/test_schema_parity.py
+++ b/spike/strawberry_poc/tests/test_schema_parity.py
@@ -1,0 +1,315 @@
+"""
+Tests for tools/schema_parity.py — the legacy↔POC SDL diff tool.
+
+Each "bugs caught this session" test reproduces a real schema-level
+divergence that was discovered in production / manual smoketests, and
+verifies the diff tool would have caught it earlier in CI.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tools.schema_parity import (  # noqa: E402
+    diff_schemas,
+    extract_types,
+    format_report,
+    has_any_diff,
+    main,
+)
+
+
+# ── Unit tests: extractor ─────────────────────────────────────────────────────
+
+
+def test_extract_types_picks_up_object_kind_and_fields():
+    sdl = "type Foo { id: ID! name: String }"
+    types = extract_types(sdl)
+    assert types["Foo"]["kind"] == "object"
+    assert types["Foo"]["fields"]["id"]["type"] == "ID!"
+    assert types["Foo"]["fields"]["name"]["type"] == "String"
+
+
+def test_extract_types_handles_interface_union_enum_input_scalar():
+    sdl = """
+    scalar BigInt
+    interface Node { id: ID! }
+    type Foo implements Node { id: ID! }
+    union FooOrBar = Foo | Bar
+    type Bar { id: ID! }
+    enum Color { RED GREEN BLUE }
+    input FilterInput { q: String limit: Int }
+    """
+    types = extract_types(sdl)
+    assert types["BigInt"]["kind"] == "scalar"
+    assert types["Node"]["kind"] == "interface"
+    assert types["Foo"]["interfaces"] == ["Node"]
+    assert types["FooOrBar"]["kind"] == "union"
+    assert types["FooOrBar"]["members"] == ["Bar", "Foo"]
+    assert types["Color"]["kind"] == "enum"
+    assert types["Color"]["values"] == ["BLUE", "GREEN", "RED"]
+    assert types["FilterInput"]["kind"] == "input"
+    assert types["FilterInput"]["fields"] == {"q": "String", "limit": "Int"}
+
+
+def test_extract_field_with_arguments():
+    sdl = "type Query { node(id: ID!, deep: Boolean): String }"
+    types = extract_types(sdl)
+    field = types["Query"]["fields"]["node"]
+    assert field["type"] == "String"
+    assert field["args"] == {"id": "ID!", "deep": "Boolean"}
+
+
+# ── Unit tests: diff primitives ───────────────────────────────────────────────
+
+
+def test_diff_detects_type_only_in_legacy():
+    legacy = "type Foo { id: ID! }"
+    poc = "type Bar { id: ID! }"
+    d = diff_schemas(legacy, poc)
+    assert d["types_only_in_legacy"] == ["Foo"]
+    assert d["types_only_in_poc"] == ["Bar"]
+
+
+def test_diff_detects_field_only_in_legacy():
+    legacy = "type Foo { id: ID! name: String }"
+    poc = "type Foo { id: ID! }"
+    d = diff_schemas(legacy, poc)
+    assert d["type_diffs"]["Foo"]["fields_only_in_legacy"] == ["name"]
+
+
+def test_diff_detects_field_only_in_poc():
+    legacy = "type Foo { id: ID! }"
+    poc = "type Foo { id: ID! extra: Int }"
+    d = diff_schemas(legacy, poc)
+    assert d["type_diffs"]["Foo"]["fields_only_in_poc"] == ["extra"]
+
+
+def test_diff_detects_field_type_mismatch():
+    legacy = "type Foo { size: BigInt }"
+    poc = "type Foo { size: Int }"
+    d = diff_schemas(legacy, poc)
+    assert d["type_diffs"]["Foo"]["field_type_mismatches"] == {"size": ("BigInt", "Int")}
+
+
+def test_diff_detects_kind_mismatch():
+    legacy = "type Foo { id: ID! }"
+    poc = "interface Foo { id: ID! }"
+    d = diff_schemas(legacy, poc)
+    assert d["type_diffs"]["Foo"]["kind_mismatch"] == ("object", "interface")
+
+
+def test_diff_detects_enum_value_drift():
+    legacy = "enum Color { RED GREEN BLUE }"
+    poc = "enum Color { RED GREEN }"
+    d = diff_schemas(legacy, poc)
+    assert d["type_diffs"]["Color"]["values_only_in_legacy"] == ["BLUE"]
+
+
+def test_diff_detects_union_member_drift():
+    legacy = "type A { id: ID! } type B { id: ID! } type C { id: ID! } union AB = A | B | C"
+    poc = "type A { id: ID! } type B { id: ID! } union AB = A | B"
+    d = diff_schemas(legacy, poc)
+    assert d["type_diffs"]["AB"]["members_only_in_legacy"] == ["C"]
+
+
+def test_diff_detects_argument_drift_on_field():
+    legacy = "type Query { node(id: ID!, deep: Boolean): String }"
+    poc = "type Query { node(id: ID!): String }"
+    d = diff_schemas(legacy, poc)
+    assert d["type_diffs"]["Query"]["field_arg_mismatches"]["node"]["args_only_in_legacy"] == [
+        "deep"
+    ]
+
+
+def test_diff_detects_interface_implementation_drift():
+    legacy = "interface Node { id: ID! } interface FI { fn: String } type Foo implements Node & FI { id: ID! fn: String }"
+    poc = "interface Node { id: ID! } type Foo implements Node { id: ID! fn: String }"
+    d = diff_schemas(legacy, poc)
+    assert d["type_diffs"]["Foo"]["interfaces_only_in_legacy"] == ["FI"]
+
+
+def test_diff_input_field_type_mismatch():
+    legacy = "input CreateInput { file_size: BigInt }"
+    poc = "input CreateInput { file_size: Int }"
+    d = diff_schemas(legacy, poc)
+    assert d["type_diffs"]["CreateInput"]["field_type_mismatches"] == {
+        "file_size": ("BigInt", "Int")
+    }
+
+
+def test_identical_schemas_produce_empty_diff():
+    sdl = "type Foo { id: ID! } enum Color { RED }"
+    d = diff_schemas(sdl, sdl)
+    assert d == {"types_only_in_legacy": [], "types_only_in_poc": [], "type_diffs": {}}
+    assert not has_any_diff(d)
+
+
+# ── Bugs this tool would have caught this session ─────────────────────────────
+
+
+@pytest.fixture
+def legacy_minimal():
+    """SDL fragment matching key legacy-schema declarations that the POC
+    must mirror. Each field/type below corresponds to a real production
+    issue we hit during the migration."""
+    return """
+        scalar BigInt
+        type ToshiFile { id: ID! file_name: String file_size: BigInt }
+        type GeneralTask {
+          id: ID!
+          title: String
+          subtask_result: EventResult
+          children(first: Int): TaskTaskRelationConnection
+        }
+        type TaskTaskRelationConnection {
+          total_count: Int
+          edges: [TaskTaskRelationEdge]
+        }
+        type TaskTaskRelationEdge { node: TaskTaskRelation }
+        type TaskTaskRelation { parent: GeneralTask }
+        type Mutation {
+          update_automation_task(input: UpdateAutomationTaskInput!): UpdateAutomationTaskPayload
+        }
+        input UpdateAutomationTaskInput { task_id: ID! }
+        type UpdateAutomationTaskPayload { task_result: AutomationTask }
+        type AutomationTask { id: ID! }
+        enum EventResult { SUCCESS FAILURE PARTIAL UNDEFINED }
+        enum TaskSubType {
+          INVERSION
+          HAZARD
+          DISAGG
+          SCALE_SOLUTION
+        }
+    """
+
+
+def test_catches_toshifile_to_file_rename(legacy_minimal):
+    """Legacy has `ToshiFile`, an earlier POC iteration registered it as `File`.
+    The diff must surface ToshiFile in legacy_only and File in poc_only."""
+    poc = """
+        type File { id: ID! file_name: String file_size: BigInt }
+        type GeneralTask { id: ID! }
+        scalar BigInt
+    """
+    d = diff_schemas(legacy_minimal, poc)
+    assert "ToshiFile" in d["types_only_in_legacy"]
+    assert "File" in d["types_only_in_poc"]
+
+
+def test_catches_missing_update_automation_task_mutation(legacy_minimal):
+    """Legacy defines `update_automation_task`; an earlier POC didn't wire it."""
+    poc = """
+        type Mutation { create_automation_task(input: ID!): String }
+        type ToshiFile { id: ID! }
+        type GeneralTask { id: ID! }
+        scalar BigInt
+    """
+    d = diff_schemas(legacy_minimal, poc)
+    mutation_diff = d["type_diffs"]["Mutation"]
+    assert "update_automation_task" in mutation_diff["fields_only_in_legacy"]
+
+
+def test_catches_subtask_result_missing_from_general_task(legacy_minimal):
+    """Production crashed because GeneralTask.subtask_result was missing in POC."""
+    poc = """
+        type GeneralTask { id: ID! title: String }
+        type ToshiFile { id: ID! }
+        scalar BigInt
+    """
+    d = diff_schemas(legacy_minimal, poc)
+    assert "subtask_result" in d["type_diffs"]["GeneralTask"]["fields_only_in_legacy"]
+
+
+def test_catches_file_size_int_vs_bigint_mismatch():
+    """The POC originally typed file_size as Int (32-bit), legacy uses BigInt.
+    Production values >2GB silently failed validation."""
+    legacy = "type ToshiFile { id: ID! file_size: BigInt }"
+    poc = "type ToshiFile { id: ID! file_size: Int }"
+    d = diff_schemas(legacy, poc)
+    assert d["type_diffs"]["ToshiFile"]["field_type_mismatches"] == {
+        "file_size": ("BigInt", "Int")
+    }
+
+
+def test_catches_missing_total_count_on_connection(legacy_minimal):
+    """relay.ListConnection in POC didn't expose total_count until we added the
+    custom connection subclass with override. The diff surfaces it as a missing field."""
+    poc = """
+        type TaskTaskRelationConnection { edges: [TaskTaskRelationEdge] }
+        type TaskTaskRelationEdge { node: TaskTaskRelation }
+        type TaskTaskRelation { parent: GeneralTask }
+        type GeneralTask { id: ID! }
+        type ToshiFile { id: ID! }
+        scalar BigInt
+    """
+    d = diff_schemas(legacy_minimal, poc)
+    assert "total_count" in d["type_diffs"]["TaskTaskRelationConnection"]["fields_only_in_legacy"]
+
+
+def test_catches_disagg_enum_value_missing(legacy_minimal):
+    """POC initially only tested HAZARD task_type. Missing DISAGG would be a real
+    enum-value gap caught by the diff."""
+    poc = """
+        enum TaskSubType { INVERSION HAZARD SCALE_SOLUTION }
+        type ToshiFile { id: ID! }
+        type GeneralTask { id: ID! }
+        scalar BigInt
+    """
+    d = diff_schemas(legacy_minimal, poc)
+    assert "DISAGG" in d["type_diffs"]["TaskSubType"]["values_only_in_legacy"]
+
+
+# ── Format + CLI smoke tests ──────────────────────────────────────────────────
+
+
+def test_format_report_handles_empty_diff():
+    sdl = "type Foo { id: ID! }"
+    text = format_report(diff_schemas(sdl, sdl))
+    assert "full parity" in text
+
+
+def test_format_report_includes_all_categories(legacy_minimal):
+    poc = """
+        type File { id: ID! }
+        type GeneralTask { id: ID! file_size: Int }
+        scalar BigInt
+    """
+    text = format_report(diff_schemas(legacy_minimal, poc))
+    assert "Types in legacy but not in POC" in text
+    assert "Types in POC but not in legacy" in text
+    assert "Per-type differences" in text
+
+
+def test_cli_self_diff_returns_zero(tmp_path):
+    sdl = tmp_path / "schema.sdl"
+    sdl.write_text("type Foo { id: ID! }")
+    exit_code = main([str(sdl), str(sdl), "--fail-on-diff"])
+    assert exit_code == 0
+
+
+def test_cli_fail_on_diff_returns_one(tmp_path, capsys):
+    a = tmp_path / "a.sdl"
+    b = tmp_path / "b.sdl"
+    a.write_text("type Foo { id: ID! }")
+    b.write_text("type Bar { id: ID! }")
+    exit_code = main([str(a), str(b), "--fail-on-diff"])
+    assert exit_code == 1
+
+
+def test_cli_json_format(tmp_path, capsys):
+    a = tmp_path / "a.sdl"
+    b = tmp_path / "b.sdl"
+    a.write_text("type Foo { id: ID! }")
+    b.write_text("type Bar { id: ID! }")
+    exit_code = main([str(a), str(b), "--format", "json"])
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert "Foo" in parsed["types_only_in_legacy"]
+    assert "Bar" in parsed["types_only_in_poc"]
+    # Without --fail-on-diff, exit is 0 even with divergences
+    assert exit_code == 0

--- a/spike/strawberry_poc/tools/README.md
+++ b/spike/strawberry_poc/tools/README.md
@@ -1,0 +1,60 @@
+# Tools
+
+## `schema_parity.py` — legacy ↔ POC SDL diff
+
+Catches schema-level divergences between the legacy Graphene/Flask API
+and the Strawberry/FastAPI POC. Designed to surface the class of bugs
+that hit production this session before they ship:
+
+- Types missing on one side (e.g. `ToshiFile` renamed to `File`)
+- Fields missing on one side (e.g. `GeneralTask.subtask_result`)
+- Field type mismatches (e.g. `file_size: BigInt` vs `Int`)
+- Mutations missing on one side (e.g. `update_automation_task`)
+- Enum value drift (e.g. `DISAGG` task type)
+- Union member drift
+
+### Usage
+
+Step 1 — dump the POC SDL (run from `spike/strawberry_poc/`):
+
+```bash
+uv run python tools/dump_poc_sdl.py > /tmp/poc.sdl
+```
+
+Step 2 — dump the legacy SDL (run from repo root, in the legacy venv):
+
+```bash
+uv run python -c "
+from graphql.utilities import print_schema
+from graphql_api.schema import root_schema
+print(print_schema(root_schema.graphql_schema))
+" > /tmp/legacy.sdl
+```
+
+Step 3 — diff:
+
+```bash
+uv run python tools/schema_parity.py /tmp/legacy.sdl /tmp/poc.sdl
+```
+
+For CI usage, add `--fail-on-diff` to exit 1 when any divergence is
+found. For machine-readable output use `--format json`.
+
+### Allowlisting intentional divergences
+
+The tool is deliberately allow-list-free in this first version. The
+report is meant to be read by humans, who decide which divergences are
+intentional (e.g. POC adds `BigInt` scalar, drops some legacy-only
+bugfix-test types) and which are accidental regressions.
+
+When the divergence set stabilises, a future iteration can add a YAML
+allowlist file (`expected_diffs.yaml`) that the tool subtracts from the
+diff before checking `--fail-on-diff`.
+
+### Why SDL rather than introspection JSON
+
+Both Graphene's `print_schema` and Strawberry's `schema.as_str()` emit
+the same standard SDL format, so the diff is symmetric and doesn't care
+which framework produced the schema. The tool uses `graphql-core`'s
+parser (already a transitive dep via `strawberry-graphql`) to turn each
+SDL into a structural dict before diffing.

--- a/spike/strawberry_poc/tools/dump_poc_sdl.py
+++ b/spike/strawberry_poc/tools/dump_poc_sdl.py
@@ -1,0 +1,25 @@
+"""Dump the Strawberry POC SDL to stdout.
+
+Usage (from spike/strawberry_poc/):
+    uv run python tools/dump_poc_sdl.py > poc.sdl
+"""
+
+import sys
+from pathlib import Path
+
+# Make spike/strawberry_poc/ importable when invoked as `python tools/dump_poc_sdl.py`
+# from the spike root. pytest config does this via pythonpath but a bare python
+# call doesn't pick that up.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from schema import schema  # noqa: E402
+
+
+def main() -> int:
+    sys.stdout.write(schema.as_str())
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/spike/strawberry_poc/tools/schema_parity.py
+++ b/spike/strawberry_poc/tools/schema_parity.py
@@ -1,0 +1,357 @@
+"""
+Schema parity diff — compare two GraphQL schemas at the SDL level.
+
+Designed to catch the exact class of bugs that surfaced this session:
+  - Types missing from one side (e.g. ToshiFile renamed to File)
+  - Fields missing from one side (e.g. GeneralTask.subtask_result)
+  - Field type mismatches (e.g. file_size: BigInt vs Int)
+  - Mutations missing from one side (e.g. update_automation_task)
+  - Enum value drift (e.g. DISAGG task type)
+  - Union member drift
+
+Inputs are two SDL strings (or files). Output is a structured diff dict
+plus a markdown report. Designed for CI: `--fail-on-diff` exits 1 when
+unexpected divergence is found, so a workflow step can gate merges.
+
+Implementation uses graphql-core's parser (already a transitive dep via
+strawberry-graphql) rather than the introspection JSON because SDL is
+the canonical comparable representation and works for any schema that
+can emit SDL — both Graphene (`print_schema(root_schema)`) and
+Strawberry (`schema.as_str()`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from graphql.language import parse
+from graphql.language.ast import (
+    DocumentNode,
+    EnumTypeDefinitionNode,
+    FieldDefinitionNode,
+    InputObjectTypeDefinitionNode,
+    InputValueDefinitionNode,
+    InterfaceTypeDefinitionNode,
+    ListTypeNode,
+    NamedTypeNode,
+    NonNullTypeNode,
+    ObjectTypeDefinitionNode,
+    ScalarTypeDefinitionNode,
+    UnionTypeDefinitionNode,
+)
+
+
+def _type_to_str(node) -> str:
+    """Render a type AST node back to SDL form (e.g. '[String!]!')."""
+    if isinstance(node, NonNullTypeNode):
+        return f"{_type_to_str(node.type)}!"
+    if isinstance(node, ListTypeNode):
+        return f"[{_type_to_str(node.type)}]"
+    if isinstance(node, NamedTypeNode):
+        return node.name.value
+    return str(node)
+
+
+def _args_to_dict(field: FieldDefinitionNode) -> dict[str, str]:
+    """{arg_name: rendered_type} for a field's arguments."""
+    return {a.name.value: _type_to_str(a.type) for a in field.arguments}
+
+
+def _fields_to_dict(field_defs) -> dict[str, dict]:
+    """{field_name: {type: ..., args: {...}}} for object/interface fields."""
+    out = {}
+    for f in field_defs:
+        entry: dict = {"type": _type_to_str(f.type)}
+        if isinstance(f, FieldDefinitionNode) and f.arguments:
+            entry["args"] = _args_to_dict(f)
+        out[f.name.value] = entry
+    return out
+
+
+def _input_fields_to_dict(field_defs) -> dict[str, str]:
+    """{field_name: rendered_type} for input object fields."""
+    return {
+        f.name.value: _type_to_str(f.type)
+        for f in field_defs
+        if isinstance(f, InputValueDefinitionNode)
+    }
+
+
+def extract_types(sdl: str) -> dict[str, dict]:
+    """Parse SDL → {type_name: {kind, ...}} dict suitable for diffing."""
+    doc = parse(sdl)
+    return _extract_types(doc)
+
+
+def _extract_types(doc: DocumentNode) -> dict[str, dict]:
+    types: dict[str, dict] = {}
+    for defn in doc.definitions:
+        if not hasattr(defn, "name"):
+            continue
+        name = defn.name.value
+        if isinstance(defn, ObjectTypeDefinitionNode):
+            types[name] = {
+                "kind": "object",
+                "interfaces": sorted(i.name.value for i in defn.interfaces),
+                "fields": _fields_to_dict(defn.fields),
+            }
+        elif isinstance(defn, InterfaceTypeDefinitionNode):
+            types[name] = {
+                "kind": "interface",
+                "fields": _fields_to_dict(defn.fields),
+            }
+        elif isinstance(defn, UnionTypeDefinitionNode):
+            types[name] = {
+                "kind": "union",
+                "members": sorted(t.name.value for t in defn.types),
+            }
+        elif isinstance(defn, EnumTypeDefinitionNode):
+            types[name] = {
+                "kind": "enum",
+                "values": sorted(v.name.value for v in defn.values),
+            }
+        elif isinstance(defn, InputObjectTypeDefinitionNode):
+            types[name] = {
+                "kind": "input",
+                "fields": _input_fields_to_dict(defn.fields),
+            }
+        elif isinstance(defn, ScalarTypeDefinitionNode):
+            types[name] = {"kind": "scalar"}
+    return types
+
+
+def _diff_object_or_interface(legacy: dict, poc: dict) -> dict:
+    l_fields = legacy["fields"]
+    p_fields = poc["fields"]
+    l_names = set(l_fields.keys())
+    p_names = set(p_fields.keys())
+
+    type_mismatches = {}
+    args_mismatches = {}
+    for name in l_names & p_names:
+        if l_fields[name]["type"] != p_fields[name]["type"]:
+            type_mismatches[name] = (l_fields[name]["type"], p_fields[name]["type"])
+        # Compare args if either side has them
+        l_args = l_fields[name].get("args", {})
+        p_args = p_fields[name].get("args", {})
+        if l_args != p_args:
+            args_mismatches[name] = {
+                "args_only_in_legacy": sorted(set(l_args) - set(p_args)),
+                "args_only_in_poc": sorted(set(p_args) - set(l_args)),
+                "arg_type_mismatches": {
+                    a: (l_args[a], p_args[a])
+                    for a in set(l_args) & set(p_args)
+                    if l_args[a] != p_args[a]
+                },
+            }
+
+    out = {}
+    only_l = sorted(l_names - p_names)
+    only_p = sorted(p_names - l_names)
+    if only_l:
+        out["fields_only_in_legacy"] = only_l
+    if only_p:
+        out["fields_only_in_poc"] = only_p
+    if type_mismatches:
+        out["field_type_mismatches"] = type_mismatches
+    if args_mismatches:
+        out["field_arg_mismatches"] = args_mismatches
+
+    # Interface list diff (objects only)
+    if legacy["kind"] == "object" and poc["kind"] == "object":
+        l_ifaces = set(legacy.get("interfaces", []))
+        p_ifaces = set(poc.get("interfaces", []))
+        if l_ifaces != p_ifaces:
+            out["interfaces_only_in_legacy"] = sorted(l_ifaces - p_ifaces)
+            out["interfaces_only_in_poc"] = sorted(p_ifaces - l_ifaces)
+
+    return out
+
+
+def _diff_input(legacy: dict, poc: dict) -> dict:
+    l_fields = legacy["fields"]
+    p_fields = poc["fields"]
+    l_names = set(l_fields.keys())
+    p_names = set(p_fields.keys())
+
+    out = {}
+    only_l = sorted(l_names - p_names)
+    only_p = sorted(p_names - l_names)
+    if only_l:
+        out["fields_only_in_legacy"] = only_l
+    if only_p:
+        out["fields_only_in_poc"] = only_p
+
+    type_mismatches = {
+        name: (l_fields[name], p_fields[name])
+        for name in l_names & p_names
+        if l_fields[name] != p_fields[name]
+    }
+    if type_mismatches:
+        out["field_type_mismatches"] = type_mismatches
+    return out
+
+
+def _diff_enum(legacy: dict, poc: dict) -> dict:
+    l_vals = set(legacy["values"])
+    p_vals = set(poc["values"])
+    out = {}
+    if l_vals - p_vals:
+        out["values_only_in_legacy"] = sorted(l_vals - p_vals)
+    if p_vals - l_vals:
+        out["values_only_in_poc"] = sorted(p_vals - l_vals)
+    return out
+
+
+def _diff_union(legacy: dict, poc: dict) -> dict:
+    l_mems = set(legacy["members"])
+    p_mems = set(poc["members"])
+    out = {}
+    if l_mems - p_mems:
+        out["members_only_in_legacy"] = sorted(l_mems - p_mems)
+    if p_mems - l_mems:
+        out["members_only_in_poc"] = sorted(p_mems - l_mems)
+    return out
+
+
+def diff_schemas(legacy_sdl: str, poc_sdl: str) -> dict:
+    """Top-level diff. Returns a dict with the divergences between the two SDL inputs."""
+    legacy = extract_types(legacy_sdl)
+    poc = extract_types(poc_sdl)
+
+    legacy_names = set(legacy.keys())
+    poc_names = set(poc.keys())
+    in_both = legacy_names & poc_names
+
+    type_diffs: dict[str, dict] = {}
+    for name in sorted(in_both):
+        l = legacy[name]
+        p = poc[name]
+        if l["kind"] != p["kind"]:
+            type_diffs[name] = {"kind_mismatch": (l["kind"], p["kind"])}
+            continue
+        kind = l["kind"]
+        if kind in ("object", "interface"):
+            d = _diff_object_or_interface(l, p)
+        elif kind == "input":
+            d = _diff_input(l, p)
+        elif kind == "enum":
+            d = _diff_enum(l, p)
+        elif kind == "union":
+            d = _diff_union(l, p)
+        else:
+            d = {}
+        if d:
+            type_diffs[name] = d
+
+    return {
+        "types_only_in_legacy": sorted(legacy_names - poc_names),
+        "types_only_in_poc": sorted(poc_names - legacy_names),
+        "type_diffs": type_diffs,
+    }
+
+
+def has_any_diff(diff: dict) -> bool:
+    return bool(diff["types_only_in_legacy"] or diff["types_only_in_poc"] or diff["type_diffs"])
+
+
+def format_report(diff: dict) -> str:
+    """Render a diff dict as markdown."""
+    lines: list[str] = ["# Schema Parity Report", ""]
+
+    if diff["types_only_in_legacy"]:
+        lines.append(f"## Types in legacy but not in POC ({len(diff['types_only_in_legacy'])})")
+        for t in diff["types_only_in_legacy"]:
+            lines.append(f"- `{t}`")
+        lines.append("")
+
+    if diff["types_only_in_poc"]:
+        lines.append(f"## Types in POC but not in legacy ({len(diff['types_only_in_poc'])})")
+        for t in diff["types_only_in_poc"]:
+            lines.append(f"- `{t}`")
+        lines.append("")
+
+    if diff["type_diffs"]:
+        lines.append(f"## Per-type differences ({len(diff['type_diffs'])} types)")
+        for name in sorted(diff["type_diffs"]):
+            d = diff["type_diffs"][name]
+            lines.append(f"\n### `{name}`")
+            if "kind_mismatch" in d:
+                lk, pk = d["kind_mismatch"]
+                lines.append(f"- **kind differs**: legacy=`{lk}` poc=`{pk}`")
+                continue
+            for key, label in (
+                ("fields_only_in_legacy", "Fields only in legacy"),
+                ("fields_only_in_poc", "Fields only in POC"),
+                ("values_only_in_legacy", "Enum values only in legacy"),
+                ("values_only_in_poc", "Enum values only in POC"),
+                ("members_only_in_legacy", "Union members only in legacy"),
+                ("members_only_in_poc", "Union members only in POC"),
+                ("interfaces_only_in_legacy", "Interfaces only in legacy"),
+                ("interfaces_only_in_poc", "Interfaces only in POC"),
+            ):
+                if d.get(key):
+                    lines.append(f"- **{label}:**")
+                    for item in d[key]:
+                        lines.append(f"  - `{item}`")
+            if d.get("field_type_mismatches"):
+                lines.append("- **Field type mismatches (legacy → poc):**")
+                for f, (lt, pt) in sorted(d["field_type_mismatches"].items()):
+                    lines.append(f"  - `{f}`: `{lt}` → `{pt}`")
+            if d.get("field_arg_mismatches"):
+                lines.append("- **Field argument mismatches:**")
+                for f, am in sorted(d["field_arg_mismatches"].items()):
+                    parts = []
+                    if am.get("args_only_in_legacy"):
+                        parts.append(f"only-legacy={am['args_only_in_legacy']}")
+                    if am.get("args_only_in_poc"):
+                        parts.append(f"only-poc={am['args_only_in_poc']}")
+                    if am.get("arg_type_mismatches"):
+                        parts.append(f"type-mismatches={am['arg_type_mismatches']}")
+                    lines.append(f"  - `{f}`: {'; '.join(parts)}")
+
+    if not has_any_diff(diff):
+        lines.append("✅ Schemas are at full parity (no divergences detected).")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Diff a legacy GraphQL SDL against a Strawberry POC SDL"
+    )
+    parser.add_argument("legacy", help="Path to legacy SDL file")
+    parser.add_argument("poc", help="Path to POC SDL file")
+    parser.add_argument(
+        "--format",
+        choices=["markdown", "json"],
+        default="markdown",
+        help="Output format (default: markdown)",
+    )
+    parser.add_argument(
+        "--fail-on-diff",
+        action="store_true",
+        help="Exit with status 1 if any divergence is found (suitable for CI gate)",
+    )
+    args = parser.parse_args(argv)
+
+    legacy_sdl = Path(args.legacy).read_text()
+    poc_sdl = Path(args.poc).read_text()
+
+    diff = diff_schemas(legacy_sdl, poc_sdl)
+
+    if args.format == "json":
+        sys.stdout.write(json.dumps(diff, indent=2, default=str))
+    else:
+        sys.stdout.write(format_report(diff))
+
+    if args.fail_on_diff and has_any_diff(diff):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/strawberry_poc_handler.py
+++ b/strawberry_poc_handler.py
@@ -1,0 +1,18 @@
+"""
+Lambda entry point shim for the Strawberry/FastAPI POC.
+
+The POC lives in spike/strawberry_poc/ and uses root-relative imports
+(e.g. `from data.search import ...`). Lambda's working directory is the
+repo root, so we insert the POC directory into sys.path before the POC
+modules are imported. This lets the POC remain self-contained without
+restructuring its imports.
+
+Handler in serverless.yml: strawberry_poc_handler.handler
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "spike", "strawberry_poc"))
+
+from app import handler  # noqa: E402, F401 — re-export for Lambda

--- a/uv.lock
+++ b/uv.lock
@@ -440,6 +440,18 @@ wheels = [
 ]
 
 [[package]]
+name = "cross-web"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/a0/bdb8370215987cc5bde497cb8b976b17ab14841566ecef2aab6ae3e6c7b0/cross_web-0.7.0.tar.gz", hash = "sha256:15fbc8b9a824a055db8127fd6e43e0773074f620fdecb6b2b587d3d0a2bdd459", size = 332407, upload-time = "2026-05-19T14:18:48.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/4a/78b52ec2edcbd9b123638f4e0421fd8699ebe653ebf63ac5f82abd2665bc/cross_web-0.7.0-py3-none-any.whl", hash = "sha256:ddea9be3c68b48eaf16561847a5831a559786949c544b3701432e00a4e8d19d9", size = 25207, upload-time = "2026-05-19T14:18:47.614Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "48.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -579,6 +591,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bb/b7/2587ab980d479adec3033a2066e3415630f1eedf0e914d77b5b274a0aa36/elasticsearch7-compatible-10.0.5.tar.gz", hash = "sha256:0420897b07dd1bf811a97b0f0dc1249b8fa3a192e260572cb70cc3e7ee70457e", size = 197201, upload-time = "2025-10-17T10:49:58.674Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/a0/d4ce1826df224d944becd3fa11e792e473b0f28476cbfc67aeba845f3480/elasticsearch7_compatible-10.0.5-py2.py3-none-any.whl", hash = "sha256:8ddae43112499d35992ed2cfc6edafbb13b68983f31f0f78d718f4ddbcda489a", size = 354500, upload-time = "2025-10-17T10:49:57.363Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.136.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
 ]
 
 [[package]]
@@ -866,6 +894,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
+]
+
+[[package]]
+name = "mangum"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/cb/d9f4d685a0b8eceac10991e15ac471d9568e4e42c2489ae9bf072828c1c2/mangum-0.21.0.tar.gz", hash = "sha256:e31ed72d67f9958fa4379f65df77729906dec6dfa00afa6ed4e06c77833000de", size = 89130, upload-time = "2026-02-01T17:17:42.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/50/e3c694b8e122551e4557450219283771334dee2ed5734a8398c8b8018c50/mangum-0.21.0-py3-none-any.whl", hash = "sha256:309e48f5c629542516c5106ecf079f4ec08809ed50df882238d98fe1392820c7", size = 17146, upload-time = "2026-02-01T17:17:41.553Z" },
 ]
 
 [[package]]
@@ -1213,6 +1253,7 @@ dependencies = [
     { name = "gql" },
     { name = "graphene" },
     { name = "graphql-server" },
+    { name = "mangum" },
     { name = "nzshm-common" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "pynamodb" },
@@ -1222,6 +1263,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests-aws4auth" },
     { name = "requests-toolbelt" },
+    { name = "strawberry-graphql", extra = ["fastapi"] },
 ]
 
 [package.dev-dependencies]
@@ -1256,6 +1298,7 @@ requires-dist = [
     { name = "gql" },
     { name = "graphene", specifier = ">=3.3" },
     { name = "graphql-server", specifier = "==3.0.0b7" },
+    { name = "mangum", specifier = ">=0.17" },
     { name = "nzshm-common" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8.0" },
     { name = "pynamodb" },
@@ -1265,6 +1308,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "requests-aws4auth" },
     { name = "requests-toolbelt" },
+    { name = "strawberry-graphql", extras = ["fastapi"], specifier = ">=0.243.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1754,6 +1798,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.29"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
+]
+
+[[package]]
 name = "python-slugify"
 version = "8.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2113,6 +2166,41 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
+]
+
+[[package]]
+name = "strawberry-graphql"
+version = "0.316.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cross-web" },
+    { name = "graphql-core" },
+    { name = "packaging" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/09/f189fd3c70544322eeba0398ccaa980d17857894c0a66d447aa0b5704686/strawberry_graphql-0.316.0.tar.gz", hash = "sha256:bee5ce0e20d522325bd1ed2db186c812c03c2ea7db29f997b35e7d694649820c", size = 223985, upload-time = "2026-05-19T17:06:10.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/dd/b2cf54803cbd0d37e3ce73c7274bdb144ba83743bc83351b5790eb2a5fad/strawberry_graphql-0.316.0-py3-none-any.whl", hash = "sha256:222e16fbbf953f5a1fa75f62bf9a8e95f274180f928f70bec459b566053aa2cb", size = 326530, upload-time = "2026-05-19T17:06:07.844Z" },
+]
+
+[package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
+    { name = "python-multipart" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Consolidates **5 previously-separate infra/docs PRs** into a single
reviewable change. Stacks on top of #296 (the POC base).

Like #310, each commit preserves its original author, date, and
message.

## Commit-by-commit map

| Commit | Original PR | What it does |
|---|---|---|
| 1 | #297 | Wire Strawberry POC as side-by-side `/graphql-v2` Lambda function |
| 2 | #297 | Make S3 env dependency explicit on `/graphql-v2` function |
| 3 | #298 | GH Actions workflow delegating to GNS-Science shared `python-run-tests-uv.yml` |
| 4 | #301 | Schema parity diff tool (`tools/schema_parity.py`) — compares legacy vs POC SDL via AST |
| 5 | #302 | ADR-001 — GraphQL schema evolution strategy + introduce `docs/adrs/` convention |
| 6 | #302 | Rename ADRs to `ADR-NNN-{descriptive-name}.md` convention |
| 7 | #307 | ADR-002 — schema interface hierarchy and input naming |
| 8 | #307 | ADR-002 — fold in client-divergence audit findings (updated after the audit in PR #309 / commit 8 of #310) |

## Test plan

- [x] All commits cherry-pick cleanly (one README conflict resolved
      by taking the latest version)
- [x] No changes to Python production code — review is concentrated
      on serverless.yml, the workflow file, the diff tool, and the
      ADR markdown

## Replaces

Once this lands, the following PRs can be closed: #297, #298, #301, #302, #307.