### PR TITLE
refactor(strawberry-poc): dispatch registry + port bugfix tests 217/252

### DIFF
--- a/spike/strawberry_poc/models/_dispatch.py
+++ b/spike/strawberry_poc/models/_dispatch.py
@@ -1,0 +1,97 @@
+"""Shared clazz_name → type dispatch.
+
+Replaces the three near-identical 14-branch `if clazz == ...` chains in
+schema.py (_dispatch_search), models/relations.py (_dispatch_file,
+_dispatch_thing). All three iterated the same legacy class names and
+called .from_dict on the matched type; the only differences were the
+list of valid types per context and the fallback type.
+
+Imports are still done lazily at call time because the Strawberry model
+graph has cycles that only resolve at runtime.
+"""
+
+import importlib
+from typing import Any
+
+# Maps legacy clazz_name → (module path under models/, class name).
+# Module is imported lazily on first dispatch to avoid Strawberry
+# circular-import issues during schema build.
+_CLAZZ_REGISTRY: dict[str, tuple[str, str]] = {
+    # Things
+    "GeneralTask": ("models.general_task", "GeneralTask"),
+    "RuptureGenerationTask": ("models.automation_task", "RuptureGenerationTask"),
+    "AutomationTask": ("models.automation_task", "AutomationTask"),
+    "StrongMotionStation": ("models.strong_motion_station", "StrongMotionStation"),
+    "OpenquakeHazardTask": ("models.openquake_hazard_task", "OpenquakeHazardTask"),
+    "OpenquakeHazardSolution": ("models.openquake_hazard_solution", "OpenquakeHazardSolution"),
+    "OpenquakeHazardConfig": ("models.openquake_hazard_config", "OpenquakeHazardConfig"),
+    # Files
+    "ToshiFile": ("models.file", "ToshiFile"),
+    "SmsFile": ("models.sms_file", "SmsFile"),
+    "RuptureSet": ("models.rupture_set", "RuptureSet"),
+    "InversionSolution": ("models.inversion_solution", "InversionSolution"),
+    "ScaledInversionSolution": ("models.scaled_inversion_solution", "ScaledInversionSolution"),
+    "AggregateInversionSolution": ("models.aggregate_inversion_solution", "AggregateInversionSolution"),
+    "TimeDependentInversionSolution": (
+        "models.time_dependent_inversion_solution",
+        "TimeDependentInversionSolution",
+    ),
+    "InversionSolutionNrml": ("models.inversion_solution_nrml", "InversionSolutionNrml"),
+}
+
+# Sets defining which clazz_names are valid in each dispatch context.
+# Anything not in the set falls through to the context's default type.
+_FILE_CLAZZ_NAMES: frozenset[str] = frozenset(
+    {
+        "SmsFile",
+        "RuptureSet",
+        "InversionSolution",
+        "ScaledInversionSolution",
+        "AggregateInversionSolution",
+        "TimeDependentInversionSolution",
+        "InversionSolutionNrml",
+    }
+)
+
+_THING_CLAZZ_NAMES: frozenset[str] = frozenset(
+    {
+        "RuptureGenerationTask",
+        "AutomationTask",
+        "StrongMotionStation",
+        "OpenquakeHazardTask",
+        "OpenquakeHazardSolution",
+        "OpenquakeHazardConfig",
+    }
+)
+
+
+def _resolve(clazz: str) -> Any:
+    """Lazily import and return the Strawberry class for `clazz`."""
+    module_path, class_name = _CLAZZ_REGISTRY[clazz]
+    module = importlib.import_module(module_path)
+    return getattr(module, class_name)
+
+
+def dispatch_search(data: dict) -> Any | None:
+    """Instantiate any registered type from an ES hit. Returns None for unknown clazz."""
+    clazz = data.get("clazz_name", "")
+    if clazz not in _CLAZZ_REGISTRY:
+        # Default: treat as a plain ToshiFile (matches legacy behaviour).
+        return _resolve("ToshiFile").from_dict(data)
+    return _resolve(clazz).from_dict(data)
+
+
+def dispatch_file(data: dict) -> Any:
+    """Instantiate the right file-type Strawberry class. Defaults to ToshiFile."""
+    clazz = data.get("clazz_name", "")
+    if clazz in _FILE_CLAZZ_NAMES:
+        return _resolve(clazz).from_dict(data)
+    return _resolve("ToshiFile").from_dict(data)
+
+
+def dispatch_thing(data: dict) -> Any:
+    """Instantiate the right thing-type Strawberry class. Defaults to GeneralTask."""
+    clazz = data.get("clazz_name", "")
+    if clazz in _THING_CLAZZ_NAMES:
+        return _resolve(clazz).from_dict(data)
+    return _resolve("GeneralTask").from_dict(data)

