### PR TITLE
docs(adrs): ADR-004 — Code Reorganization (POC → top-level)

### DIFF
--- a/docs/adrs/ADR-004-code-reorganization.md
+++ b/docs/adrs/ADR-004-code-reorganization.md
@@ -93,28 +93,21 @@ POC today and is a hard prerequisite (see *Prerequisites* below).
 
 ## Prerequisites
 
-1. **Auth-middleware parity in the POC**, validated on test stage.
-   The legacy `app` Lambda runs `auth/middleware.py`, which
-   enforces:
-   - `toshi/read` required on every authenticated request
-   - `toshi/write` required for GraphQL mutations (parses the AST,
-     fails closed on parse error)
-   - attaches `{userId, scopes, authMethod}` to request context
-   - audit-logs userId/scopes/authMethod per request
-
-   The `strawberry-poc` Lambda runs the same `jwtAuthorizer` (so
-   unauthenticated callers are rejected at API Gateway) but does
-   **no scope enforcement**, no request-context attachment, and no
-   per-request audit log. Deleting the `app` Lambda without porting
-   this layer would silently downgrade authorization: any holder of
-   a `toshi/read`-only token could mutate.
-
-   Port + tests required before this reorg can land.
+1. **Auth-middleware parity in the POC**, validated on test stage —
+   tracked in #327, implemented in #328. The legacy `app` Lambda
+   runs `auth/middleware.py`, which enforces `toshi/read` on every
+   request, `toshi/write` on mutations, attaches `{userId, scopes,
+   authMethod}` to request context, and audit-logs per request.
+   Deleting the `app` Lambda without an equivalent in the POC would
+   silently downgrade authorization (any `toshi/read`-only token
+   holder could mutate). #328 ports this as a Strawberry
+   `SchemaExtension`; must merge and be validated on test stage
+   before this reorg lands.
 
 2. Test-stage cutover complete: `/graphql` migrated off legacy.
 3. mini Phase 4 testing concluded.
 
-(2) and (3) are tracked in #295. (1) needs its own ticket.
+(2) and (3) are tracked in #295.
 
 ## Related decisions
 

--- a/docs/adrs/ADR-004-code-reorganization.md
+++ b/docs/adrs/ADR-004-code-reorganization.md
@@ -43,13 +43,18 @@ route is no longer load-bearing, a single PR:
   from `pyproject.toml`.
 - `git mv spike/strawberry_poc/* graphql_api/` (preserving subdirs:
   `models/`, `data/`, `tests/`, `tools/`).
-- Moves `strawberry_poc_handler.py` → `graphql_api/handler.py` and
-  updates the serverless function block.
+- Moves `strawberry_poc_handler.py` → `graphql_api/handler.py`.
+- Renames the serverless function `strawberry-poc` → `graphql` and
+  updates `package.include` accordingly. The URL path `/graphql-v2`
+  is unchanged — path promotion is Phase 5.
 - Replaces `spike.strawberry_poc.*` imports with `graphql_api.*`.
 - Updates CI workflow `working-directory`, pyproject coverage source,
   CLAUDE.md, and ADR-002's audit footer paths.
 - Consolidates `spike/strawberry_poc/pyproject.toml` into the top-level
   one.
+
+Both `spike` and `poc` naming disappear from source, deploy config,
+and Lambda function names in this PR.
 
 The previous draft of this ADR split this into three PRs (prune,
 rename, cleanup) on the assumption a side-by-side review window was

--- a/docs/adrs/ADR-004-code-reorganization.md
+++ b/docs/adrs/ADR-004-code-reorganization.md
@@ -1,4 +1,4 @@
-# ADR-004: Code Reorganization — Promote the Strawberry POC to a Top-Level Package
+# ADR-004: Code Reorganization — Promote the Strawberry POC to `graphql_api/`
 
 ## Status
 
@@ -7,242 +7,93 @@ Proposed.
 ## Context
 
 The Strawberry/FastAPI implementation lives at `spike/strawberry_poc/` —
-the original "feasibility spike" location, never updated as the work
-grew from a feasibility check into the substantive replacement for
-`graphql_api/`. Today the directory contains:
+the original feasibility-spike location, never moved as the work grew
+into the substantive replacement for `graphql_api/`. As of #318 the
+test-stage Lambda serves **all writes** through the POC at
+`/test/graphql-v2`; the legacy Flask/Graphene stack at `/test/graphql`
+is read-only.
 
-- ~30 model files and a custom schema layer (`spike/strawberry_poc/models/`, `schema.py`)
-- A complete data layer (`data/dynamo.py`, `data/s3.py`, `data/search.py`)
-- 30+ test modules (~250+ passing tests on the test stage)
-- ADR-002 interface implementations + the audit closures
-- Its own `pyproject.toml`, `tox.ini`, and tooling under `tools/`
+Calling that code "spike" is now misleading: new contributors hit
+`spike/strawberry_poc/` and reasonably assume it's experimental, and
+tooling (CI working-directory, IDE config, pytest discovery) has to be
+configured for a non-standard layout.
 
