### PR TITLE
fix(strawberry-poc): wire post_url on all file types + align create_file/create_file_relation with legacy positional-arg SDL

### DIFF
--- a/spike/strawberry_poc/models/aggregate_inversion_solution.py
+++ b/spike/strawberry_poc/models/aggregate_inversion_solution.py
@@ -10,6 +10,7 @@ from strawberry.types import Info
 
 from data.dynamo import create_file, get_file, list_files
 from data.models import AggregateInversionSolutionData
+from data.s3 import presigned_post_for_file
 
 from .common import AggregationFn, BigInt, DateTime, KeyValuePair, KeyValuePairInput, _try_enum, client_mutation_id_input_field
 from .file_interface import FileInterface
@@ -130,4 +131,8 @@ def mutate_create_aggregate_inversion_solution(
         "predecessors": predecessors,
     }
     data = create_file(info.context["dynamodb"], "AggregateInversionSolution", payload)
-    return AggregateInversionSolution.from_dict(data)
+    instance = AggregateInversionSolution.from_dict(data)
+    # Surface a presigned-POST so nshm-toshi-client / runzi can upload the
+    # file bytes via the standard FileInterface handshake.
+    instance.post_url_data = presigned_post_for_file(instance.pk, input.file_name, input.md5_digest)
+    return instance

--- a/spike/strawberry_poc/models/file.py
+++ b/spike/strawberry_poc/models/file.py
@@ -15,6 +15,7 @@ from strawberry.types import Info
 
 from data.dynamo import create_file, get_file, list_files
 from data.models import ToshiFileData
+from data.s3 import presigned_post_for_file
 
 from .common import BigInt, DateTime, KeyValuePair, KeyValuePairInput, client_mutation_id_input_field
 from .file_interface import FileInterface
@@ -84,4 +85,8 @@ def mutate_create_file(info: Info, input: CreateFileInput) -> ToshiFile:
         "created": input.created,
     }
     data = create_file(info.context["dynamodb"], "File", payload)
-    return ToshiFile.from_dict(data)
+    instance = ToshiFile.from_dict(data)
+    # Surface a presigned-POST so nshm-toshi-client / runzi can upload the
+    # file bytes via the standard FileInterface handshake.
+    instance.post_url_data = presigned_post_for_file(instance.pk, input.file_name, input.md5_digest)
+    return instance

--- a/spike/strawberry_poc/models/inversion_solution.py
+++ b/spike/strawberry_poc/models/inversion_solution.py
@@ -18,6 +18,7 @@ from strawberry.types import Info
 
 from data.dynamo import _file_table, create_file, get_file, list_files
 from data.models import InversionSolutionData
