### PR TITLE
chore(deploy): append `serverless info` so URLs always print

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "requirements_1": "serverless requirements clean",
     "requirements_2": "serverless requirements cleanCache",
     "dummy_pkg": "serverless package --stage dummy",
-    "deploy": "serverless deploy --stage ${STAGE}",
+    "deploy": "serverless deploy --stage ${STAGE} && serverless info --stage ${STAGE}",
     "sls_doctor": "serverless doctor"
   },
   "repository": {


### PR DESCRIPTION
## Summary

Latest deploy-test failure: `Could not extract API URL from deployment output`. Run https://github.com/GNS-Science/nshm-toshi-api/actions/runs/27250356741.

## Root cause

Serverless v4 prints:

```
No changes to deploy. Deployment skipped. (30s)
```

…when the package is up-to-date. No endpoint URLs appear in `deploy.out`. The smoketest action's `urlRegex = /https:.*/` then matches nothing, and the action fails.

The previous failed run (27249856168) actually did deploy (and would have printed URLs) — but crashed on the undici Node 20 issue (now fixed upstream by #56). After the fix, the second attempt found nothing to deploy and so printed no URLs.

## Fix

```diff
- "deploy": "serverless deploy --stage ${STAGE}",
+ "deploy": "serverless deploy --stage ${STAGE} && serverless info --stage ${STAGE}",
```

`serverless info` prints the API Gateway endpoint URLs unconditionally. Result:

- **Deploy ran**: URLs printed twice (deploy + info). Harmless.
- **Deploy skipped**: URLs printed by `info`. Smoketest now works.

## Test plan

- [ ] Push to this branch triggers `deploy-aws-lambda` → both deploy and smoketest go green