-It is *de facto* the project's GraphQL API: as of #318 (mini Phase 4)
-the test-stage Lambda `nzshm22-toshi-api-test-strawberry-poc` serves
-**all writes** at `/test/graphql-v2`, with the legacy Flask/Graphene
-stack at `/test/graphql` deliberately downgraded to read-only. Calling
-that code "spike" is now misleading. New contributors hit
-`spike/strawberry_poc/` and reasonably assume it is experimental. Git
-history searches need to know to look there. Tooling (linters, IDEs,
-test discovery) has to be configured for a non-standard layout.
-
-The cutover plan in issue #295 names this work as **Phase 1 — Code
-reorg** (POC → top-level), separately from **Phase 2 — Legacy
-pruning** (delete `graphql_api/`). The two phases were proposed
-separately because they answer different questions: "where does the
-new code live?" and "when do we delete the old code?" — and the order
-between them matters.
-
-This ADR fixes both: the target location, and the sequencing.
-
-### What this ADR is *not* about
-
-- *Whether* to migrate from Graphene/Flask to Strawberry/FastAPI —
-  that decision was made implicitly by the spike work shipping all the
-  way through mini Phase 4. The migration is happening; this ADR is
-  about how to land it.
-- *When* to flip production — Phase 4 (traffic flip on prod) and Phase
-  5 (path promotion) have their own ADRs to come.
-- *The numbering drift in ADR-001 / ADR-002.* Both predict
-  `ADR-003 = scalar policy`, but ADR-003 was actually used by
-  chrisdicaprio for the Cognito permission model (good and useful
-  work). Future scalar/deprecation/camelCase ADRs will land as
-  ADR-005, ADR-006, ADR-007 in chronological order.
+The cutover plan in #295 named this work as Phase 1 (reorg) and
+Phase 2 (legacy pruning). Because all validation happens on the test
+stage — there is no parallel testing in prod — the two phases
+collapse into a single landing.
 
 ## Decision
 
 ### 1. Target location: `graphql_api/`
 
-`spike/strawberry_poc/` → `graphql_api/`. The same path the legacy
-code occupies today.
+`spike/strawberry_poc/` → `graphql_api/`, the same path the legacy
+code occupies today. Keeps the existing package name that downstream
+tooling already knows, and gives the idiomatic
+`from graphql_api.schema import schema` import path.
 
-Alternatives considered:
+### 2. One PR, not three
 
-| Option | Verdict | Why |
-|---|---|---|
-| **`graphql_api/`** (replace legacy) | ✅ adopt | Single canonical location; matches what new contributors expect; importable as `graphql_api.schema` (industry-norm shape) |
-| `graphql/` (no `_api` suffix) | ❌ reject | Saves one suffix; loses continuity with the existing package name that downstream tooling (CI, IDE configs, GH search) already knows |
-| `graphql_v2/` (versioned) | ❌ reject | "v2" is the path-versioning baggage we're explicitly removing in Phase 5 (see *ADR-002 §3a Ex-D* discussion of `/graphql-v2`). The same logic applies to the package name |
-| `api/` (generic) | ❌ reject | Too generic; nothing in the name tells you it's GraphQL |
-| Keep `spike/strawberry_poc/` | ❌ reject | "spike" semantically wrong; loses the discoverability win that motivated this ADR |
+Once the test-stage cutover is complete and the legacy `/graphql`
+route is no longer load-bearing, a single PR:
 
-### 2. Sequence: legacy pruning happens **before** the rename
+- Deletes `graphql_api/` (the Flask/Graphene code) and the `app`
+  Lambda from `serverless.yml`.
+- Drops legacy deps (`graphene`, `flask`, `pynamodb`, `serverless-wsgi`)
+  from `pyproject.toml`.
+- `git mv spike/strawberry_poc/* graphql_api/` (preserving subdirs:
+  `models/`, `data/`, `tests/`, `tools/`).
+- Moves `strawberry_poc_handler.py` → `graphql_api/handler.py` and
+  updates the serverless function block.
+- Replaces `spike.strawberry_poc.*` imports with `graphql_api.*`.
+- Updates CI workflow `working-directory`, pyproject coverage source,
+  CLAUDE.md, and ADR-002's audit footer paths.
+- Consolidates `spike/strawberry_poc/pyproject.toml` into the top-level
+  one.
 