--- a/spike/strawberry_poc/models/relations.py
+++ b/spike/strawberry_poc/models/relations.py
@@ -194,72 +194,8 @@ class TaskRelationsConnection(CompatListConnection[TaskTaskRelation]):
 # ── Dispatch helpers ──────────────────────────────────────────────────────────
 
 
-def _dispatch_file(data: dict):
-    """Instantiate the right Strawberry file type from a raw data dict."""
-    clazz = data.get("clazz_name", "")
-    if clazz == "SmsFile":
-        from models.sms_file import SmsFile  # noqa: PLC0415
-
-        return SmsFile.from_dict(data)
-    if clazz == "RuptureSet":
-        from models.rupture_set import RuptureSet  # noqa: PLC0415
-
-        return RuptureSet.from_dict(data)
-    if clazz == "InversionSolution":
-        from models.inversion_solution import InversionSolution  # noqa: PLC0415
-
-        return InversionSolution.from_dict(data)
-    if clazz == "ScaledInversionSolution":
-        from models.scaled_inversion_solution import ScaledInversionSolution  # noqa: PLC0415
-
-        return ScaledInversionSolution.from_dict(data)
-    if clazz == "AggregateInversionSolution":
-        from models.aggregate_inversion_solution import AggregateInversionSolution  # noqa: PLC0415
-
-        return AggregateInversionSolution.from_dict(data)
-    if clazz == "TimeDependentInversionSolution":
-        from models.time_dependent_inversion_solution import TimeDependentInversionSolution  # noqa: PLC0415
-
-        return TimeDependentInversionSolution.from_dict(data)
-    if clazz == "InversionSolutionNrml":
-        from models.inversion_solution_nrml import InversionSolutionNrml  # noqa: PLC0415
-
-        return InversionSolutionNrml.from_dict(data)
-    from models.file import ToshiFile  # noqa: PLC0415
-
-    return ToshiFile.from_dict(data)
-
-
-def _dispatch_thing(data: dict):
-    """Instantiate the right Strawberry thing type from a raw data dict."""
-    clazz = data.get("clazz_name", "")
-    if clazz == "RuptureGenerationTask":
-        from models.automation_task import RuptureGenerationTask  # noqa: PLC0415
-
-        return RuptureGenerationTask.from_dict(data)
-    if clazz == "AutomationTask":
-        from models.automation_task import AutomationTask  # noqa: PLC0415
-
-        return AutomationTask.from_dict(data)
-    if clazz == "StrongMotionStation":
-        from models.strong_motion_station import StrongMotionStation  # noqa: PLC0415
-
-        return StrongMotionStation.from_dict(data)
-    if clazz == "OpenquakeHazardTask":
-        from models.openquake_hazard_task import OpenquakeHazardTask  # noqa: PLC0415
-
-        return OpenquakeHazardTask.from_dict(data)
-    if clazz == "OpenquakeHazardSolution":
-        from models.openquake_hazard_solution import OpenquakeHazardSolution  # noqa: PLC0415
-
-        return OpenquakeHazardSolution.from_dict(data)
-    if clazz == "OpenquakeHazardConfig":
-        from models.openquake_hazard_config import OpenquakeHazardConfig  # noqa: PLC0415
-
-        return OpenquakeHazardConfig.from_dict(data)
-    from models.general_task import GeneralTask  # noqa: PLC0415
-
-    return GeneralTask.from_dict(data)
+from ._dispatch import dispatch_file as _dispatch_file
+from ._dispatch import dispatch_thing as _dispatch_thing
 
 
 # ── Input types for mutations ─────────────────────────────────────────────────

--- a/spike/strawberry_poc/schema.py
+++ b/spike/strawberry_poc/schema.py
@@ -21,8 +21,6 @@ from strawberry.schema.config import StrawberryConfig
 
 import data.search as _data_search
 from data.dynamo import es_key_for, get_object, scan_objects_paginated