+from data.s3 import presigned_post_for_file
 
 from .common import (
     BigInt,
@@ -180,7 +181,11 @@ def mutate_create_inversion_solution(info: Info, input: CreateInversionSolutionI
         "predecessors": predecessors,
     }
     data = create_file(info.context["dynamodb"], "InversionSolution", payload)
-    return InversionSolution.from_dict(data)
+    instance = InversionSolution.from_dict(data)
+    # Surface a presigned-POST so nshm-toshi-client / runzi can upload the
+    # file bytes via the standard FileInterface handshake.
+    instance.post_url_data = presigned_post_for_file(instance.pk, input.file_name, input.md5_digest)
+    return instance
 
 
 def mutate_append_inversion_solution_tables(

--- a/spike/strawberry_poc/models/inversion_solution_nrml.py
+++ b/spike/strawberry_poc/models/inversion_solution_nrml.py
@@ -10,6 +10,7 @@ from strawberry.types import Info
 
 from data.dynamo import create_file, get_file, list_files
 from data.models import InversionSolutionNrmlData
+from data.s3 import presigned_post_for_file
 
 from .common import BigInt, DateTime, KeyValuePair, KeyValuePairInput, client_mutation_id_input_field
 from .file_interface import FileInterface
@@ -86,4 +87,8 @@ def mutate_create_inversion_solution_nrml(info: Info, input: CreateInversionSolu
         "predecessors": predecessors,
     }
     data = create_file(info.context["dynamodb"], "InversionSolutionNrml", payload)
-    return InversionSolutionNrml.from_dict(data)
+    instance = InversionSolutionNrml.from_dict(data)
+    # Surface a presigned-POST so nshm-toshi-client / runzi can upload the
+    # file bytes via the standard FileInterface handshake.
+    instance.post_url_data = presigned_post_for_file(instance.pk, input.file_name, input.md5_digest)
+    return instance

--- a/spike/strawberry_poc/models/scaled_inversion_solution.py
+++ b/spike/strawberry_poc/models/scaled_inversion_solution.py
@@ -10,6 +10,7 @@ from strawberry.types import Info
 
 from data.dynamo import create_file, get_file, list_files
 from data.models import ScaledInversionSolutionData
+from data.s3 import presigned_post_for_file
 
 from .common import BigInt, DateTime, KeyValuePair, KeyValuePairInput, client_mutation_id_input_field
 from .file_interface import FileInterface
@@ -134,4 +135,8 @@ def mutate_create_scaled_inversion_solution(
         "predecessors": predecessors,
     }
     data = create_file(info.context["dynamodb"], "ScaledInversionSolution", payload)
-    return ScaledInversionSolution.from_dict(data)
+    instance = ScaledInversionSolution.from_dict(data)
+    # Surface a presigned-POST so nshm-toshi-client / runzi can upload the
+    # file bytes via the standard FileInterface handshake.
+    instance.post_url_data = presigned_post_for_file(instance.pk, input.file_name, input.md5_digest)
+    return instance

--- a/spike/strawberry_poc/models/time_dependent_inversion_solution.py
+++ b/spike/strawberry_poc/models/time_dependent_inversion_solution.py
@@ -10,6 +10,7 @@ from strawberry.types import Info
 
 from data.dynamo import create_file, get_file, list_files
 from data.models import TimeDependentInversionSolutionData
+from data.s3 import presigned_post_for_file
 
 from .common import BigInt, DateTime, KeyValuePair, KeyValuePairInput, client_mutation_id_input_field
 from .file_interface import FileInterface
@@ -102,4 +103,8 @@ def mutate_create_time_dependent_inversion_solution(
         "predecessors": predecessors,
     }
     data = create_file(info.context["dynamodb"], "TimeDependentInversionSolution", payload)
-    return TimeDependentInversionSolution.from_dict(data)
+    instance = TimeDependentInversionSolution.from_dict(data)
+    # Surface a presigned-POST so nshm-toshi-client / runzi can upload the
+    # file bytes via the standard FileInterface handshake.
+    instance.post_url_data = presigned_post_for_file(instance.pk, input.file_name, input.md5_digest)
+    return instance

--- a/spike/strawberry_poc/schema.py
+++ b/spike/strawberry_poc/schema.py
@@ -23,8 +23,6 @@ import data.search as _data_search
 from data.dynamo import es_key_for, get_object, scan_objects_paginated
 from data.s3 import scan_s3_paginated
 from data.search import search as es_search
-from models.page_info import CompatListConnection
-from models.common import client_mutation_id_payload_field
 from models.aggregate_inversion_solution import (
     AggregateInversionSolution,
     CreateAggregateInversionSolutionInput,
@@ -42,6 +40,13 @@ from models.automation_task import (
     mutate_update_rupture_generation_task,
     resolve_automation_tasks,
     resolve_rupture_generation_tasks,
+)
+from models.common import (
+    BigInt,
+    DateTime,
+    FileRole,
+    KeyValuePairInput,
+    client_mutation_id_payload_field,
 )
 from models.file import CreateFileInput, ToshiFile, mutate_create_file, resolve_files
 from models.general_task import (
@@ -91,6 +96,7 @@ from models.openquake_hazard_task import (
     mutate_update_openquake_hazard_task,
     resolve_openquake_hazard_tasks,
 )
+from models.page_info import CompatListConnection
 from models.relations import (
     CreateFileRelationInput,
     CreateTaskRelationInput,
@@ -507,10 +513,31 @@ class Mutation:
         )
 
     @strawberry.mutation
-    def create_file(self, info: strawberry.types.Info, input: CreateFileInput) -> CreateFilePayload:
-        return CreateFilePayload(
-            ok=True, file_result=mutate_create_file(info, input), client_mutation_id=input.client_mutation_id
+    def create_file(
+        self,
+        info: strawberry.types.Info,
+        file_name: str,
+        md5_digest: str,
+        file_size: BigInt,
+        created: DateTime | None = None,
+        meta: list[KeyValuePairInput] | None = None,
+    ) -> CreateFilePayload:
+        # Positional signature mirrors the legacy SDL `create_file(file_name,
+        # md5_digest, file_size, created, meta, predecessors): CreateFile`.
+        # nshm-toshi-client sends this shape directly; the `input:` wrapper
+        # form would reject the client's query at validation time.
+        #
+        # `predecessors` is in legacy SDL but no current client (nshm-toshi-
+        # client/runzi/weka) uses it on plain File create — omitted for now;
+        # add back if a client surfaces a need.
+        input_obj = CreateFileInput(
+            file_name=file_name,
+            md5_digest=md5_digest,
+            file_size=file_size,
+            created=created,
+            meta=meta,
         )
+        return CreateFilePayload(ok=True, file_result=mutate_create_file(info, input_obj), client_mutation_id=None)
 
     @strawberry.mutation
     def create_sms_file(self, info: strawberry.types.Info, input: CreateSmsFileInput) -> CreateSmsFilePayload:
@@ -667,10 +694,18 @@ class Mutation:
 
     @strawberry.mutation
     def create_file_relation(
-        self, info: strawberry.types.Info, input: CreateFileRelationInput
+        self,
+        info: strawberry.types.Info,
+        file_id: strawberry.ID,
+        role: FileRole,
+        thing_id: strawberry.ID,
     ) -> CreateFileRelationPayload:
-        mutate_create_file_relation(info, input)
-        return CreateFileRelationPayload(ok=True, client_mutation_id=input.client_mutation_id)
+        # Positional signature mirrors legacy `create_file_relation(file_id,
+        # role, thing_id): CreateFileRelation`. nshm-toshi-client and runzi
+        # both send this shape; the `input:` wrapper form would be rejected.
+        input_obj = CreateFileRelationInput(file_id=file_id, role=role, thing_id=thing_id)
+        mutate_create_file_relation(info, input_obj)
+        return CreateFileRelationPayload(ok=True, client_mutation_id=None)
 
     @strawberry.mutation
     def create_task_relation(

--- a/spike/strawberry_poc/tests/test_client_mutation_id_compat.py
+++ b/spike/strawberry_poc/tests/test_client_mutation_id_compat.py
@@ -7,10 +7,8 @@ echoed back unchanged in the payload. Modern Relay 2 / Apollo clients can
 omit it entirely.
 """
 
-import pytest
 
 from schema import schema
-
 
 CREATE_WITH_CMI_MUTATION = """
 mutation CreateWithCMI($input: CreateGeneralTaskInput!) {
@@ -30,11 +28,15 @@ mutation CreateWithoutCMI($input: CreateGeneralTaskInput!) {
 }
 """
 
-CREATE_FILE_WITH_CMI_MUTATION = """
-mutation CreateFileWithCMI($input: CreateFileInput!) {
-    create_file(input: $input) {
+# Note: this test originally targeted `create_file`, but `create_file` was
+# realigned to legacy's positional-arg SDL (no `input:` wrapper, no
+# clientMutationId — see PR-after-#320). Picking another file-create mutation
+# that still uses the input-wrapper form (and therefore still supports CMI).
+CREATE_IS_WITH_CMI_MUTATION = """
+mutation CreateISWithCMI($input: CreateInversionSolutionInput!) {
+    create_inversion_solution(input: $input) {
         ok
-        file_result { id file_name }
+        inversion_solution { id file_name }
         clientMutationId
     }
 }
@@ -69,22 +71,41 @@ def test_omitted_client_mutation_id_yields_null_in_payload(gql_context):
 
 
 def test_round_trip_works_on_other_mutations(gql_context):
-    """The CMI compat field works on more than just GeneralTask mutations."""
-    cmi = "file-create-cmi"
+    """The CMI compat field works on more than just GeneralTask mutations.
+
+    Switched from create_file → create_inversion_solution because create_file
+    was realigned to legacy SDL's positional-arg shape (no input wrapper, no
+    CMI — matches what nshm-toshi-client/runzi actually send).
+    """
+    # Need a parent AutomationTask for the produced_by field.
+    import base64  # noqa: PLC0415
+
+    from data.dynamo import create_thing  # noqa: PLC0415
+
+    at_data = create_thing(
+        gql_context["dynamodb"],
+        "AutomationTask",
+        {"state": "done", "result": "success", "task_type": "INVERSION", "created": "2026-01-01T00:00:00Z"},
+    )
+    at_id = base64.b64encode(f"AutomationTask:{at_data['object_id']}".encode()).decode()
+
+    cmi = "is-create-cmi"
     result = schema.execute_sync(
-        CREATE_FILE_WITH_CMI_MUTATION,
+        CREATE_IS_WITH_CMI_MUTATION,
         variable_values={
             "input": {
                 "file_name": "cmi-test.zip",
                 "md5_digest": "abc",
                 "file_size": 1024,
+                "produced_by": at_id,
+                "created": "2026-01-01T00:00:00Z",
                 "clientMutationId": cmi,
             }
         },
         context_value=gql_context,
     )
     assert result.errors is None, result.errors
-    payload = result.data["create_file"]
+    payload = result.data["create_inversion_solution"]
     assert payload["ok"] is True
     assert payload["clientMutationId"] == cmi
 

--- a/spike/strawberry_poc/tests/test_create_file_validation.py
+++ b/spike/strawberry_poc/tests/test_create_file_validation.py
@@ -13,8 +13,8 @@ from schema import schema
 MAX_INT32 = 2**31 - 1  # 2_147_483_647
 
 CREATE_FILE_MUTATION = """
-mutation($input: CreateFileInput!) {
-    create_file(input: $input) {
+mutation($file_name: String!, $md5_digest: String!, $file_size: BigInt!, $created: DateTime = null, $meta: [KeyValuePairInput!] = null) {
+    create_file(file_name: $file_name, md5_digest: $md5_digest, file_size: $file_size, created: $created, meta: $meta) {
         ok
         file_result {
             id
@@ -31,13 +31,11 @@ def test_create_file_with_int_file_size(gql_context):
     result = schema.execute_sync(
         CREATE_FILE_MUTATION,
         variable_values={
-            "input": {
                 "file_name": "small.zip",
                 "md5_digest": "00",
                 "file_size": 1024,
                 "created": "2024-05-01T00:00:00Z",
-            }
-        },
+            },
         context_value=gql_context,
     )
     assert result.errors is None, result.errors
@@ -49,13 +47,11 @@ def test_create_file_with_max_int32_file_size(gql_context):
     result = schema.execute_sync(
         CREATE_FILE_MUTATION,
         variable_values={
-            "input": {
                 "file_name": "near_max.zip",
                 "md5_digest": "01a",
                 "file_size": MAX_INT32,
                 "created": "2024-05-01T00:00:00Z",
-            }
-        },
+            },
         context_value=gql_context,
     )
     assert result.errors is None, result.errors
@@ -68,13 +64,11 @@ def test_create_file_with_large_file_size_bigint(gql_context):
     result = schema.execute_sync(
         CREATE_FILE_MUTATION,
         variable_values={
-            "input": {
                 "file_name": "big.zip",
                 "md5_digest": "01",
                 "file_size": big,
                 "created": "2024-05-01T00:00:00Z",
-            }
-        },
+            },
         context_value=gql_context,
     )
     assert result.errors is None, result.errors
@@ -86,31 +80,32 @@ def test_create_file_rejects_string_file_size(gql_context):
     result = schema.execute_sync(
         CREATE_FILE_MUTATION,
         variable_values={
-            "input": {
                 "file_name": "bad.zip",
                 "md5_digest": "02",
                 "file_size": "not-a-number",
                 "created": "2024-05-01T00:00:00Z",
-            }
-        },
+            },
         context_value=gql_context,
     )
     assert result.errors is not None
     assert any("file_size" in str(e).lower() or "int" in str(e).lower() for e in result.errors)
 
 
-def test_create_file_with_null_file_size(gql_context):
-    """file_size omitted (null) is acceptable; the field is optional."""
+def test_create_file_rejects_missing_file_size(gql_context):
+    """file_size omitted is rejected — the field is required (matches legacy SDL).
+
+    Previously this test asserted the opposite (POC had file_size as nullable),
+    but legacy SDL has `file_size: BigInt!`. After the positional-args
+    realignment (PR-after-#320), POC follows suit.
+    """
     result = schema.execute_sync(
         CREATE_FILE_MUTATION,
         variable_values={
-            "input": {
-                "file_name": "nofsize.zip",
-                "md5_digest": "03",
-                "created": "2024-05-01T00:00:00Z",
-            }
+            "file_name": "nofsize.zip",
+            "md5_digest": "03",
+            "created": "2024-05-01T00:00:00Z",
         },
         context_value=gql_context,
     )
-    assert result.errors is None, result.errors
-    assert result.data["create_file"]["file_result"]["file_size"] is None
+    assert result.errors is not None
+    assert any("file_size" in str(e) for e in result.errors)

--- a/spike/strawberry_poc/tests/test_file_relation.py
+++ b/spike/strawberry_poc/tests/test_file_relation.py
@@ -18,8 +18,8 @@ mutation CreateTask($input: CreateAutomationTaskInput!) {
 """
 
 CREATE_FILE_MUTATION = """
-mutation CreateFile($input: CreateFileInput!) {
-    create_file(input: $input) {
+mutation CreateFile($file_name: String!, $md5_digest: String!, $file_size: BigInt!, $created: DateTime = null, $meta: [KeyValuePairInput!] = null) {
+    create_file(file_name: $file_name, md5_digest: $md5_digest, file_size: $file_size, created: $created, meta: $meta) {
         ok
         file_result { id }
     }
@@ -27,8 +27,8 @@ mutation CreateFile($input: CreateFileInput!) {
 """
 
 CREATE_FILE_RELATION_MUTATION = """
-mutation CreateFileRelation($input: CreateFileRelationInput!) {
-    create_file_relation(input: $input) {
+mutation CreateFileRelation($file_id: ID!, $role: FileRole!, $thing_id: ID!) {
+    create_file_relation(file_id: $file_id, role: $role, thing_id: $thing_id) {
         ok
     }
 }
@@ -81,13 +81,11 @@ def file_id(gql_context):
     result = schema.execute_sync(
         CREATE_FILE_MUTATION,
         variable_values={
-            "input": {
                 "file_name": "output_data.zip",
                 "md5_digest": "99aabbcc",
                 "file_size": 2048,
                 "created": "2024-08-01T00:00:00Z",
-            }
-        },
+            },
         context_value=gql_context,
     )
     assert result.errors is None, result.errors
@@ -98,7 +96,7 @@ def file_id(gql_context):
 def created_relation(gql_context, task_id, file_id):
     result = schema.execute_sync(
         CREATE_FILE_RELATION_MUTATION,
-        variable_values={"input": {"thing_id": task_id, "file_id": file_id, "role": "READ"}},
+        variable_values={"thing_id": task_id, "file_id": file_id, "role": "READ"},
         context_value=gql_context,
     )
     assert result.errors is None, result.errors

--- a/spike/strawberry_poc/tests/test_file_relation_compression.py
+++ b/spike/strawberry_poc/tests/test_file_relation_compression.py
@@ -31,8 +31,8 @@ mutation CreateTask($input: CreateAutomationTaskInput!) {
 """
 
 CREATE_FILE_MUTATION = """
-mutation CreateFile($input: CreateFileInput!) {
-    create_file(input: $input) {
+mutation CreateFile($file_name: String!, $md5_digest: String!, $file_size: BigInt!, $created: DateTime = null, $meta: [KeyValuePairInput!] = null) {
+    create_file(file_name: $file_name, md5_digest: $md5_digest, file_size: $file_size, created: $created, meta: $meta) {
         ok
         file_result { id file_name }
     }
@@ -40,8 +40,8 @@ mutation CreateFile($input: CreateFileInput!) {
 """
 
 CREATE_FILE_RELATION_MUTATION = """
-mutation CreateFileRelation($input: CreateFileRelationInput!) {
-    create_file_relation(input: $input) { ok }
+mutation CreateFileRelation($file_id: ID!, $role: FileRole!, $thing_id: ID!) {
+    create_file_relation(file_id: $file_id, role: $role, thing_id: $thing_id) { ok }
 }
 """
 
@@ -96,13 +96,11 @@ def test_relations_stored_as_list_under_threshold(gql_context, lower_threshold):
     file_result = schema.execute_sync(
         CREATE_FILE_MUTATION,
         variable_values={
-            "input": {
                 "file_name": "compression_under.zip",
                 "md5_digest": "00aa",
                 "file_size": 1024,
                 "created": "2024-07-01T00:00:00Z",
-            }
-        },
+            },
         context_value=gql_context,
     )
     assert file_result.errors is None, file_result.errors
@@ -127,9 +125,7 @@ def test_relations_stored_as_list_under_threshold(gql_context, lower_threshold):
         thing_gid = at.data["create_automation_task"]["task_result"]["id"]
         rel = schema.execute_sync(
             CREATE_FILE_RELATION_MUTATION,
-            variable_values={
-                "input": {"thing_id": thing_gid, "file_id": file_gid, "role": "READ"}
-            },
+            variable_values={"thing_id": thing_gid, "file_id": file_gid, "role": "READ"},
             context_value=gql_context,
         )
         assert rel.errors is None, rel.errors
@@ -145,13 +141,11 @@ def test_relations_compressed_above_threshold(gql_context, lower_threshold):
     file_result = schema.execute_sync(
         CREATE_FILE_MUTATION,
         variable_values={
-            "input": {
                 "file_name": "compression_over.zip",
                 "md5_digest": "01bb",
                 "file_size": 1024,
                 "created": "2024-07-02T00:00:00Z",
-            }
-        },
+            },
         context_value=gql_context,
     )
     assert file_result.errors is None, file_result.errors
@@ -176,9 +170,7 @@ def test_relations_compressed_above_threshold(gql_context, lower_threshold):
         thing_gid = at.data["create_automation_task"]["task_result"]["id"]
         rel = schema.execute_sync(
             CREATE_FILE_RELATION_MUTATION,
-            variable_values={
-                "input": {"thing_id": thing_gid, "file_id": file_gid, "role": "READ"}
-            },
+            variable_values={"thing_id": thing_gid, "file_id": file_gid, "role": "READ"},
             context_value=gql_context,
         )
         assert rel.errors is None, rel.errors
@@ -198,13 +190,11 @@ def test_relations_round_trip_through_graphql(gql_context, lower_threshold):
     file_result = schema.execute_sync(
         CREATE_FILE_MUTATION,
         variable_values={
-            "input": {
                 "file_name": "compression_roundtrip.zip",
                 "md5_digest": "02cc",
                 "file_size": 1024,
                 "created": "2024-07-03T00:00:00Z",
-            }
-        },
+            },
         context_value=gql_context,
     )
     assert file_result.errors is None, file_result.errors
@@ -229,9 +219,7 @@ def test_relations_round_trip_through_graphql(gql_context, lower_threshold):
         thing_gids.append(thing_gid)
         rel = schema.execute_sync(
             CREATE_FILE_RELATION_MUTATION,
-            variable_values={
-                "input": {"thing_id": thing_gid, "file_id": file_gid, "role": "READ"}
-            },
+            variable_values={"thing_id": thing_gid, "file_id": file_gid, "role": "READ"},
             context_value=gql_context,
         )
         assert rel.errors is None, rel.errors
@@ -255,13 +243,11 @@ def test_pre_compressed_legacy_data_reads_correctly(gql_context):
     file_result = schema.execute_sync(
         CREATE_FILE_MUTATION,
         variable_values={
-            "input": {
                 "file_name": "legacy_compressed.zip",
                 "md5_digest": "03dd",
                 "file_size": 1024,
                 "created": "2024-07-04T00:00:00Z",
-            }
-        },
+            },
         context_value=gql_context,
     )
     assert file_result.errors is None, file_result.errors

--- a/spike/strawberry_poc/tests/test_inversion_solution_interface.py
+++ b/spike/strawberry_poc/tests/test_inversion_solution_interface.py
@@ -73,8 +73,8 @@ mutation CreateSIS($input: CreateScaledInversionSolutionInput!) {
 """
 
 CREATE_FILE_RELATION_MUTATION = """
-mutation CreateFileRelation($input: CreateFileRelationInput!) {
-    create_file_relation(input: $input) {
+mutation CreateFileRelation($file_id: ID!, $role: FileRole!, $thing_id: ID!) {
+    create_file_relation(file_id: $file_id, role: $role, thing_id: $thing_id) {
         ok
     }
 }
@@ -269,7 +269,7 @@ def test_relations_total_count_after_create_file_relation(gql_context, is_with_m
     task_id = _seed_automation_task(gql_context)
     rel_result = schema.execute_sync(
         CREATE_FILE_RELATION_MUTATION,
-        variable_values={"input": {"thing_id": task_id, "file_id": is_with_mfd_table, "role": "READ"}},
+        variable_values={"thing_id": task_id, "file_id": is_with_mfd_table, "role": "READ"},
         context_value=gql_context,
     )
     assert rel_result.errors is None, rel_result.errors

--- a/spike/strawberry_poc/tests/test_nshm_toshi_client_compat.py
+++ b/spike/strawberry_poc/tests/test_nshm_toshi_client_compat.py
@@ -1,0 +1,137 @@
+"""Regression tests — exact query shapes that nshm-toshi-client sends.
+
+The wire-format issue surfaced by chrisdicaprio's mini-Phase-4 runzi testing:
+legacy `create_file` and `create_file_relation` use POSITIONAL ARGUMENTS in
+the SDL (no `input:` wrapper), and nshm-toshi-client sends them in exactly
+that shape. The POC had wrapped both in `CreateFileInput!` / `CreateFileRelationInput!`
+which rejected the client's queries at GraphQL validation time.
+
+After realignment (PR-after-#320), both mutations match legacy SDL:
+
+    create_file(file_name: String!, md5_digest: String!, file_size: BigInt!, …)
+    create_file_relation(file_id: ID!, role: FileRole!, thing_id: ID!)
+
+These tests reproduce the *exact* mutation strings nshm-toshi-client uses
+(copied verbatim from `LIB/nshm-toshi-client/nshm_toshi_client/toshi_file.py`
+and `toshi_task_file.py`), so future schema drift is caught before clients
+break in production.
+"""
+
+import base64
+
+import pytest
+
+from schema import schema
+
+# ── Verbatim from nshm-toshi-client/nshm_toshi_client/toshi_file.py ───────────
+
+NSHM_TOSHI_CLIENT_CREATE_FILE = """
+    mutation ($digest: String!, $file_name: String!, $file_size: BigInt!) {
+      create_file(
+          md5_digest: $digest
+          file_name: $file_name
+          file_size: $file_size
+      ) {
+          ok
+          file_result { id, file_name, file_size, md5_digest, post_url, meta {k v}}
+      }
+    }
+"""
+
+
+def test_nshm_toshi_client_create_file_query_shape(gql_context):
+    """The exact GraphQL string nshm-toshi-client sends must validate + execute."""
+    result = schema.execute_sync(
+        NSHM_TOSHI_CLIENT_CREATE_FILE,
+        variable_values={"digest": "abc==", "file_name": "client-test.zip", "file_size": 1024},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    file_result = result.data["create_file"]["file_result"]
+    assert file_result["file_name"] == "client-test.zip"
+    assert file_result["file_size"] == 1024
+    assert file_result["md5_digest"] == "abc=="
+
+
+# ── Verbatim from nshm-toshi-client/nshm_toshi_client/toshi_task_file.py ──────
+
+NSHM_TOSHI_CLIENT_CREATE_FILE_RELATION = """
+    mutation ($file_id: ID!, $thing_id: ID!, $role: FileRole!) {
+        create_file_relation(
+            file_id: $file_id
+            thing_id: $thing_id
+            role: $role
+        ) {
+            ok
+        }
+    }
+"""
+
+
+@pytest.fixture
+def thing_id(gql_context):
+    from data.dynamo import create_thing  # noqa: PLC0415
+
+    data = create_thing(
+        gql_context["dynamodb"],
+        "AutomationTask",
+        {"state": "done", "result": "success", "task_type": "INVERSION", "created": "2026-01-01T00:00:00Z"},
+    )
+    return base64.b64encode(f"AutomationTask:{data['object_id']}".encode()).decode()
+
+
+@pytest.fixture
+def file_id(gql_context):
+    result = schema.execute_sync(
+        NSHM_TOSHI_CLIENT_CREATE_FILE,
+        variable_values={"digest": "abc==", "file_name": "fr-test.zip", "file_size": 100},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    return result.data["create_file"]["file_result"]["id"]
+
+
+def test_nshm_toshi_client_create_file_relation_query_shape(gql_context, thing_id, file_id):
+    """The exact create_file_relation GraphQL string nshm-toshi-client sends."""
+    result = schema.execute_sync(
+        NSHM_TOSHI_CLIENT_CREATE_FILE_RELATION,
+        variable_values={"file_id": file_id, "thing_id": thing_id, "role": "WRITE"},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    assert result.data["create_file_relation"]["ok"] is True
+
+
+# ── SDL contract pins ─────────────────────────────────────────────────────────
+
+
+def test_create_file_sdl_matches_legacy_positional_shape():
+    """create_file SDL must use positional args, not input: wrapper."""
+    sdl = schema.as_str()
+    import re
+
+    m = re.search(r"create_file\([^)]+\)[^\n]+", sdl, re.S)
+    assert m, "create_file missing from SDL"
+    sig = m.group(0)
+    # Legacy SDL has these positional args; new shape must too.
+    assert "file_name: String!" in sig, f"create_file lost file_name positional: {sig}"
+    assert "md5_digest: String!" in sig, f"create_file lost md5_digest positional: {sig}"
+    assert "file_size: BigInt!" in sig, f"create_file lost file_size positional: {sig}"
+    # And must NOT have the input wrapper.
+    assert "input: CreateFileInput" not in sig, (
+        f"create_file regressed to input-wrapper form — would break nshm-toshi-client: {sig}"
+    )
+
+
+def test_create_file_relation_sdl_matches_legacy_positional_shape():
+    """create_file_relation SDL must use positional args, not input: wrapper."""
+    sdl = schema.as_str()
+    import re
+
+    m = re.search(r"create_file_relation\([^)]+\)[^\n]+", sdl, re.S)
+    assert m, "create_file_relation missing from SDL"
+    sig = m.group(0)
+    assert "file_id: ID!" in sig, f"create_file_relation lost file_id positional: {sig}"
+    assert "role: FileRole!" in sig, f"create_file_relation lost role positional: {sig}"
+    assert "thing_id: ID!" in sig, f"create_file_relation lost thing_id positional: {sig}"
+    assert "input: CreateFileRelationInput" not in sig, f"create_file_relation regressed to input-wrapper form: {sig}"

--- a/spike/strawberry_poc/tests/test_post_url_all_file_types.py
+++ b/spike/strawberry_poc/tests/test_post_url_all_file_types.py
@@ -94,8 +94,8 @@ def _assert_post_url_is_valid_json(payload: dict, file_node_key: str):
 
 def test_create_file_post_url(gql_context, s3_bucket):
     mutation = """
-    mutation CreateFile($input: CreateFileInput!) {
-        create_file(input: $input) {
+    mutation CreateFile($file_name: String!, $md5_digest: String!, $file_size: BigInt!, $created: DateTime = null, $meta: [KeyValuePairInput!] = null) {
+        create_file(file_name: $file_name, md5_digest: $md5_digest, file_size: $file_size, created: $created, meta: $meta) {
             ok
             file_result { id post_url }
         }
@@ -103,7 +103,7 @@ def test_create_file_post_url(gql_context, s3_bucket):
     """
     result = _create(
         mutation,
-        {"input": {"file_name": "f.zip", "md5_digest": "abc==", "file_size": 100}},
+        {"file_name": "f.zip", "md5_digest": "abc==", "file_size": 100},
         gql_context,
     )
     assert result.errors is None, result.errors

--- a/spike/strawberry_poc/tests/test_post_url_all_file_types.py
+++ b/spike/strawberry_poc/tests/test_post_url_all_file_types.py
@@ -1,0 +1,367 @@
+"""Regression tests — `post_url` must be populated on every file-create mutation.
+
+The Gap 4 closure in PR #310 wired `presigned_post_for_file` into
+`mutate_create_rupture_set` only. Every other file-create mutation still
+returned `null` for `post_url`, breaking nshm-toshi-client/runzi which
+unconditionally `json.loads(post_url)` after each create call.
+
+These tests lock in the contract for the remaining six file types so a
+future refactor can't quietly drop the presigned-POST again:
+
+  - create_file                       (plain File / ToshiFile)
+  - create_inversion_solution
+  - create_scaled_inversion_solution
+  - create_aggregate_inversion_solution
+  - create_time_dependent_inversion_solution
+  - create_inversion_solution_nrml
+
+For each: confirm `post_url` is a JSON string of field values that round-
+trips through `json.loads`. Doesn't repeat the full requests-based upload
+round-trip — that's already covered by test_bugfix_gap4_rupture_set.py
+and the codepath is identical.
+"""
+
+import base64
+import json
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from schema import schema
+
+_BUCKET = "toshi-strawberry-test-allfiles"
+
+
+@pytest.fixture
+def s3_bucket(monkeypatch):
+    """moto-backed S3 bucket; matches the pattern in test_bugfix_gap4_rupture_set."""
+    import data.s3 as s3_mod  # noqa: PLC0415
+
+    monkeypatch.setattr(s3_mod, "S3_BUCKET_NAME", _BUCKET)
+    with mock_aws():
+        client = boto3.client("s3", region_name=s3_mod.REGION)
+        client.create_bucket(
+            Bucket=_BUCKET,
+            CreateBucketConfiguration={"LocationConstraint": s3_mod.REGION},
+        )
+        yield client
+
+
+@pytest.fixture
+def rgt_id(gql_context):
+    from data.dynamo import create_thing  # noqa: PLC0415
+
+    data = create_thing(
+        gql_context["dynamodb"],
+        "RuptureGenerationTask",
+        {"state": "done", "result": "success", "created": "2026-01-01T00:00:00Z"},
+    )
+    raw = data["object_id"]
+    return base64.b64encode(f"RuptureGenerationTask:{raw}".encode()).decode()
+
+
+@pytest.fixture
+def at_id(gql_context):
+    from data.dynamo import create_thing  # noqa: PLC0415
+
+    data = create_thing(
+        gql_context["dynamodb"],
+        "AutomationTask",
+        {"state": "done", "result": "success", "task_type": "INVERSION", "created": "2026-01-01T00:00:00Z"},
+    )
+    raw = data["object_id"]
+    return base64.b64encode(f"AutomationTask:{raw}".encode()).decode()
+
+
+def _create(mutation: str, variables: dict, gql_context):
+    return schema.execute_sync(mutation, variable_values=variables, context_value=gql_context)
+
+
+def _assert_post_url_is_valid_json(payload: dict, file_node_key: str):
+    """Every file create response in legacy/POC returns a `post_url` that
+    nshm-toshi-client immediately `json.loads`. Confirm the contract."""
+    post_url = payload[file_node_key]["post_url"]
+    assert post_url, f"post_url is null/empty on {file_node_key} — runzi will crash on json.loads"
+    parsed = json.loads(post_url)
+    assert isinstance(parsed, dict), f"post_url did not deserialize to a dict on {file_node_key}: {parsed!r}"
+    # The presigned-POST fields dict from boto3 always contains `key`.
+    assert "key" in parsed, f"post_url fields missing `key` on {file_node_key}"
+
+
+# ── 1. Plain File / ToshiFile ─────────────────────────────────────────────────
+
+
+def test_create_file_post_url(gql_context, s3_bucket):
+    mutation = """
+    mutation CreateFile($input: CreateFileInput!) {
+        create_file(input: $input) {
+            ok
+            file_result { id post_url }
+        }
+    }
+    """
+    result = _create(
+        mutation,
+        {"input": {"file_name": "f.zip", "md5_digest": "abc==", "file_size": 100}},
+        gql_context,
+    )
+    assert result.errors is None, result.errors
+    _assert_post_url_is_valid_json(result.data["create_file"], "file_result")
+
+
+# ── 2. InversionSolution ──────────────────────────────────────────────────────
+
+
+def test_create_inversion_solution_post_url(gql_context, s3_bucket, at_id):
+    mutation = """
+    mutation CreateIS($input: CreateInversionSolutionInput!) {
+        create_inversion_solution(input: $input) {
+            ok
+            inversion_solution { id post_url }
+        }
+    }
+    """
+    result = _create(
+        mutation,
+        {
+            "input": {
+                "file_name": "is.zip",
+                "md5_digest": "abc==",
+                "file_size": 100,
+                "produced_by": at_id,
+                "created": "2026-01-01T00:00:00Z",
+            }
+        },
+        gql_context,
+    )
+    assert result.errors is None, result.errors
+    _assert_post_url_is_valid_json(result.data["create_inversion_solution"], "inversion_solution")
+
+
+# ── 3. ScaledInversionSolution ────────────────────────────────────────────────
+
+
+def test_create_scaled_inversion_solution_post_url(gql_context, s3_bucket, at_id):
+    # Need a source IS first.
+    create_is = """
+    mutation CreateIS($input: CreateInversionSolutionInput!) {
+        create_inversion_solution(input: $input) {
+            inversion_solution { id }
+        }
+    }
+    """
+    is_res = _create(
+        create_is,
+        {
+            "input": {
+                "file_name": "is.zip",
+                "md5_digest": "abc==",
+                "file_size": 100,
+                "produced_by": at_id,
+                "created": "2026-01-01T00:00:00Z",
+            }
+        },
+        gql_context,
+    )
+    assert is_res.errors is None, is_res.errors
+    source_id = is_res.data["create_inversion_solution"]["inversion_solution"]["id"]
+
+    mutation = """
+    mutation CreateSIS($input: CreateScaledInversionSolutionInput!) {
+        create_scaled_inversion_solution(input: $input) {
+            ok
+            solution { id post_url }
+        }
+    }
+    """
+    result = _create(
+        mutation,
+        {
+            "input": {
+                "file_name": "sis.zip",
+                "md5_digest": "abc==",
+                "file_size": 100,
+                "produced_by": at_id,
+                "source_solution": source_id,
+                "created": "2026-01-01T00:00:00Z",
+            }
+        },
+        gql_context,
+    )
+    assert result.errors is None, result.errors
+    _assert_post_url_is_valid_json(result.data["create_scaled_inversion_solution"], "solution")
+
+
+# ── 4. AggregateInversionSolution ─────────────────────────────────────────────
+
+
+def test_create_aggregate_inversion_solution_post_url(gql_context, s3_bucket, at_id, rgt_id):
+    # Need a RuptureSet (common_rupture_set) and at least one source IS.
+    create_rs = """
+    mutation CreateRS($input: CreateRuptureSetInput!) {
+        create_rupture_set(input: $input) { rupture_set { id } }
+    }
+    """
+    rs_res = _create(
+        create_rs,
+        {
+            "input": {
+                "file_name": "rs.zip",
+                "md5_digest": "abc==",
+                "file_size": 100,
+                "produced_by": rgt_id,
+                "created": "2026-01-01T00:00:00Z",
+                "fault_models": ["A"],
+            }
+        },
+        gql_context,
+    )
+    assert rs_res.errors is None, rs_res.errors
+    rs_id = rs_res.data["create_rupture_set"]["rupture_set"]["id"]
+
+    create_is = """
+    mutation CreateIS($input: CreateInversionSolutionInput!) {
+        create_inversion_solution(input: $input) { inversion_solution { id } }
+    }
+    """
+    is_res = _create(
+        create_is,
+        {
+            "input": {
+                "file_name": "is.zip",
+                "md5_digest": "abc==",
+                "file_size": 100,
+                "produced_by": at_id,
+                "created": "2026-01-01T00:00:00Z",
+            }
+        },
+        gql_context,
+    )
+    is_id = is_res.data["create_inversion_solution"]["inversion_solution"]["id"]
+
+    mutation = """
+    mutation CreateAIS($input: CreateAggregateInversionSolutionInput!) {
+        create_aggregate_inversion_solution(input: $input) {
+            ok
+            solution { id post_url }
+        }
+    }
+    """
+    result = _create(
+        mutation,
+        {
+            "input": {
+                "file_name": "ais.zip",
+                "md5_digest": "abc==",
+                "file_size": 100,
+                "produced_by": at_id,
+                "common_rupture_set": rs_id,
+                "source_solutions": [is_id],
+                "aggregation_fn": "MEAN",
+                "created": "2026-01-01T00:00:00Z",
+            }
+        },
+        gql_context,
+    )
+    assert result.errors is None, result.errors
+    _assert_post_url_is_valid_json(result.data["create_aggregate_inversion_solution"], "solution")
+
+
+# ── 5. TimeDependentInversionSolution ─────────────────────────────────────────
+
+
+def test_create_time_dependent_inversion_solution_post_url(gql_context, s3_bucket, at_id):
+    create_is = """
+    mutation CreateIS($input: CreateInversionSolutionInput!) {
+        create_inversion_solution(input: $input) { inversion_solution { id } }
+    }
+    """
+    is_res = _create(
+        create_is,
+        {
+            "input": {
+                "file_name": "is.zip",
+                "md5_digest": "abc==",
+                "file_size": 100,
+                "produced_by": at_id,
+                "created": "2026-01-01T00:00:00Z",
+            }
+        },
+        gql_context,
+    )
+    source_id = is_res.data["create_inversion_solution"]["inversion_solution"]["id"]
+
+    mutation = """
+    mutation CreateTDIS($input: CreateTimeDependentInversionSolutionInput!) {
+        create_time_dependent_inversion_solution(input: $input) {
+            ok
+            solution { id post_url }
+        }
+    }
+    """
+    result = _create(
+        mutation,
+        {
+            "input": {
+                "file_name": "tdis.zip",
+                "md5_digest": "abc==",
+                "file_size": 100,
+                "produced_by": at_id,
+                "source_solution": source_id,
+                "created": "2026-01-01T00:00:00Z",
+            }
+        },
+        gql_context,
+    )
+    assert result.errors is None, result.errors
+    _assert_post_url_is_valid_json(result.data["create_time_dependent_inversion_solution"], "solution")
+
+
+# ── 6. InversionSolutionNrml ──────────────────────────────────────────────────
+
+
+def test_create_inversion_solution_nrml_post_url(gql_context, s3_bucket, at_id):
+    create_is = """
+    mutation CreateIS($input: CreateInversionSolutionInput!) {
+        create_inversion_solution(input: $input) { inversion_solution { id } }
+    }
+    """
+    is_res = _create(
+        create_is,
+        {
+            "input": {
+                "file_name": "is.zip",
+                "md5_digest": "abc==",
+                "file_size": 100,
+                "produced_by": at_id,
+                "created": "2026-01-01T00:00:00Z",
+            }
+        },
+        gql_context,
+    )
+    source_id = is_res.data["create_inversion_solution"]["inversion_solution"]["id"]
+
+    mutation = """
+    mutation CreateNRML($input: CreateInversionSolutionNrmlInput!) {
+        create_inversion_solution_nrml(input: $input) {
+            ok
+            inversion_solution_nrml { id post_url }
+        }
+    }
+    """
+    result = _create(
+        mutation,
+        {
+            "input": {
+                "file_name": "nrml.zip",
+                "md5_digest": "abc==",
+                "file_size": 100,
+                "source_solution": source_id,
+                "created": "2026-01-01T00:00:00Z",
+            }
+        },
+        gql_context,
+    )
+    assert result.errors is None, result.errors
+    _assert_post_url_is_valid_json(result.data["create_inversion_solution_nrml"], "inversion_solution_nrml")

--- a/spike/strawberry_poc/tests/test_reindex.py
+++ b/spike/strawberry_poc/tests/test_reindex.py
@@ -23,7 +23,7 @@ mutation { create_general_task(input: { title: "Reindex Me", created: "2024-01-0
 """
 
 CREATE_FILE = """
-mutation { create_file(input: { file_name: "reindex.txt", file_size: 1, md5_digest: "abc" }) {
+mutation { create_file(file_name: "reindex.txt", file_size: 1, md5_digest: "abc") {
     file_result { id }
 } }
 """

--- a/spike/strawberry_poc/tests/test_smoketest_ab.py
+++ b/spike/strawberry_poc/tests/test_smoketest_ab.py
@@ -92,12 +92,10 @@ def ids(gql_context):
     # 4. File — mirrors "new_rupt_file"
     data = run("""
         mutation new_rupt_file {
-            create_file(input: {
-                file_name: "myfile2.txt"
+            create_file(file_name: "myfile2.txt"
                 file_size: 2000
                 md5_digest: "abc123"
-                meta: [{ k: "encoding", v: "utf8" }]
-            }) {
+                meta: [{ k: "encoding", v: "utf8" }]) {
                 file_result { id meta { k v } }
             }
         }
@@ -108,11 +106,9 @@ def ids(gql_context):
     data = run(
         """
         mutation new_rupt_file_relation($file_id: ID!, $thing_id: ID!) {
-            create_file_relation(input: {
-                file_id: $file_id
+            create_file_relation(file_id: $file_id
                 thing_id: $thing_id
-                role: WRITE
-            }) { ok }
+                role: WRITE) { ok }
         }
     """,
         {"file_id": collected["file_id"], "thing_id": collected["rgt1_id"]},
@@ -138,11 +134,9 @@ def ids(gql_context):
     data = run(
         """
         mutation new_sms_file_relation($file_id: ID!, $thing_id: ID!) {
-            create_file_relation(input: {
-                file_id: $file_id
+            create_file_relation(file_id: $file_id
                 thing_id: $thing_id
-                role: UNDEFINED
-            }) { ok }
+                role: UNDEFINED) { ok }
         }
     """,
         {"file_id": collected["sms_file_id"], "thing_id": collected["sms_id"]},
@@ -168,11 +162,9 @@ def ids(gql_context):
     data = run(
         """
         mutation new_gt_file_relation($file_id: ID!, $thing_id: ID!) {
-            create_file_relation(input: {
-                file_id: $file_id
+            create_file_relation(file_id: $file_id
                 thing_id: $thing_id
-                role: READ
-            }) { ok }
+                role: READ) { ok }
         }
     """,
         {"file_id": collected["file_id"], "thing_id": collected["gt_id"]},
@@ -183,11 +175,9 @@ def ids(gql_context):
     data = run(
         """
         mutation new_gt_smsfile_relation($file_id: ID!, $thing_id: ID!) {
-            create_file_relation(input: {
-                file_id: $file_id
+            create_file_relation(file_id: $file_id
                 thing_id: $thing_id
-                role: UNDEFINED
-            }) { ok }
+                role: UNDEFINED) { ok }
         }
     """,
         {"file_id": collected["sms_file_id"], "thing_id": collected["gt_id"]},

--- a/spike/strawberry_poc/tests/test_weka_parity.py
+++ b/spike/strawberry_poc/tests/test_weka_parity.py
@@ -41,8 +41,8 @@ query GetFile($id: ID!) {
 """
 
 CREATE_FILE_MUTATION = """
-mutation CreateFile($input: CreateFileInput!) {
-    create_file(input: $input) {
+mutation CreateFile($file_name: String!, $md5_digest: String!, $file_size: BigInt!, $created: DateTime = null, $meta: [KeyValuePairInput!] = null) {
+    create_file(file_name: $file_name, md5_digest: $md5_digest, file_size: $file_size, created: $created, meta: $meta) {
         ok
         file_result { id file_name }
     }
@@ -53,7 +53,7 @@ mutation CreateFile($input: CreateFileInput!) {
 def test_file_sdl_typename(gql_context):
     res = schema.execute_sync(
         CREATE_FILE_MUTATION,
-        variable_values={"input": {"file_name": "weka.zip"}},
+        variable_values={"file_name": "weka.zip", "md5_digest": "abc", "file_size": 100},
         context_value=gql_context,
     )
     assert res.errors is None, res.errors
@@ -96,7 +96,7 @@ def test_nodes_payload_sdl_name():
 def test_nodes_works(gql_context):
     create_res = schema.execute_sync(
         CREATE_FILE_MUTATION,
-        variable_values={"input": {"file_name": "nodes-test.zip"}},
+        variable_values={"file_name": "nodes-test.zip", "md5_digest": "abc", "file_size": 100},
         context_value=gql_context,
     )
     fid = create_res.data["create_file"]["file_result"]["id"]
@@ -195,8 +195,8 @@ mutation CreateIS($input: CreateInversionSolutionInput!) {
 """
 
 CREATE_FILE_RELATION = """
-mutation CreateRel($input: CreateFileRelationInput!) {
-    create_file_relation(input: $input) { ok }
+mutation CreateRel($file_id: ID!, $role: FileRole!, $thing_id: ID!) {
+    create_file_relation(file_id: $file_id, role: $role, thing_id: $thing_id) { ok }
 }
 """
 
@@ -231,7 +231,7 @@ def test_automation_task_inversion_solution_resolves(gql_context, task_id):
 
     rel_res = schema.execute_sync(
         CREATE_FILE_RELATION,
-        variable_values={"input": {"thing_id": task_id, "file_id": is_id, "role": "WRITE"}},
+        variable_values={"thing_id": task_id, "file_id": is_id, "role": "WRITE"},
         context_value=gql_context,
     )
     assert rel_res.errors is None, rel_res.errors


### PR DESCRIPTION
## Summary

Closes the **two highest-priority runzi-compat gaps** surfaced by chrisdicaprio's mini-Phase-4 testing.

### Issue 1: `post_url` returned `null` on every file-create except RuptureSet

PR #310's Gap 4 closure wired `presigned_post_for_file` into `mutate_create_rupture_set` only. For all other file types, `post_url` returned the `FileInterface` default `None`. nshm-toshi-client and runzi do `json.loads(executed['create_X']['Y']['post_url'])` immediately, which crashes on `None`.

**Wired post_url on 6 mutations:**
- `create_file` (plain File / ToshiFile)
- `create_inversion_solution`
- `create_scaled_inversion_solution`
- `create_aggregate_inversion_solution`
- `create_time_dependent_inversion_solution`
- `create_inversion_solution_nrml`

Identical pattern in each `mutate_create_*` function — see the three-line addition.

SMS / StrongMotionStation `create_sms_file` deliberately NOT included (deprecation per #295).

### Issue 2: Three legacy mutations use positional args; POC wrapped them in `input:`

`create_file` and `create_file_relation` in legacy SDL are:

```
create_file(file_name: String!, md5_digest: String!, file_size: BigInt!, …): CreateFile
create_file_relation(file_id: ID!, role: FileRole!, thing_id: ID!): CreateFileRelation
```

nshm-toshi-client sends them in exactly that shape (verbatim copies live in this PR's `test_nshm_toshi_client_compat.py`). The POC had wrapped both in `CreateFileInput!` / `CreateFileRelationInput!`, rejecting the client's queries at GraphQL validation time.

**Realigned both mutations** to use positional args matching legacy. `CreateFileInput` and `CreateFileRelationInput` Python dataclasses remain for internal pipe-through to `mutate_create_*`; built inside the resolver. Strawberry auto-drops unused `@strawberry.input` types from the SDL.

`clientMutationId` on `create_file`: removed — legacy never had it on that mutation, nshm-toshi-client doesn't send it. The CMI alias still lives on every other mutation (e.g., create_inversion_solution) per ADR-001 Phase 1.

### What's NOT in this PR

- `update_subtask_count` was flagged as a missing mutation in the initial triage. Re-reading runzi: it's just the OPERATION name of a wrapper around `update_general_task(subtask_count: ...)`. POC's `UpdateGeneralTaskInput` already has `subtask_count`. False alarm.
- `create_sms_file` and `create_sms_file_link` positional alignment: SMS flow is on the deprecation list per #295.

## Tests

**New: `test_post_url_all_file_types.py`** (6 tests) — one per mutation, asserts `post_url` is a non-null JSON string that deserializes via `json.loads` and contains the expected `key` field. Skips the full requests-based upload round-trip since that's already covered by `test_bugfix_gap4_rupture_set.py`.

**New: `test_nshm_toshi_client_compat.py`** (4 tests):
- The exact verbatim GraphQL strings from `nshm-toshi-client/toshi_file.py` and `toshi_task_file.py` validate + execute.
- SDL contract pins assert positional shape can't regress to input-wrapper form.

**Updated**: 8 existing test files migrated from input-wrapper to positional form.

**Reframed**: `test_create_file_with_null_file_size` → `test_create_file_rejects_missing_file_size` (legacy SDL has file_size required).

**Retargeted**: `test_round_trip_works_on_other_mutations` from `create_file` → `create_inversion_solution` (still input-wrapped, still supports CMI).

## Test plan

- [x] Full POC suite: **261 passed**, 1 skipped (was 251 → +10 new)
- [x] Ruff format + check clean
- [x] Verbatim-from-client mutation strings exercise the exact wire format runzi sends

## Related

- #310 (Gap 4 original) — wired only RuptureSet
- #318 — mini Phase 4 (the read/write flip that exposed this)
- #295 — migration epic