-Phases 1 (reorg) and 2 (pruning) get coordinated into a single
-sequence of three PRs:
+The previous draft of this ADR split this into three PRs (prune,
+rename, cleanup) on the assumption a side-by-side review window was
+needed. Without parallel prod testing, the staging buys nothing: a
+half-pruned or half-renamed tree is a broken intermediate, and the
+diff is large but mechanical.
 
-1. **PR-A — Legacy retirement (Phase 2, blocking on cutover completion).**
-   Delete `graphql_api/` (the Flask/Graphene code, ~12k LOC and ~178
-   legacy tests). Drop the `app` Lambda from `serverless.yml`. Drop
-   `serverless-wsgi`, `graphene`, `flask`, `pynamodb` from
-   `pyproject.toml`. After this PR, the path `graphql_api/` is free.
-   *Must wait until the live `/graphql` route has been migrated to the
-   POC — see Phase 5 in #295.*
+### 3. Use `git mv`
 
-2. **PR-B — Reorg (Phase 1, immediately after PR-A merges).**
-   `git mv spike/strawberry_poc/* graphql_api/` plus the
-   sub-directories. Update internal imports (`spike.strawberry_poc.*` →
-   `graphql_api.*`). Update the Lambda handler reference in
-   `serverless.yml` (`strawberry_poc_handler.handler` →
-   `graphql_api.handler.handler` or equivalent). Update the CI
-   workflow's `working-directory` from `spike/strawberry_poc` to
-   `graphql_api`. Update `pyproject.toml`'s test target and
-   `tool.coverage.source` settings.
+Preserves blame and `git log --follow`. Strawberry interface tracing
+and ADR-002 back-references depend on it.
 
