### PR TITLE
chore(deploy): bump yarn pin to 4.16.0 — unblock deploy-test

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,5 @@
     "serverless-s3-local": "^0.8.5",
     "serverless-wsgi": "^3.1.0"
   },
-  "packageManager": "yarn@4.14.1"
+  "packageManager": "yarn@4.16.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 9
+  version: 10
   cacheKey: 10c0
 
 "@aws-crypto/crc32@npm:5.2.0":


### PR DESCRIPTION
## Summary

Unblocks the deploy-test deploy workflow, which has been failing on every push since 2026-05-11 (7 consecutive failures).

## Root cause

The shared workflow `GNS-Science/nshm-github-actions/.github/workflows/deploy-to-aws-uv.yml` runs:

```
corepack enable
yarn set version berry          # ← forces latest berry release (currently 4.16.0)
yarn install --immutable
```

Our `packageManager` field pinned `yarn@4.14.1` (lockfile metadata `version: 9`). When `yarn set version berry` upgrades to 4.16.0, the lockfile metadata wants to bump to `version: 10`, and `--immutable` blocks it:

```
YN0028: -  version: 9
YN0028: +  version: 10
YN0028: The lockfile would have been modified by this install,
        which is explicitly forbidden.
```

Started when yarn 4.15 / 4.16 shipped the metadata bump.

## Fix

Bump the local pin to match what CI actually installs, and regenerate `yarn.lock` with v10 metadata.

```diff
- "packageManager": "yarn@4.14.1"
+ "packageManager": "yarn@4.16.0"
```

```diff
  __metadata:
-   version: 9
+   version: 10
```

No package additions / removals / version bumps. Pure metadata change.

## Test plan

- [x] `yarn install` runs clean locally with yarn 4.16.0
- [ ] CI run on this PR's push exercises the deploy workflow end-to-end (the same `yarn set version berry` + `yarn install --immutable` path) — should now go green

## Future hardening

The shared workflow's `yarn set version berry` overrides any `packageManager` pin. A separate upstream PR could drop that line so consumers can control yarn version. Out of scope for this fix; tracked informally.