### PR TITLE
chore(infra): mini Phase 4 — flip read/write on test (legacy ↔ POC)

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -125,6 +125,15 @@ custom:
           - resourcee.Resources.ElasticSearchInstance
           - provider.iamrolestatements.1
           - functions.app.environment.0
+          # Mini Phase 4 (test only): the POC becomes the read-write primary.
+          # Drop its DB_READ_ONLY guard so writes succeed.
+          - functions.strawberry-poc.environment.DB_READ_ONLY
+        Set:
+          # Mini Phase 4 (test only): legacy app becomes read-only. Any client
+          # still POSTing mutations to /graphql will get a clear RuntimeError
+          # from graphql_api/data/base_data.py:347, forcing the cutover to
+          # /graphql-v2. Reads on /graphql still work.
+          functions.app.environment.DB_READ_ONLY: "1"
 
 provider:
   name: aws


### PR DESCRIPTION
## Summary

Test stage only. Prod is unchanged.

**Before** (test stage):
| Endpoint | Lambda | DB |
|---|---|---|
| `/graphql` | legacy `app` (Flask + Graphene) | read-write |
| `/graphql-v2` | `strawberry-poc` (FastAPI + Strawberry) | read-only (`DB_READ_ONLY=1`) |

**After** (test stage):
| Endpoint | Lambda | DB |
|---|---|---|
| `/graphql` | legacy `app` | **read-only** (`DB_READ_ONLY=1`) |
| `/graphql-v2` | `strawberry-poc` | **read-write** (`DB_READ_ONLY` dropped) |

## Implementation

Extends the existing `serverless-plugin-ifelse` block with two new transformations applied only when `stage == "test"`:

```yaml
Exclude:
  - functions.strawberry-poc.environment.DB_READ_ONLY
Set:
  functions.app.environment.DB_READ_ONLY: "1"
```

Both the legacy code (`graphql_api/data/base_data.py:347`) and the POC code (`spike/strawberry_poc/data/dynamo.py:43`) guard writes with the same env-var check, so flipping `DB_READ_ONLY` is sufficient. No code change.

Single-file diff, 9 lines added.

## Why this is safe

- Production deploys still set legacy = read-write, POC = read-only. The `If: stage == "test"` wraps the whole change.
- Rollback is one revert + redeploy (~5 min). For even faster recovery, override the env var on either function via the AWS Console.
- Reads on /graphql continue to work — only writes are blocked.

## What this enables

Client testing: weka, runzi, and manual scripts can be repointed at `/graphql-v2` and exercise the POC's full write path against the real test stage. That gives us a real signal on whether the POC is production-ready before the broader cutover.

## Trade-offs

1. **Any client still POSTing mutations to `/graphql` will fail** with `Aborting write operation, API config has DB_READ_ONLY == True`. That's the point — it forces the cutover.
2. **POC write hot-path cost** is fixed by #317 (cached low-level DynamoDB client). Without #317, each write costs ~tens of ms in boto3 construction; with it, ~zero overhead in warm invocations.

## Merge order

- **#317 (boto3 client caching) must merge first.** Without it, POC writes will work but each one pays the per-call boto3 construction cost. Acceptable for test-volume traffic but worth eliminating before clients hit it.
- This PR (mini Phase 4 flip) can merge any time after.

## Verification plan (after deploy)

- [ ] `POST /graphql` with a mutation → expect 500 with the `RuntimeError`
- [ ] `POST /graphql-v2` with the same mutation → expect success
- [ ] Confirm the new row appears in DynamoDB and the ES index
- [ ] Point test-weka at `/graphql-v2` and exercise a real workflow
- [ ] Check Lambda CloudWatch logs for any unexpected errors

## Related

- #317 — boto3 client caching (perf prerequisite, merge first)
- #312 — broader tracker for production-readiness items
- #295 — migration epic