-3. **PR-C — Cleanup (Phase 1 follow-up, low-priority).** Delete the
-   now-empty `spike/` directory if no other spike work remains there
-   (currently `spike/auth/` is still active — leave it alone in PR-B,
-   handle in a separate decision). Update any remaining doc cross-
-   references that pointed at `spike/strawberry_poc/` (CLAUDE.md,
-   READMEs, ADR-002's audit footer, etc.).
+### 4. `spike/` stays for `spike/auth/`
 
-### Why prune-first, not rename-first
-
-Three options for the sequence were considered:
-
-| Order | Verdict | Why |
-|---|---|---|
-| **Prune, then rename** (chosen) | ✅ adopt | Each PR is reviewable in isolation; no temporary "two implementations at top level" state; legacy `graphql_api/` becomes vacant cleanly, POC slides in |
-| Rename POC to `graphql_api_v2/`, prune legacy, rename `_v2` → final name | ❌ reject | Three PRs instead of two; awkward intermediate state; lots of churn in import paths and tooling |
-| Mega-PR: prune + rename in one swoop | ❌ reject | Diff would be enormous (delete 12k LOC, move 30+ files, fix all imports). Review-hostile and revert-hostile |
-
-### 3. Tooling: `git mv` over `git rm` + `git add`
-
-Use `git mv` (or rename detection via `-M` on the diff) so blame and
-history survive the move. Strawberry interface tracing, ADR-002 audit
-back-references, and `git log --follow` on individual files all
-depend on this.
-
-### 4. Test location: alongside source as a sibling
-
-`graphql_api/tests/` — same convention as the current POC layout
-(`spike/strawberry_poc/tests/`). The legacy code also used that path;
-it's vacant once PR-A lands. Pytest convention allows either
-side-by-side or top-level `tests/`; we keep side-by-side because (a)
-it matches existing POC habit, (b) it makes `graphql_api/` a single
-self-contained package.
-
-### 5. Lambda handler entry point
-
-The POC currently uses `strawberry_poc_handler.py` at the repo root
-(per `spike/strawberry_poc/COVERAGE_GAPS.md`'s package include block).
-After PR-B, it moves to `graphql_api/handler.py` and the serverless.yml
-function block updates accordingly. No deploy-time URL change.
-
-### 6. `pyproject.toml` consolidation
-
-The POC has its own `pyproject.toml` at `spike/strawberry_poc/`. After
-PR-B that file moves to `graphql_api/pyproject.toml`. The top-level
-`pyproject.toml` was updated in #310 to include the POC's runtime
-dependencies (`strawberry-graphql[fastapi]`, `mangum`, `pydantic`);
-PR-A will additionally remove the legacy deps (`graphene`, `flask`,
-`pynamodb`). The two `pyproject.toml`s coexist briefly; PR-B
-reconciles into one top-level file.
+`spike/auth/` is still active and out of scope here. Whether it
+graduates to a top-level location is a separate decision.
 
 ## Consequences
 
 ### Positive
 
-- **Discoverability**: new contributors find the code at the obvious
-  path. `graphql_api/` is what the package is called, and it lives at
-  the top level alongside `auth/`, `docs/`, etc.
-- **Tooling alignment**: IDE jump-to-definition, `pytest tests/`,
-  Codecov reports, sphinx autodoc (if/when added) — all stop needing
-  bespoke configuration for an in-tree spike directory.
-- **Import paths become idiomatic**: `from graphql_api.schema import schema`
-  instead of `from spike.strawberry_poc.schema import schema`. Matches
-  what clients writing custom test harnesses would expect.
-- **Ends the "spike" misnomer**: removes a friction point in PR review
-  ("wait, are we still calling this experimental?").
+- One canonical location. Discoverable, idiomatic imports,
+  no bespoke tooling config.
+- Ends the "spike" misnomer that keeps surfacing in review.
 
 ### Negative
 
-- **One coordinated review window** during the PR-A → PR-B sequence
-  where contributors stage work against both `spike/strawberry_poc/`
-  and (after merge) `graphql_api/`. Mitigated by landing both PRs
-  same-day where possible.
-- **Internal-import churn**: every file under `spike/strawberry_poc/`
-  that uses internal absolute imports needs updating. PR-B is
-  predominantly `sed`-able but each test file's `from schema import schema`
-  shorthand depends on `pythonpath` settings — those need to update too.
-- **Out-of-tree consumers** (none known) that imported from
-  `spike.strawberry_poc.*` would break. Audit before PR-B.
+- Large diff (~30–50 files, mostly path substitutions). Mechanical;
+  parity is verified by re-running the schema parity tool and the
+  full test suite.
+- Any out-of-tree consumer importing `spike.strawberry_poc.*` would
+  break. None known — audit before merge.
 
-### Neutral
+## Prerequisites
 
-- **`spike/` directory remains** for as long as `spike/auth/` does. PR-B
-  does not touch it. Whether `spike/auth/` graduates to top-level (with
-  its own ADR) is out of scope here.
+1. Test-stage cutover complete: `/graphql` migrated off legacy.
+2. mini Phase 4 testing concluded.
 
-## Implementation plan for PR-B
-
-Once PR-A has merged and `graphql_api/` is vacant:
-
-1. `git mv spike/strawberry_poc/* graphql_api/`
-   (preserve subdirectories — `models/`, `data/`, `tests/`, `tools/`)
-2. Move `strawberry_poc_handler.py` → `graphql_api/handler.py`
-3. Replace `from spike.strawberry_poc.X` and `from spike.strawberry_poc import X`
-   with `from graphql_api.X` / `from graphql_api import X` across:
-   - Source files under `graphql_api/`
-   - The Lambda handler
-   - Top-level pyproject.toml package config
-   - CI workflow `working-directory`
-4. Update `serverless.yml`:
-   - `handler:` path
-   - `package.include` (`spike/strawberry_poc/**` → `graphql_api/**`)
-   - `package.exclude` (drop the now-irrelevant `spike/` exclude)
-5. Consolidate `pyproject.toml`s into the top-level one; remove
-   `spike/strawberry_poc/pyproject.toml`.
-6. Update CLAUDE.md (its current spike-directory references) and any
-   README that points at `spike/strawberry_poc/`.
-7. Update `docs/adrs/ADR-002` "Post-implementation audit" section's
-   path references for code-reorg accuracy.
-8. Run the full suite under the new layout; confirm 250+ tests pass.
-9. Re-run the schema parity tool — output should be byte-identical.
-
-### Estimated size
-
-PR-B is large in line count (many imports touched) but mechanical
-(near-100% sed-style edits). Estimated 30–50 files touched, ~500
-lines diff (mostly path substitutions).
-
-## Why not now
-
-Mini Phase 4 is currently in test, with chrisdicaprio exercising the
-POC writes via runzi. Moving the source while that's in progress
-would:
-
-1. Disrupt his branch state if any local checkout is needed.
-2. Add noise to subsequent CI runs (CI workflow path changes plus
-   import-path churn make `gh run view` outputs less useful to him).
-3. Block on test-stage rollback if any of his findings need a quick
-   POC patch — the import paths would have just shifted.
-
-Therefore PR-A and PR-B both wait for:
-
-1. mini Phase 4 testing to conclude (chrisdicaprio's blessing).
-2. The cutover decision to move `/graphql` from legacy to POC on test
-   stage (which makes PR-A safe — legacy code can be deleted only
-   after the live `/graphql` route stops pointing at it).
-
-Once those two prerequisites are met, PR-A → PR-B can land back to
-back, probably within the same day.
+Both are tracked in #295.
 
 ## Related decisions
 
 - [ADR-001](ADR-001-graphql-schema-evolution-strategy.md) — schema
-  evolution strategy. The reorg doesn't change schema semantics; it
-  just moves where the schema-implementing code lives.
+  evolution.
 - [ADR-002](ADR-002-schema-interface-hierarchy-and-input-naming.md) —
-  interface hierarchy & input naming. The "Post-implementation
-  audit" section there has paths that point at `spike/strawberry_poc/`;
-  those need updating in PR-B.
-- (Future) ADR-005: Custom scalar policy.
-- (Future) ADR-006: Deprecation logging and sunset policy — how we
-  measure deprecated-field usage and when we remove (ADR-001 Phase 3).
-- (Future) ADR-007: snake_case vs camelCase for client-facing fields
-  — strategic call on whether to undertake the broader migration.
-- (Future) ADR-NNN: `spike/auth/` graduation — whether the auth
-  middleware moves to a top-level `auth/` location (note: the
-  authorizer already lives at `auth/`; only `spike/auth/middleware.py`
-  and friends are in spike).
+  the audit section there points at `spike/strawberry_poc/`; update
+  in this PR.

--- a/docs/adrs/ADR-004-code-reorganization.md
+++ b/docs/adrs/ADR-004-code-reorganization.md
@@ -67,10 +67,13 @@ diff is large but mechanical.
 Preserves blame and `git log --follow`. Strawberry interface tracing
 and ADR-002 back-references depend on it.
 
-### 4. `spike/` stays for `spike/auth/`
+### 4. `auth/` is unchanged
 
-`spike/auth/` is still active and out of scope here. Whether it
-graduates to a top-level location is a separate decision.
+The top-level `auth/` package (Lambda authorizer, Cognito CLIs,
+m2m secret tooling) is unchanged by this reorg. `auth/middleware.py`
+— the Flask `before_request` hook that enforces `toshi/read` on every
+request and `toshi/write` on mutations — has no equivalent in the
+POC today and is a hard prerequisite (see *Prerequisites* below).
 
 ## Consequences
 
@@ -90,10 +93,28 @@ graduates to a top-level location is a separate decision.
 
 ## Prerequisites
 
-1. Test-stage cutover complete: `/graphql` migrated off legacy.
-2. mini Phase 4 testing concluded.
+1. **Auth-middleware parity in the POC**, validated on test stage.
+   The legacy `app` Lambda runs `auth/middleware.py`, which
+   enforces:
+   - `toshi/read` required on every authenticated request
+   - `toshi/write` required for GraphQL mutations (parses the AST,
+     fails closed on parse error)
+   - attaches `{userId, scopes, authMethod}` to request context
+   - audit-logs userId/scopes/authMethod per request
 
-Both are tracked in #295.
+   The `strawberry-poc` Lambda runs the same `jwtAuthorizer` (so
+   unauthenticated callers are rejected at API Gateway) but does
+   **no scope enforcement**, no request-context attachment, and no
+   per-request audit log. Deleting the `app` Lambda without porting
+   this layer would silently downgrade authorization: any holder of
+   a `toshi/read`-only token could mutate.
+
+   Port + tests required before this reorg can land.
+
+2. Test-stage cutover complete: `/graphql` migrated off legacy.
+3. mini Phase 4 testing concluded.
+
+(2) and (3) are tracked in #295. (1) needs its own ticket.
 
 ## Related decisions
 

--- a/docs/adrs/ADR-004-code-reorganization.md
+++ b/docs/adrs/ADR-004-code-reorganization.md
@@ -1,0 +1,248 @@
+# ADR-004: Code Reorganization — Promote the Strawberry POC to a Top-Level Package
+
+## Status
+
+Proposed.
+
+## Context
+
+The Strawberry/FastAPI implementation lives at `spike/strawberry_poc/` —
+the original "feasibility spike" location, never updated as the work
+grew from a feasibility check into the substantive replacement for
+`graphql_api/`. Today the directory contains:
+
+- ~30 model files and a custom schema layer (`spike/strawberry_poc/models/`, `schema.py`)
+- A complete data layer (`data/dynamo.py`, `data/s3.py`, `data/search.py`)
+- 30+ test modules (~250+ passing tests on the test stage)
+- ADR-002 interface implementations + the audit closures
+- Its own `pyproject.toml`, `tox.ini`, and tooling under `tools/`
+
+It is *de facto* the project's GraphQL API: as of #318 (mini Phase 4)
+the test-stage Lambda `nzshm22-toshi-api-test-strawberry-poc` serves
+**all writes** at `/test/graphql-v2`, with the legacy Flask/Graphene
+stack at `/test/graphql` deliberately downgraded to read-only. Calling
+that code "spike" is now misleading. New contributors hit
+`spike/strawberry_poc/` and reasonably assume it is experimental. Git
+history searches need to know to look there. Tooling (linters, IDEs,
+test discovery) has to be configured for a non-standard layout.
+
+The cutover plan in issue #295 names this work as **Phase 1 — Code
+reorg** (POC → top-level), separately from **Phase 2 — Legacy
+pruning** (delete `graphql_api/`). The two phases were proposed
+separately because they answer different questions: "where does the
+new code live?" and "when do we delete the old code?" — and the order
+between them matters.
+
+This ADR fixes both: the target location, and the sequencing.
+
+### What this ADR is *not* about
+
+- *Whether* to migrate from Graphene/Flask to Strawberry/FastAPI —
+  that decision was made implicitly by the spike work shipping all the
+  way through mini Phase 4. The migration is happening; this ADR is
+  about how to land it.
+- *When* to flip production — Phase 4 (traffic flip on prod) and Phase
+  5 (path promotion) have their own ADRs to come.
+- *The numbering drift in ADR-001 / ADR-002.* Both predict
+  `ADR-003 = scalar policy`, but ADR-003 was actually used by
+  chrisdicaprio for the Cognito permission model (good and useful
+  work). Future scalar/deprecation/camelCase ADRs will land as
+  ADR-005, ADR-006, ADR-007 in chronological order.
+
+## Decision
+
+### 1. Target location: `graphql_api/`
+
+`spike/strawberry_poc/` → `graphql_api/`. The same path the legacy
+code occupies today.
+
+Alternatives considered:
+
+| Option | Verdict | Why |
+|---|---|---|
+| **`graphql_api/`** (replace legacy) | ✅ adopt | Single canonical location; matches what new contributors expect; importable as `graphql_api.schema` (industry-norm shape) |
+| `graphql/` (no `_api` suffix) | ❌ reject | Saves one suffix; loses continuity with the existing package name that downstream tooling (CI, IDE configs, GH search) already knows |
+| `graphql_v2/` (versioned) | ❌ reject | "v2" is the path-versioning baggage we're explicitly removing in Phase 5 (see *ADR-002 §3a Ex-D* discussion of `/graphql-v2`). The same logic applies to the package name |
+| `api/` (generic) | ❌ reject | Too generic; nothing in the name tells you it's GraphQL |
+| Keep `spike/strawberry_poc/` | ❌ reject | "spike" semantically wrong; loses the discoverability win that motivated this ADR |
+
+### 2. Sequence: legacy pruning happens **before** the rename
+
+Phases 1 (reorg) and 2 (pruning) get coordinated into a single
+sequence of three PRs:
+
+1. **PR-A — Legacy retirement (Phase 2, blocking on cutover completion).**
+   Delete `graphql_api/` (the Flask/Graphene code, ~12k LOC and ~178
+   legacy tests). Drop the `app` Lambda from `serverless.yml`. Drop
+   `serverless-wsgi`, `graphene`, `flask`, `pynamodb` from
+   `pyproject.toml`. After this PR, the path `graphql_api/` is free.
+   *Must wait until the live `/graphql` route has been migrated to the
+   POC — see Phase 5 in #295.*
+
+2. **PR-B — Reorg (Phase 1, immediately after PR-A merges).**
+   `git mv spike/strawberry_poc/* graphql_api/` plus the
+   sub-directories. Update internal imports (`spike.strawberry_poc.*` →
+   `graphql_api.*`). Update the Lambda handler reference in
+   `serverless.yml` (`strawberry_poc_handler.handler` →
+   `graphql_api.handler.handler` or equivalent). Update the CI
+   workflow's `working-directory` from `spike/strawberry_poc` to
+   `graphql_api`. Update `pyproject.toml`'s test target and
+   `tool.coverage.source` settings.
+
+3. **PR-C — Cleanup (Phase 1 follow-up, low-priority).** Delete the
+   now-empty `spike/` directory if no other spike work remains there
+   (currently `spike/auth/` is still active — leave it alone in PR-B,
+   handle in a separate decision). Update any remaining doc cross-
+   references that pointed at `spike/strawberry_poc/` (CLAUDE.md,
+   READMEs, ADR-002's audit footer, etc.).
+
+### Why prune-first, not rename-first
+
+Three options for the sequence were considered:
+
+| Order | Verdict | Why |
+|---|---|---|
+| **Prune, then rename** (chosen) | ✅ adopt | Each PR is reviewable in isolation; no temporary "two implementations at top level" state; legacy `graphql_api/` becomes vacant cleanly, POC slides in |
+| Rename POC to `graphql_api_v2/`, prune legacy, rename `_v2` → final name | ❌ reject | Three PRs instead of two; awkward intermediate state; lots of churn in import paths and tooling |
+| Mega-PR: prune + rename in one swoop | ❌ reject | Diff would be enormous (delete 12k LOC, move 30+ files, fix all imports). Review-hostile and revert-hostile |
+
+### 3. Tooling: `git mv` over `git rm` + `git add`
+
+Use `git mv` (or rename detection via `-M` on the diff) so blame and
+history survive the move. Strawberry interface tracing, ADR-002 audit
+back-references, and `git log --follow` on individual files all
+depend on this.
+
+### 4. Test location: alongside source as a sibling
+
+`graphql_api/tests/` — same convention as the current POC layout
+(`spike/strawberry_poc/tests/`). The legacy code also used that path;
+it's vacant once PR-A lands. Pytest convention allows either
+side-by-side or top-level `tests/`; we keep side-by-side because (a)
+it matches existing POC habit, (b) it makes `graphql_api/` a single
+self-contained package.
+
+### 5. Lambda handler entry point
+
+The POC currently uses `strawberry_poc_handler.py` at the repo root
+(per `spike/strawberry_poc/COVERAGE_GAPS.md`'s package include block).
+After PR-B, it moves to `graphql_api/handler.py` and the serverless.yml
+function block updates accordingly. No deploy-time URL change.
+
+### 6. `pyproject.toml` consolidation
+
+The POC has its own `pyproject.toml` at `spike/strawberry_poc/`. After
+PR-B that file moves to `graphql_api/pyproject.toml`. The top-level
+`pyproject.toml` was updated in #310 to include the POC's runtime
+dependencies (`strawberry-graphql[fastapi]`, `mangum`, `pydantic`);
+PR-A will additionally remove the legacy deps (`graphene`, `flask`,
+`pynamodb`). The two `pyproject.toml`s coexist briefly; PR-B
+reconciles into one top-level file.
+
+## Consequences
+
+### Positive
+
+- **Discoverability**: new contributors find the code at the obvious
+  path. `graphql_api/` is what the package is called, and it lives at
+  the top level alongside `auth/`, `docs/`, etc.
+- **Tooling alignment**: IDE jump-to-definition, `pytest tests/`,
+  Codecov reports, sphinx autodoc (if/when added) — all stop needing
+  bespoke configuration for an in-tree spike directory.
+- **Import paths become idiomatic**: `from graphql_api.schema import schema`
+  instead of `from spike.strawberry_poc.schema import schema`. Matches
+  what clients writing custom test harnesses would expect.
+- **Ends the "spike" misnomer**: removes a friction point in PR review
+  ("wait, are we still calling this experimental?").
+
+### Negative
+
+- **One coordinated review window** during the PR-A → PR-B sequence
+  where contributors stage work against both `spike/strawberry_poc/`
+  and (after merge) `graphql_api/`. Mitigated by landing both PRs
+  same-day where possible.
+- **Internal-import churn**: every file under `spike/strawberry_poc/`
+  that uses internal absolute imports needs updating. PR-B is
+  predominantly `sed`-able but each test file's `from schema import schema`
+  shorthand depends on `pythonpath` settings — those need to update too.
+- **Out-of-tree consumers** (none known) that imported from
+  `spike.strawberry_poc.*` would break. Audit before PR-B.
+
+### Neutral
+
+- **`spike/` directory remains** for as long as `spike/auth/` does. PR-B
+  does not touch it. Whether `spike/auth/` graduates to top-level (with
+  its own ADR) is out of scope here.
+
+## Implementation plan for PR-B
+
+Once PR-A has merged and `graphql_api/` is vacant:
+
+1. `git mv spike/strawberry_poc/* graphql_api/`
+   (preserve subdirectories — `models/`, `data/`, `tests/`, `tools/`)
+2. Move `strawberry_poc_handler.py` → `graphql_api/handler.py`
+3. Replace `from spike.strawberry_poc.X` and `from spike.strawberry_poc import X`
+   with `from graphql_api.X` / `from graphql_api import X` across:
+   - Source files under `graphql_api/`
+   - The Lambda handler
+   - Top-level pyproject.toml package config
+   - CI workflow `working-directory`
+4. Update `serverless.yml`:
+   - `handler:` path
+   - `package.include` (`spike/strawberry_poc/**` → `graphql_api/**`)
+   - `package.exclude` (drop the now-irrelevant `spike/` exclude)
+5. Consolidate `pyproject.toml`s into the top-level one; remove
+   `spike/strawberry_poc/pyproject.toml`.
+6. Update CLAUDE.md (its current spike-directory references) and any
+   README that points at `spike/strawberry_poc/`.
+7. Update `docs/adrs/ADR-002` "Post-implementation audit" section's
+   path references for code-reorg accuracy.
+8. Run the full suite under the new layout; confirm 250+ tests pass.
+9. Re-run the schema parity tool — output should be byte-identical.
+
+### Estimated size
+
+PR-B is large in line count (many imports touched) but mechanical
+(near-100% sed-style edits). Estimated 30–50 files touched, ~500
+lines diff (mostly path substitutions).
+
+## Why not now
+
+Mini Phase 4 is currently in test, with chrisdicaprio exercising the
+POC writes via runzi. Moving the source while that's in progress
+would:
+
+1. Disrupt his branch state if any local checkout is needed.
+2. Add noise to subsequent CI runs (CI workflow path changes plus
+   import-path churn make `gh run view` outputs less useful to him).
+3. Block on test-stage rollback if any of his findings need a quick
+   POC patch — the import paths would have just shifted.
+
+Therefore PR-A and PR-B both wait for:
+
+1. mini Phase 4 testing to conclude (chrisdicaprio's blessing).
+2. The cutover decision to move `/graphql` from legacy to POC on test
+   stage (which makes PR-A safe — legacy code can be deleted only
+   after the live `/graphql` route stops pointing at it).
+
+Once those two prerequisites are met, PR-A → PR-B can land back to
+back, probably within the same day.
+
+## Related decisions
+
+- [ADR-001](ADR-001-graphql-schema-evolution-strategy.md) — schema
+  evolution strategy. The reorg doesn't change schema semantics; it
+  just moves where the schema-implementing code lives.
+- [ADR-002](ADR-002-schema-interface-hierarchy-and-input-naming.md) —
+  interface hierarchy & input naming. The "Post-implementation
+  audit" section there has paths that point at `spike/strawberry_poc/`;
+  those need updating in PR-B.
+- (Future) ADR-005: Custom scalar policy.
+- (Future) ADR-006: Deprecation logging and sunset policy — how we
+  measure deprecated-field usage and when we remove (ADR-001 Phase 3).
+- (Future) ADR-007: snake_case vs camelCase for client-facing fields
+  — strategic call on whether to undertake the broader migration.
+- (Future) ADR-NNN: `spike/auth/` graduation — whether the auth
+  middleware moves to a top-level `auth/` location (note: the
+  authorizer already lives at `auth/`; only `spike/auth/middleware.py`
+  and friends are in spike).

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -83,3 +83,4 @@ leave the file in place).
 | [ADR-001](ADR-001-graphql-schema-evolution-strategy.md) | GraphQL Schema Evolution Strategy: Legacy Parity, Modern Defaults, Deprecation Aliases | Proposed |
 | [ADR-002](ADR-002-schema-interface-hierarchy-and-input-naming.md) | Schema Interface Hierarchy and Input Naming Conventions | Accepted |
 | [ADR-003](ADR-003-cognito-permission-model.md) | Cognito Permission Model: Two Axes and a Cumulative AWS Ladder | Accepted |
+| [ADR-004](ADR-004-code-reorganization.md) | Code Reorganization — Promote the Strawberry POC to a Top-Level Package | Proposed |


### PR DESCRIPTION
## Summary

Drafts the structural decision for **Phase 1 of #295** (migration epic). The Strawberry/FastAPI work that started life at `spike/strawberry_poc/` is now *de facto* the project's GraphQL API — the test stage serves all writes through it after #318 (mini Phase 4). The "spike" naming is misleading and the layout makes tooling configuration awkward.

## Decisions in the ADR

1. **Target location**: `spike/strawberry_poc/` → `graphql_api/` (replacing the legacy path).
2. **Sequence**: prune legacy first, then rename. Three follow-up PRs (PR-A, PR-B, PR-C).
3. **Tooling**: `git mv` so blame and history survive.
4. **Test location**: `graphql_api/tests/` (side-by-side, matches current habit).
5. **Lambda handler**: `strawberry_poc_handler.py` → `graphql_api/handler.py` — no URL change.
6. **pyproject.toml consolidation**: POC's file folds into the top-level one.

## Why this is a doc-only PR

The implementation (PR-A → PR-B → PR-C) is deliberately gated. The ADR documents the gates:

- **PR-A blocks on** the cutover decision to move `/graphql` from legacy to POC on test stage. Legacy code can be deleted only after the live `/graphql` route stops pointing at it.
- **PR-B blocks on** PR-A merging.
- All three block on chrisdicaprio's mini-Phase-4 runzi testing concluding cleanly.

So this PR is purely the decision record — safe to merge any time, doesn't move any code.

## Numbering note in the ADR

ADR-001 and ADR-002 both predicted `ADR-003 = scalar policy`, but ADR-003 was actually used by chrisdicaprio for the Cognito permission model. The ADR-004 status section calls out the drift; future scalar/deprecation/camelCase ADRs land as ADR-005/006/007 in chronological order.

## Related

- #295 — migration epic (Phase 1 = this work)
- #318 — mini Phase 4 (the read-write flip on test stage)
- #312 — production-readiness tracker
- ADR-002 §3a — the audit footer that needs path updates in eventual PR-B
