### PR TITLE
perf(strawberry-poc): cache DynamoDB client in _atomic_put (#312 concern 2)

### DIFF
--- a/spike/strawberry_poc/data/dynamo.py
+++ b/spike/strawberry_poc/data/dynamo.py
@@ -71,6 +71,23 @@ def _dynamodb(endpoint_url: str | None = None):
     return boto3.resource("dynamodb", **kwargs)
 
 
+# Low-level DynamoDB client cache, keyed by endpoint URL. The Lambda runtime
+# reuses module state across warm invocations, so this builds at most one
+# client per endpoint per cold start instead of one per write. Required by
+# `_atomic_put` — see note in that function for why we can't reuse the
+# resource's `.meta.client`. Tests use DynamoDB Local at a different endpoint
+# than production AWS, so we key by endpoint to keep both paths happy.
+_DYNAMODB_CLIENT_CACHE: dict[str, Any] = {}
+
+
+def _get_dynamodb_client(endpoint_url: str):
+    client = _DYNAMODB_CLIENT_CACHE.get(endpoint_url)
+    if client is None:
+        client = boto3.client("dynamodb", endpoint_url=endpoint_url, region_name=REGION)
+        _DYNAMODB_CLIENT_CACHE[endpoint_url] = client
+    return client
+
+
 def _thing_table(dynamodb, stage: str = STAGE):
     return dynamodb.Table(f"ToshiThingObject-{stage}")
 
@@ -173,10 +190,17 @@ def _atomic_put(dynamodb, dest_table_name: str, clazz_name: str, payload: dict, 
     Requires real DynamoDB (Local or AWS) — moto 5.x does not support
     transact_write_items across two tables.
     """
-    # boto3 resource.meta.client has a serialization issue when used for raw
-    # low-level calls — create a fresh client from the same endpoint instead.
-    endpoint_url = str(dynamodb.meta.client.meta.endpoint_url)
-    client = boto3.client("dynamodb", endpoint_url=endpoint_url, region_name=REGION)
+    # We use a low-level boto3 client (not the resource's `.meta.client`)
+    # because the call below passes raw dynamodb-native type-wrapped payloads
+    # (`{"S": ...}`, `{"N": ...}`). The resource's client has DynamoDB
+    # high-level handlers wired into its session that re-marshal the already-
+    # wrapped payload, producing `ValidationException: operand type: M` on the
+    # UpdateExpression. See GH issue #312 concern 2.
+    #
+    # Caching by endpoint URL at module scope means at most one client per
+    # cold start instead of one per write, saving ~tens of ms on every Lambda
+    # invocation that mutates state.
+    client = _get_dynamodb_client(str(dynamodb.meta.client.meta.endpoint_url))
 
     for attempt in range(10):
         current_id = read_current_id(dynamodb, stage)


### PR DESCRIPTION
## Summary

Closes #312 concern 2 — the blocker named for removing `DB_READ_ONLY=1` from `/graphql-v2` in production, and the prerequisite for the upcoming mini-Phase-4 flip (POC becomes read-write on test stage).

## Background

`_atomic_put` was instantiating a fresh `boto3.client("dynamodb", ...)` on every Lambda invocation that mutates state, paying ~tens of ms per call. The original comment said "boto3 resource.meta.client has a serialization issue when used for raw low-level calls."

I tried to use `dynamodb.meta.client` to confirm the comment was a ghost. **It wasn't.** Running the full POC suite against the resource's client produces:

```
ValidationException: Invalid UpdateExpression: Incorrect operand type
for operator or function; operator or function: +, operand type: M
```

The resource's client has DynamoDB high-level handlers wired into its session that try to re-marshal the already-wrapped payload (`{"S": ...}`, `{"N": ...}`) the call below passes, producing the `operand type: M` (Map) error.

So we **genuinely need** a low-level client — but we don't need a **new one per call**.

## Change

Module-scope cache, keyed by endpoint URL:

```python
_DYNAMODB_CLIENT_CACHE: dict[str, Any] = {}

def _get_dynamodb_client(endpoint_url: str):
    client = _DYNAMODB_CLIENT_CACHE.get(endpoint_url)
    if client is None:
        client = boto3.client("dynamodb", endpoint_url=endpoint_url, region_name=REGION)
        _DYNAMODB_CLIENT_CACHE[endpoint_url] = client
    return client
```

`_atomic_put` now calls `_get_dynamodb_client(endpoint_url)` instead of constructing in-line.

Keyed by endpoint URL so DynamoDB Local (tests) and production AWS coexist in the cache.

## Hot-path impact

- **Cold start**: ~one client construction per endpoint, same as before
- **Warm invocation**: ~zero overhead — dict lookup + return

## Test plan

- [x] Full POC suite: **251 passed**, 1 skipped
- [x] Verified the "serialization issue" reproduces with the resource's client (51 failures, all with `operand type: M`) so the cache pattern is the right fix, not "swap to the resource's client"

## What this unblocks

After this merges:
1. **Mini Phase 4** — flip POC to read-write on test stage via the `serverlessIfElse` block we discussed
2. Eventually: removing `DB_READ_ONLY=1` from production once #312 concerns 3 (env caching) and 6 (mypy/ruff) are also addressed, plus the broader cutover prep work