-
-log = logging.getLogger(__name__)
 from data.s3 import scan_s3_paginated
 from data.search import search as es_search
 from models.page_info import CompatListConnection
@@ -127,6 +125,9 @@ from models.time_dependent_inversion_solution import (
     resolve_time_dependent_inversion_solutions,
 )
 
+log = logging.getLogger(__name__)
+
+
 # ── SearchResult union + connection ───────────────────────────────────────────
 
 SearchResult = Annotated[
@@ -164,42 +165,18 @@ class SearchPayload:
     search_result: SearchResultConnection | None = None
 
 
-def _dispatch_search(hit: dict) -> SearchResult | None:  # noqa: C901
-    """Instantiate the right Strawberry type from an ES _source dict."""
-    clazz = hit.get("clazz_name", "")
+def _dispatch_search(hit: dict) -> SearchResult | None:
+    """Instantiate the right Strawberry type from an ES _source dict.
+
+    Delegates to the shared clazz_name → type registry in models/_dispatch.py.
+    Unknown clazz values fall back to ToshiFile, matching legacy behaviour.
+    """
+    from models._dispatch import dispatch_search  # noqa: PLC0415
+
     try:
-        if clazz == "GeneralTask":
-            return GeneralTask.from_dict(hit)
-        elif clazz == "RuptureGenerationTask":
-            return RuptureGenerationTask.from_dict(hit)
-        elif clazz == "AutomationTask":
-            return AutomationTask.from_dict(hit)
-        elif clazz == "StrongMotionStation":
-            return StrongMotionStation.from_dict(hit)
-        elif clazz == "OpenquakeHazardTask":
-            return OpenquakeHazardTask.from_dict(hit)
-        elif clazz == "OpenquakeHazardSolution":
-            return OpenquakeHazardSolution.from_dict(hit)
-        elif clazz == "OpenquakeHazardConfig":
-            return OpenquakeHazardConfig.from_dict(hit)
-        elif clazz == "SmsFile":
-            return SmsFile.from_dict(hit)
-        elif clazz == "RuptureSet":
-            return RuptureSet.from_dict(hit)
-        elif clazz == "InversionSolution":
-            return InversionSolution.from_dict(hit)
-        elif clazz == "ScaledInversionSolution":
-            return ScaledInversionSolution.from_dict(hit)
-        elif clazz == "AggregateInversionSolution":
-            return AggregateInversionSolution.from_dict(hit)
-        elif clazz == "TimeDependentInversionSolution":
-            return TimeDependentInversionSolution.from_dict(hit)
-        elif clazz == "InversionSolutionNrml":
-            return InversionSolutionNrml.from_dict(hit)
-        else:
-            return ToshiFile.from_dict(hit)
+        return dispatch_search(hit)
     except (KeyError, AttributeError, ValueError, TypeError) as e:
-        log.warning("_dispatch_search: failed to instantiate %s from hit: %s", clazz or "?", e)
+        log.warning("_dispatch_search: failed to instantiate %s from hit: %s", hit.get("clazz_name") or "?", e)
         return None
 
 
@@ -511,119 +488,182 @@ class Mutation:
     def create_general_task(
         self, info: strawberry.types.Info, input: CreateGeneralTaskInput
     ) -> CreateGeneralTaskPayload:
-        return CreateGeneralTaskPayload(general_task=mutate_create_general_task(info, input), client_mutation_id=input.client_mutation_id)
+        return CreateGeneralTaskPayload(
+            general_task=mutate_create_general_task(info, input), client_mutation_id=input.client_mutation_id
+        )
 
     @strawberry.mutation
     def update_general_task(
         self, info: strawberry.types.Info, input: UpdateGeneralTaskInput
     ) -> UpdateGeneralTaskPayload:
-        return UpdateGeneralTaskPayload(general_task=mutate_update_general_task(info, input), client_mutation_id=input.client_mutation_id)
+        return UpdateGeneralTaskPayload(
+            general_task=mutate_update_general_task(info, input), client_mutation_id=input.client_mutation_id
+        )
 
     @strawberry.mutation
     def create_rupture_set(self, info: strawberry.types.Info, input: CreateRuptureSetInput) -> CreateRuptureSetPayload:
-        return CreateRuptureSetPayload(ok=True, rupture_set=mutate_create_rupture_set(info, input), client_mutation_id=input.client_mutation_id)
+        return CreateRuptureSetPayload(
+            ok=True, rupture_set=mutate_create_rupture_set(info, input), client_mutation_id=input.client_mutation_id
+        )
 
     @strawberry.mutation
     def create_file(self, info: strawberry.types.Info, input: CreateFileInput) -> CreateFilePayload:
-        return CreateFilePayload(ok=True, file_result=mutate_create_file(info, input), client_mutation_id=input.client_mutation_id)
+        return CreateFilePayload(
+            ok=True, file_result=mutate_create_file(info, input), client_mutation_id=input.client_mutation_id
+        )
 
     @strawberry.mutation
     def create_sms_file(self, info: strawberry.types.Info, input: CreateSmsFileInput) -> CreateSmsFilePayload:
-        return CreateSmsFilePayload(ok=True, file_result=mutate_create_sms_file(info, input), client_mutation_id=input.client_mutation_id)
+        return CreateSmsFilePayload(
+            ok=True, file_result=mutate_create_sms_file(info, input), client_mutation_id=input.client_mutation_id
+        )
 
     @strawberry.mutation
     def create_strong_motion_station(
         self, info: strawberry.types.Info, input: CreateStrongMotionStationInput
     ) -> CreateStrongMotionStationPayload:
-        return CreateStrongMotionStationPayload(strong_motion_station=mutate_create_strong_motion_station(info, input), client_mutation_id=input.client_mutation_id)
+        return CreateStrongMotionStationPayload(
+            strong_motion_station=mutate_create_strong_motion_station(info, input),
+            client_mutation_id=input.client_mutation_id,
+        )
 
     @strawberry.mutation
     def create_automation_task(
         self, info: strawberry.types.Info, input: CreateAutomationTaskInput
     ) -> CreateAutomationTaskPayload:
-        return CreateAutomationTaskPayload(task_result=mutate_create_automation_task(info, input), client_mutation_id=input.client_mutation_id)
+        return CreateAutomationTaskPayload(
+            task_result=mutate_create_automation_task(info, input), client_mutation_id=input.client_mutation_id
+        )
 
     @strawberry.mutation
     def create_rupture_generation_task(
         self, info: strawberry.types.Info, input: CreateAutomationTaskInput
     ) -> CreateRuptureGenerationTaskPayload:
-        return CreateRuptureGenerationTaskPayload(task_result=mutate_create_rupture_generation_task(info, input), client_mutation_id=input.client_mutation_id)
+        return CreateRuptureGenerationTaskPayload(
+            task_result=mutate_create_rupture_generation_task(info, input), client_mutation_id=input.client_mutation_id
+        )
 
     @strawberry.mutation
     def update_rupture_generation_task(
         self, info: strawberry.types.Info, input: UpdateAutomationTaskInput
     ) -> UpdateRuptureGenerationTaskPayload:
-        return UpdateRuptureGenerationTaskPayload(task_result=mutate_update_rupture_generation_task(info, input), client_mutation_id=input.client_mutation_id)
+        return UpdateRuptureGenerationTaskPayload(
+            task_result=mutate_update_rupture_generation_task(info, input), client_mutation_id=input.client_mutation_id
+        )
 
     @strawberry.mutation
     def update_automation_task(
         self, info: strawberry.types.Info, input: UpdateAutomationTaskInput
     ) -> UpdateAutomationTaskPayload:
-        return UpdateAutomationTaskPayload(task_result=mutate_update_automation_task(info, input), client_mutation_id=input.client_mutation_id)
+        return UpdateAutomationTaskPayload(
+            task_result=mutate_update_automation_task(info, input), client_mutation_id=input.client_mutation_id
+        )
 
     @strawberry.mutation
     def create_inversion_solution(
         self, info: strawberry.types.Info, input: CreateInversionSolutionInput
     ) -> CreateInversionSolutionPayload:
-        return CreateInversionSolutionPayload(ok=True, inversion_solution=mutate_create_inversion_solution(info, input), client_mutation_id=input.client_mutation_id)
+        return CreateInversionSolutionPayload(
+            ok=True,
+            inversion_solution=mutate_create_inversion_solution(info, input),
+            client_mutation_id=input.client_mutation_id,
+        )
 
     @strawberry.mutation
     def create_table(self, info: strawberry.types.Info, input: CreateTableInput) -> CreateTablePayload:
-        return CreateTablePayload(ok=True, table=mutate_create_table(info, input), client_mutation_id=input.client_mutation_id)
+        return CreateTablePayload(
+            ok=True, table=mutate_create_table(info, input), client_mutation_id=input.client_mutation_id
+        )
 
     @strawberry.mutation
     def append_inversion_solution_tables(
         self, info: strawberry.types.Info, input: AppendInversionSolutionTablesInput
     ) -> AppendInversionSolutionTablesPayload:
-        return AppendInversionSolutionTablesPayload(ok=True, inversion_solution=mutate_append_inversion_solution_tables(info, input), client_mutation_id=input.client_mutation_id)
+        return AppendInversionSolutionTablesPayload(
+            ok=True,
+            inversion_solution=mutate_append_inversion_solution_tables(info, input),
+            client_mutation_id=input.client_mutation_id,
+        )
 
     @strawberry.mutation
     def create_scaled_inversion_solution(
         self, info: strawberry.types.Info, input: CreateScaledInversionSolutionInput
     ) -> CreateScaledInversionSolutionPayload:
-        return CreateScaledInversionSolutionPayload(ok=True, solution=mutate_create_scaled_inversion_solution(info, input), client_mutation_id=input.client_mutation_id)
+        return CreateScaledInversionSolutionPayload(
+            ok=True,
+            solution=mutate_create_scaled_inversion_solution(info, input),
+            client_mutation_id=input.client_mutation_id,
+        )
 
     @strawberry.mutation
     def create_aggregate_inversion_solution(
         self, info: strawberry.types.Info, input: CreateAggregateInversionSolutionInput
     ) -> CreateAggregateInversionSolutionPayload:
-        return CreateAggregateInversionSolutionPayload(ok=True, solution=mutate_create_aggregate_inversion_solution(info, input), client_mutation_id=input.client_mutation_id)
+        return CreateAggregateInversionSolutionPayload(
+            ok=True,
+            solution=mutate_create_aggregate_inversion_solution(info, input),
+            client_mutation_id=input.client_mutation_id,
+        )
 
     @strawberry.mutation
     def create_time_dependent_inversion_solution(
         self, info: strawberry.types.Info, input: CreateTimeDependentInversionSolutionInput
     ) -> CreateTimeDependentInversionSolutionPayload:
-        return CreateTimeDependentInversionSolutionPayload(ok=True, solution=mutate_create_time_dependent_inversion_solution(info, input), client_mutation_id=input.client_mutation_id)
+        return CreateTimeDependentInversionSolutionPayload(
+            ok=True,
+            solution=mutate_create_time_dependent_inversion_solution(info, input),
+            client_mutation_id=input.client_mutation_id,
+        )
 
     @strawberry.mutation
     def create_inversion_solution_nrml(
         self, info: strawberry.types.Info, input: CreateInversionSolutionNrmlInput
     ) -> CreateInversionSolutionNrmlPayload:
-        return CreateInversionSolutionNrmlPayload(ok=True, inversion_solution_nrml=mutate_create_inversion_solution_nrml(info, input), client_mutation_id=input.client_mutation_id)
+        return CreateInversionSolutionNrmlPayload(
+            ok=True,
+            inversion_solution_nrml=mutate_create_inversion_solution_nrml(info, input),
+            client_mutation_id=input.client_mutation_id,
+        )
 
     @strawberry.mutation
     def create_openquake_hazard_config(
         self, info: strawberry.types.Info, input: CreateOpenquakeHazardConfigInput
     ) -> CreateOpenquakeHazardConfigPayload:
-        return CreateOpenquakeHazardConfigPayload(ok=True, config=mutate_create_openquake_hazard_config(info, input), client_mutation_id=input.client_mutation_id)
+        return CreateOpenquakeHazardConfigPayload(
+            ok=True,
+            config=mutate_create_openquake_hazard_config(info, input),
+            client_mutation_id=input.client_mutation_id,
+        )
 
     @strawberry.mutation
     def create_openquake_hazard_solution(
         self, info: strawberry.types.Info, input: CreateOpenquakeHazardSolutionInput
     ) -> CreateOpenquakeHazardSolutionPayload:
-        return CreateOpenquakeHazardSolutionPayload(ok=True, openquake_hazard_solution=mutate_create_openquake_hazard_solution(info, input), client_mutation_id=input.client_mutation_id)
+        return CreateOpenquakeHazardSolutionPayload(
+            ok=True,
+            openquake_hazard_solution=mutate_create_openquake_hazard_solution(info, input),
+            client_mutation_id=input.client_mutation_id,
+        )
 
     @strawberry.mutation
     def create_openquake_hazard_task(
         self, info: strawberry.types.Info, input: CreateOpenquakeHazardTaskInput
     ) -> CreateOpenquakeHazardTaskPayload:
-        return CreateOpenquakeHazardTaskPayload(ok=True, task_result=mutate_create_openquake_hazard_task(info, input), client_mutation_id=input.client_mutation_id)
+        return CreateOpenquakeHazardTaskPayload(
+            ok=True,
+            task_result=mutate_create_openquake_hazard_task(info, input),
+            client_mutation_id=input.client_mutation_id,
+        )
 
     @strawberry.mutation
     def update_openquake_hazard_task(
         self, info: strawberry.types.Info, input: UpdateOpenquakeHazardTaskInput
     ) -> UpdateOpenquakeHazardTaskPayload:
-        return UpdateOpenquakeHazardTaskPayload(ok=True, task_result=mutate_update_openquake_hazard_task(info, input), client_mutation_id=input.client_mutation_id)
+        return UpdateOpenquakeHazardTaskPayload(
+            ok=True,
+            task_result=mutate_update_openquake_hazard_task(info, input),
+            client_mutation_id=input.client_mutation_id,
+        )
 
     @strawberry.mutation
     def create_file_relation(

--- a/spike/strawberry_poc/tests/test_bugfix_217_general_task.py
+++ b/spike/strawberry_poc/tests/test_bugfix_217_general_task.py
@@ -1,0 +1,43 @@
+"""Regression test for legacy bug #217 — `subtask_type` + `model_type` on GeneralTask.
+
+Ports `graphql_api/tests/test_general_task_bugfix_217.py`. The original bug
+was that the enum values OPENQUAKE_HAZARD / COMPOSITE were not round-tripping
+correctly through Graphene's enum coercion when paired with the
+`argument_lists` key-value-list payload. Pin the contract here so a future
+Strawberry enum refactor doesn't reintroduce the same shape.
+"""
+
+from schema import schema
+
+CREATE_GT = """
+mutation CreateGT($created: DateTime!) {
+    create_general_task(input: {
+        created: $created
+        title: "TEST Build opensha rupture set Coulomb #1"
+        description: "Using "
+        agent_name: "chrisbc"
+        subtask_type: OPENQUAKE_HAZARD
+        model_type: COMPOSITE
+        argument_lists: [{k: "some_metric", v: ["20", "25"]}]
+    }) {
+        general_task {
+            id
+            subtask_type
+            model_type
+        }
+    }
+}
+"""
+
+
+def test_create_general_task_with_subtype_and_model_type(gql_context):
+    res = schema.execute_sync(
+        CREATE_GT,
+        variable_values={"created": "2026-01-01T00:00:00Z"},
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    gt = res.data["create_general_task"]["general_task"]
+    assert gt["id"]
+    assert gt["subtask_type"] == "OPENQUAKE_HAZARD"
+    assert gt["model_type"] == "COMPOSITE"

--- a/spike/strawberry_poc/tests/test_bugfix_252_table_create.py
+++ b/spike/strawberry_poc/tests/test_bugfix_252_table_create.py
@@ -1,0 +1,82 @@
+"""Regression test for legacy bug #252 — table creation from runzi.
+
+Ports `graphql_api/tests/test_table_schema_fix_252.py`. The original bug
+was a Graphene-side enum serialisation error ("Object of type EnumMeta is
+not JSON serializable") when runzi sent the canonical create_table
+mutation with `column_types: [RowItemType]!` and a `dimensions` payload.
+
+The exact mutation shape comes from production runzi:
+https://github.com/GNS-Science/nzshm-runzi/blob/8c390a34d3a803fd357846aadfce21b891c9d299/runzi/automation/scaling/toshi_api/toshi_api.py#L250-L274
+
+The POC's `RowItemType` enum and `column_types` field were added in the
+weka-parity work specifically to keep this contract alive — this test
+pins it.
+"""
+
+from schema import schema
+
+CREATE_TABLE = """
+mutation CreateTable(
+    $rows: [[String!]!]!,
+    $object_id: ID!,
+    $table_name: String!,
+    $headers: [String!]!,
+    $column_types: [RowItemType!]!,
+    $created: DateTime!,
+    $table_type: TableType!,
+    $dimensions: [KeyValueListPairInput!]!
+) {
+    create_table(input: {
+        name: $table_name
+        created: $created
+        table_type: $table_type
+        dimensions: $dimensions
+        object_id: $object_id
+        column_headers: $headers
+        column_types: $column_types
+        rows: $rows
+    }) {
+        table { id }
+    }
+}
+"""
+
+CREATE_THING = """
+mutation CreateThing($input: CreateAutomationTaskInput!) {
+    create_automation_task(input: $input) { task_result { id } }
+}
+"""
+
+
+def test_create_table_runzi_shape(gql_context):
+    # Seed a parent thing whose ID is the object_id for the table.
+    thing = schema.execute_sync(
+        CREATE_THING,
+        variable_values={
+            "input": {
+                "state": "UNDEFINED",
+                "result": "UNDEFINED",
+                "task_type": "INVERSION",
+                "created": "2026-01-01T00:00:00Z",
+            }
+        },
+        context_value=gql_context,
+    )
+    assert thing.errors is None, thing.errors
+    parent_id = thing.data["create_automation_task"]["task_result"]["id"]
+
+    # Exact shape from nzshm-runzi.
+    variables = {
+        "headers": ["series", "series_name", "X", "Y"],
+        "object_id": parent_id,
+        "rows": [["0", "foo", "1.0", "2.0"], ["1", "bar", "1.5", "2.5"]],
+        "column_types": ["integer", "string", "double", "double"],
+        "table_name": "Inversion Solution MFD table",
+        "created": "2026-01-01T00:00:00Z",
+        "table_type": "MFD_CURVES",
+        "dimensions": [],
+    }
+
+    res = schema.execute_sync(CREATE_TABLE, variable_values=variables, context_value=gql_context)
+    assert res.errors is None, res.errors
+    assert res.data["create_table"]["table"]["id"]


### PR DESCRIPTION
## Summary

Addresses concerns **5** and **7** from chrisdicaprio's [PR #296 review](https://github.com/GNS-Science/nshm-toshi-api/pull/296#pullrequestreview-4454098816).

Stacked on top of #310 (`strawberry-poc-code-fixes`) — review/merge that one first.

### Concern 5 — dispatch chains collapsed to a registry

Three near-identical 14-branch `if clazz == ...` chains:
- `schema.py::_dispatch_search`
- `models/relations.py::_dispatch_file`
- `models/relations.py::_dispatch_thing`

All replaced by a single `_CLAZZ_REGISTRY` dict + three thin wrappers in `models/_dispatch.py`. Lazy imports preserved.

Net: ~110 lines of duplicated dispatch logic → ~90 lines of data-driven dispatch. Adding a new type now means one entry in the registry instead of three identical conditionals.

### Concern 7 — port the two missing bugfix-pinning tests

- `tests/test_bugfix_217_general_task.py` — GeneralTask creation with `subtask_type` + `model_type` + `argument_lists` (originally bug 217: enum + key-value-list payload coupling)
- `tests/test_bugfix_252_table_create.py` — `create_table` with the exact nzshm-runzi query shape: `column_types: [RowItemType]!`, `dimensions: [KeyValueListPairInput]!` (originally bug 252: EnumMeta JSON serialisation)

The POC's `RowItemType` enum was added in #310 specifically to keep contract alive — this test now pins it.

## Test plan

- [x] Full POC suite: **205 passed**, 1 skipped (was 203 — +2 ported tests)
- [x] All dispatch-using paths still resolve correctly: search, node lookup, file_relations, task_relations
- [x] Lint clean on touched files

## Related

- PR #310 — quick-win fixes (concerns 1, 4, 8) folded directly
- Issue #312 — concerns 2, 3, 6 deferred to production-readiness work