### PR TITLE
fix(strawberry-poc): comprehensive schema parity with legacy (runzi/weka)

### DIFF
--- a/docs/adrs/ADR-002-schema-interface-hierarchy-and-input-naming.md
+++ b/docs/adrs/ADR-002-schema-interface-hierarchy-and-input-naming.md
@@ -159,7 +159,8 @@ Per ADR-001. No new action.
 | `AutomationTaskInterface` | Declared, implemented by 3 concrete types | Missing | **Adopt** — same pattern |
 | Input naming `<Type>Input` | snake-Graphene convention | `Create<Type>Input` (Strawberry-modern) | **Accept divergence** — wire-equivalent, modern preferred |
 | Edge types per node | Shared `FileEdge` / `ThingEdge` etc. | Per-type `<Node>Edge` | **Accept divergence** — wire-equivalent, structural cost too high |
-| `FileRelationsConnection` etc. | `FileRelationConnection` | Already POC-named | **Already resolved** (ADR-001) |
+| `FileRelationsConnection` etc. | `FileRelationConnection` | POC-named (no decorator) | **Revised by round-2 audit** — adopt legacy SDL names via `@strawberry.type(name="FileRelationConnection")` / `(name="TaskTaskRelationConnection")` decorators; Python class names retain plural form. See Post-implementation audit, round 2 |
+| List-typed input fields | `[T]` (nullable elements) | `[T!]` (Strawberry default) | **Revised by round-2 audit** — convert to `list[T \| None]` everywhere to match legacy. Variable-type subsumption is wire-impacting |
 
 ## Implementation plan for the interface adoptions
 
@@ -385,6 +386,74 @@ analysis missed. All four are fixed in PR #309.
    "POC-only types" half of the parity diff that we'd partially
    characterised as cosmetic. For future schema ADRs, run the
    client-query audit *before* drafting decisions, not after.
+
+## Post-implementation audit, round 2 (June 2026 — runzi smoke test)
+
+After PR #309 landed the four wire-breaking divergences above,
+chrisdicaprio drove a runzi end-to-end smoke test that surfaced a
+second, larger class of regressions the audit also missed. PR #321
+(`docs/smoke-test-learnings.md`) is the writeup of how this slipped
+through; the comprehensive fixes ship in this PR.
+
+The root cause: **§3a above conflated wire-equivalence of *response*
+JSON with wire-equivalence of *input variable types*.** GraphQL
+applies a strict subsumption check on variable types — `$x: [T]!`
+is not accepted at a `[T!]!` position even though the JSON values
+sent on the wire are identical. Strawberry's `list[T]` emits
+`[T!]` by default; legacy Graphene emits `[T]`. Every list-typed
+input field that we declared as `list[T]` in the POC was a latent
+runzi/weka break.
+
+| # | Divergence | Wire-impact path | Fix |
+|---|---|---|---|
+| E | All `@strawberry.input` list fields used non-null elements (`[T!]`) | runzi sends `$meta: [KeyValuePair]!` → rejected by variable-type subsumption against `[KeyValuePair!]!` position | Convert every `list[T] \| None = None` to `list[T \| None] \| None = None` in input types (~35 files) |
+| F | All `@strawberry.type` list output fields used non-null elements | Older clients expect `[T]` on responses; new typed clients regenerated against POC SDL would treat nullable items as a build error | Same `list[T \| None]` treatment in output types |
+| G | `FileRelationsConnection` / `TaskRelationsConnection` SDL names | runzi/weka fragments spell `... on FileRelationConnection` / `... on TaskTaskRelationConnection` | Add `@strawberry.type(name="FileRelationConnection")` / `(name="TaskTaskRelationConnection")` decorators |
+| H | `create_task_relation(input: CreateTaskRelationInput!)` wrapper | nshm-toshi-client sends `create_task_relation(child_id:, parent_id:)` positional | Convert to positional args, matching `create_file` / `create_file_relation` |
+| I | `CreateOpenquakeHazardTaskPayload.task_result` / `UpdateOpenquakeHazardTaskPayload.task_result` | runzi selects `openquake_hazard_task { id }` per legacy contract | Rename via `strawberry.field(name="openquake_hazard_task")` |
+| J | `LabelledTableRelation` missing `table: Table` resolver | runzi queries `tables { table { id } }` on InversionSolution | Add `@strawberry.field def table(...)` resolver |
+| K | `CreateInversionSolutionInput` missing `mfd_table_id` / `hazard_table_id` | runzi still sends them as deprecated transient fields | Add to input; resolver tolerates and ignores |
+
+### Revised principle (supersedes §3a)
+
+> Wire compat is the contract. **Wire compat covers both response
+> JSON shapes and the input variable types declared in the SDL** —
+> not just the JSON sent over the wire. Variable-type subsumption
+> means `[T]` vs `[T!]` differs at the schema-validation layer
+> even when the JSON payload is identical. SDL differences that
+> change validation behaviour are not "cosmetic"; they break
+> existing clients before any bytes are exchanged.
+
+### What changed in the decisions table
+
+- **Connection naming (`FileRelationConnection`,
+  `TaskTaskRelationConnection`)** moves from "Already resolved
+  (ADR-001)" to **"Adopt legacy names via
+  `@strawberry.type(name=...)` decorators"**. The Python class
+  names keep their POC spelling (with the extra "s") to avoid
+  colliding with Strawberry's per-node auto-generated Connection
+  type, but the SDL emits the legacy name. ADR-001's assumption
+  that POC-side naming was already adopted by clients was wrong —
+  both weka and runzi spell the legacy name in fragments.
+- **Category 2 (input naming)** decision still stands for the
+  *Input vs no-suffix* difference (e.g. `CreateFileInput` vs
+  legacy `FileInput`). What does **not** stand is allowing
+  Strawberry's default list-element nullability to leak into
+  inputs. Input list fields must match legacy element-nullability
+  even though the wrapper-type name may differ.
+
+### Lesson added
+
+4. **"Wire-equivalent" is not just JSON payload shape.** The
+   variable-type subsumption check, the validation rules around
+   `Connection` fragment spreads, and any decorator-only SDL rename
+   (`@strawberry.type(name=...)`) all live at the schema layer,
+   not the bytes layer. A round of automated SDL-text comparison
+   is necessary but not sufficient — a query-validation test
+   harness (runzi or auto-extracted client queries against the POC
+   SDL) is the actual gate. `test_sdl_emission_invariants.py` and
+   the schema-parity CI step added in this PR are the durable
+   defenses.
 
 ## Related decisions
 

--- a/spike/strawberry_poc/models/aggregate_inversion_solution.py
+++ b/spike/strawberry_poc/models/aggregate_inversion_solution.py
@@ -27,14 +27,14 @@ _RuptureSet = Annotated["RuptureSet", strawberry.lazy("models.rupture_set")]
 @strawberry.type
 class AggregateInversionSolution(relay.Node, FileInterface, InversionSolutionInterface, PredecessorsInterface):
     pk: relay.NodeID[str]
-    metrics: list[KeyValuePair] | None = None
+    metrics: list[KeyValuePair | None] | None = None
     aggregation_fn: AggregationFn | None = None
     # tables, produced_by, mfd_table, mfd_table_id, hazard_table_id, relations
     # are all inherited from InversionSolutionInterface.
 
     produced_by_raw_id: strawberry.Private[str | None] = None
     common_rupture_set_raw_id: strawberry.Private[str | None] = None
-    source_solutions_raw_ids: strawberry.Private[list[str] | None] = None
+    source_solutions_raw_ids: strawberry.Private[list[str | None] | None] = None
     relations_raw: strawberry.Private[list | None] = None
     predecessors_raw: strawberry.Private[list | None] = None
 
@@ -52,7 +52,7 @@ class AggregateInversionSolution(relay.Node, FileInterface, InversionSolutionInt
         return RuptureSet.from_dict(data)
 
     @strawberry.field
-    def source_solutions(self, info: Info) -> list[SourceSolutionUnion] | None:
+    def source_solutions(self, info: Info) -> list[SourceSolutionUnion | None] | None:
         if not self.source_solutions_raw_ids:
             return None
         results = []
@@ -97,14 +97,14 @@ class AggregateInversionSolution(relay.Node, FileInterface, InversionSolutionInt
 class CreateAggregateInversionSolutionInput:
     file_name: str
     common_rupture_set: strawberry.ID
-    source_solutions: list[strawberry.ID]
+    source_solutions: list[strawberry.ID | None]
     aggregation_fn: AggregationFn
     produced_by: strawberry.ID | None = None
     md5_digest: str | None = None
     file_size: BigInt | None = None
-    meta: list[KeyValuePairInput] | None = None
+    meta: list[KeyValuePairInput | None] | None = None
     created: DateTime | None = None
-    predecessors: list[PredecessorInput] | None = None
+    predecessors: list[PredecessorInput | None] | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
 
 

--- a/spike/strawberry_poc/models/automation_task.py
+++ b/spike/strawberry_poc/models/automation_task.py
@@ -64,9 +64,9 @@ class AutomationTask(relay.Node, Thing, AutomationTaskInterface):
     created: DateTime | None = None
     duration: float | None = None
     general_task_id: strawberry.ID | None = None
-    arguments: list[KeyValuePair] | None = None
-    environment: list[KeyValuePair] | None = None
-    metrics: list[KeyValuePair] | None = None
+    arguments: list[KeyValuePair | None] | None = None
+    environment: list[KeyValuePair | None] | None = None
+    metrics: list[KeyValuePair | None] | None = None
 
     # Embedded relation arrays — hidden from schema, resolved lazily
     files_raw: strawberry.Private[list | None] = None
@@ -74,15 +74,15 @@ class AutomationTask(relay.Node, Thing, AutomationTaskInterface):
     children_raw: strawberry.Private[list | None] = None
 
     @relay.connection(FileRelationsConnection)
-    def files(self, info: Info) -> list[FileRelation]:
+    def files(self, info: Info) -> list[FileRelation | None]:
         return build_file_relations_for_thing(self.pk, self.files_raw or [])
 
     @relay.connection(TaskRelationsConnection)
-    def parents(self, info: Info) -> list[TaskTaskRelation]:
+    def parents(self, info: Info) -> list[TaskTaskRelation | None]:
         return build_task_parents(self.pk, self.parents_raw or [])
 
     @relay.connection(TaskRelationsConnection)
-    def children(self, info: Info) -> list[TaskTaskRelation]:
+    def children(self, info: Info) -> list[TaskTaskRelation | None]:
         return build_task_children(self.pk, self.children_raw or [])
 
     @strawberry.field
@@ -129,24 +129,24 @@ class RuptureGenerationTask(relay.Node, Thing, AutomationTaskInterface):
     created: DateTime | None = None
     duration: float | None = None
     general_task_id: strawberry.ID | None = None
-    arguments: list[KeyValuePair] | None = None
-    environment: list[KeyValuePair] | None = None
-    metrics: list[KeyValuePair] | None = None
+    arguments: list[KeyValuePair | None] | None = None
+    environment: list[KeyValuePair | None] | None = None
+    metrics: list[KeyValuePair | None] | None = None
 
     files_raw: strawberry.Private[list | None] = None
     parents_raw: strawberry.Private[list | None] = None
     children_raw: strawberry.Private[list | None] = None
 
     @relay.connection(FileRelationsConnection)
-    def files(self, info: Info) -> list[FileRelation]:
+    def files(self, info: Info) -> list[FileRelation | None]:
         return build_file_relations_for_thing(self.pk, self.files_raw or [])
 
     @relay.connection(TaskRelationsConnection)
-    def parents(self, info: Info) -> list[TaskTaskRelation]:
+    def parents(self, info: Info) -> list[TaskTaskRelation | None]:
         return build_task_parents(self.pk, self.parents_raw or [])
 
     @relay.connection(TaskRelationsConnection)
-    def children(self, info: Info) -> list[TaskTaskRelation]:
+    def children(self, info: Info) -> list[TaskTaskRelation | None]:
         return build_task_children(self.pk, self.children_raw or [])
 
     @strawberry.field
@@ -193,9 +193,9 @@ class CreateAutomationTaskInput:
     # validates the AT's `arguments` against the GT's swept_arguments
     # (mirrors graphql_api/schema/custom/automation_task.py:197-234).
     general_task_id: strawberry.ID | None = None
-    arguments: list[KeyValuePairInput] | None = None
-    environment: list[KeyValuePairInput] | None = None
-    metrics: list[KeyValuePairInput] | None = None
+    arguments: list[KeyValuePairInput | None] | None = None
+    environment: list[KeyValuePairInput | None] | None = None
+    metrics: list[KeyValuePairInput | None] | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
 
 
@@ -205,9 +205,9 @@ class UpdateAutomationTaskInput:
     state: EventState | None = None
     result: EventResult | None = None
     duration: float | None = None
-    arguments: list[KeyValuePairInput] | None = None
-    environment: list[KeyValuePairInput] | None = None
-    metrics: list[KeyValuePairInput] | None = None
+    arguments: list[KeyValuePairInput | None] | None = None
+    environment: list[KeyValuePairInput | None] | None = None
+    metrics: list[KeyValuePairInput | None] | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
 
 

--- a/spike/strawberry_poc/models/common.py
+++ b/spike/strawberry_poc/models/common.py
@@ -106,13 +106,16 @@ class KeyValuePairInput:
 @strawberry.type
 class KeyValueListPair:
     k: str
-    v: list[str]
+    v: list[str | None] | None = None
 
 
 @strawberry.input
 class KeyValueListPairInput:
     k: str
-    v: list[str]
+    # `v` matches legacy `[String]` exactly — nullable outer list, nullable
+    # elements — so client variables typed `[String]!` validate at this
+    # position. See docs/smoke-test-learnings.md §1.
+    v: list[str | None] | None = None
 
 
 # ── Task enums ────────────────────────────────────────────────────────────────

--- a/spike/strawberry_poc/models/file.py
+++ b/spike/strawberry_poc/models/file.py
@@ -31,7 +31,7 @@ class ToshiFile(relay.Node, FileInterface):
     relations_raw: strawberry.Private[list | None] = None
 
     @relay.connection(FileRelationsConnection)
-    def relations(self, info: Info) -> list[FileRelation]:
+    def relations(self, info: Info) -> list[FileRelation | None]:
         return build_file_relations_for_file(self.pk, self.relations_raw or [])
 
     @classmethod
@@ -64,7 +64,7 @@ class CreateFileInput:
     file_name: str
     md5_digest: str | None = None
     file_size: BigInt | None = None
-    meta: list[KeyValuePairInput] | None = None
+    meta: list[KeyValuePairInput | None] | None = None
     created: DateTime | None = None
     created: str | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()

--- a/spike/strawberry_poc/models/file_interface.py
+++ b/spike/strawberry_poc/models/file_interface.py
@@ -18,7 +18,7 @@ class FileInterface:
     md5_digest: str | None = None
     file_size: BigInt | None = None
     created: DateTime | None = None
-    meta: list[KeyValuePair] | None = None
+    meta: list[KeyValuePair | None] | None = None
 
     # Populated at create-time by mutate_create_<file_type> when S3 is configured.
     # Legacy semantics: presigned-POST is generated once and surfaced on the

--- a/spike/strawberry_poc/models/general_task.py
+++ b/spike/strawberry_poc/models/general_task.py
@@ -60,25 +60,25 @@ class GeneralTask(relay.Node, Thing):
     subtask_type: TaskSubType | None = None
     subtask_result: EventResult | None = None
     model_type: ModelType | None = None
-    argument_lists: list[KeyValueListPair] | None = None
-    meta: list[KeyValuePair] | None = None
+    argument_lists: list[KeyValueListPair | None] | None = None
+    meta: list[KeyValuePair | None] | None = None
     # files_raw / parents_raw / children_raw and the @relay.connection
     # resolvers for files / parents / children are inherited from Thing
 
     @relay.connection(FileRelationsConnection)
-    def files(self, info: Info) -> list[FileRelation]:
+    def files(self, info: Info) -> list[FileRelation | None]:
         return build_file_relations_for_thing(self.pk, self.files_raw or [])
 
     @relay.connection(TaskRelationsConnection)
-    def children(self, info: Info) -> list[TaskTaskRelation]:
+    def children(self, info: Info) -> list[TaskTaskRelation | None]:
         return build_task_children(self.pk, self.children_raw or [])
 
     @relay.connection(TaskRelationsConnection)
-    def parents(self, info: Info) -> list[TaskTaskRelation]:
+    def parents(self, info: Info) -> list[TaskTaskRelation | None]:
         return build_task_parents(self.pk, self.parents_raw or [])
 
     @strawberry.field
-    def swept_arguments(self) -> list[str]:
+    def swept_arguments(self) -> list[str | None] | None:
         """Keys with >1 value in argument_lists."""
         if not self.argument_lists:
             return []
@@ -128,8 +128,8 @@ class CreateGeneralTaskInput:
     subtask_type: TaskSubType | None = None
     subtask_result: EventResult | None = None
     model_type: ModelType | None = None
-    argument_lists: list[KeyValueListPairInput] | None = None
-    meta: list[KeyValuePairInput] | None = None
+    argument_lists: list[KeyValueListPairInput | None] | None = None
+    meta: list[KeyValuePairInput | None] | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
 
 @strawberry.input
@@ -144,8 +144,8 @@ class UpdateGeneralTaskInput:
     subtask_type: TaskSubType | None = None
     subtask_result: EventResult | None = None
     model_type: ModelType | None = None
-    argument_lists: list[KeyValueListPairInput] | None = None
-    meta: list[KeyValuePairInput] | None = None
+    argument_lists: list[KeyValueListPairInput | None] | None = None
+    meta: list[KeyValuePairInput | None] | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
 
 def resolve_general_tasks(info: Info) -> Iterable[GeneralTask]:

--- a/spike/strawberry_poc/models/inversion_solution.py
+++ b/spike/strawberry_poc/models/inversion_solution.py
@@ -55,7 +55,26 @@ class LabelledTableRelation:
     label: str | None = None
     table_id: strawberry.ID | None = None
     table_type: TableType | None = None
-    dimensions: list[KeyValueListPair] | None = None
+    dimensions: list[KeyValueListPair | None] | None = None
+
+    @strawberry.field
+    def table(self, info: Info) -> Optional["Table"]:
+        """Resolved Table reference matching legacy SDL (chris's Problem 2 #4).
+
+        Without this field, runzi queries that select `tables { table { id } }`
+        on InversionSolution fail validation.
+        """
+        if not self.table_id:
+            return None
+        from data.dynamo import get_table  # noqa: PLC0415
+        from models.table import Table  # noqa: PLC0415
+
+        try:
+            raw_id = GlobalID.from_id(str(self.table_id)).node_id
+        except Exception:
+            raw_id = str(self.table_id)
+        data = get_table(info.context["dynamodb"], raw_id)
+        return Table.from_dict(data) if data else None
 
 
 @strawberry.input
@@ -64,7 +83,7 @@ class LabelledTableRelationInput:
     table_type: TableType
     label: str | None = None
     produced_by_id: strawberry.ID | None = None
-    dimensions: list[KeyValueListPairInput] | None = None
+    dimensions: list[KeyValueListPairInput | None] | None = None
 
 
 def _ltr_from_dict(d: dict) -> LabelledTableRelation:
@@ -101,7 +120,7 @@ class InversionSolution(relay.Node, FileInterface, InversionSolutionInterface, P
     """An Inversion Solution file produced by an automation task."""
 
     pk: relay.NodeID[str]
-    metrics: list[KeyValuePair] | None = None
+    metrics: list[KeyValuePair | None] | None = None
     # tables, produced_by, mfd_table, mfd_table_id, hazard_table_id, relations
     # are all inherited from InversionSolutionInterface.
 
@@ -140,19 +159,24 @@ class CreateInversionSolutionInput:
     file_name: str
     md5_digest: str | None = None
     file_size: BigInt | None = None
-    meta: list[KeyValuePairInput] | None = None
+    meta: list[KeyValuePairInput | None] | None = None
     created: DateTime | None = None
+    # Legacy SDL preserves both deprecated table-id fields on input (chris's
+    # Problem 2 #5). Runzi may still send `mfd_table_id`; accept it silently.
+    # Transient fields — resolver may consume them but they're not persisted.
+    mfd_table_id: strawberry.ID | None = None
+    hazard_table_id: strawberry.ID | None = None
     produced_by: strawberry.ID | None = None
-    metrics: list[KeyValuePairInput] | None = None
-    tables: list[LabelledTableRelationInput] | None = None
-    predecessors: list[PredecessorInput] | None = None
+    metrics: list[KeyValuePairInput | None] | None = None
+    tables: list[LabelledTableRelationInput | None] | None = None
+    predecessors: list[PredecessorInput | None] | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
 
 
 @strawberry.input
 class AppendInversionSolutionTablesInput:
     id: strawberry.ID
-    tables: list[LabelledTableRelationInput]
+    tables: list[LabelledTableRelationInput | None]
     client_mutation_id: str | None = client_mutation_id_input_field()
 
 

--- a/spike/strawberry_poc/models/inversion_solution_interface.py
+++ b/spike/strawberry_poc/models/inversion_solution_interface.py
@@ -74,7 +74,7 @@ class InversionSolutionInterface:
     md5_digest: str | None = None
     file_size: BigInt | None = None
     created: DateTime | None = None
-    meta: list[KeyValuePair] | None = None
+    meta: list[KeyValuePair | None] | None = None
 
     @strawberry.field
     def file_url(self) -> str | None:
@@ -82,7 +82,7 @@ class InversionSolutionInterface:
 
     # ── IS-specific fields ────────────────────────────────────────────────────
 
-    tables: list[_LabelledTableRelation] | None = None
+    tables: list[_LabelledTableRelation | None] | None = None
 
     @strawberry.field
     def relations(self, info: Info) -> InversionSolutionRelations | None:

--- a/spike/strawberry_poc/models/inversion_solution_nrml.py
+++ b/spike/strawberry_poc/models/inversion_solution_nrml.py
@@ -63,9 +63,9 @@ class CreateInversionSolutionNrmlInput:
     source_solution: strawberry.ID | None = None
     md5_digest: str | None = None
     file_size: BigInt | None = None
-    meta: list[KeyValuePairInput] | None = None
+    meta: list[KeyValuePairInput | None] | None = None
     created: DateTime | None = None
-    predecessors: list[PredecessorInput] | None = None
+    predecessors: list[PredecessorInput | None] | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
 
 

--- a/spike/strawberry_poc/models/object_identity.py
+++ b/spike/strawberry_poc/models/object_identity.py
@@ -43,7 +43,7 @@ class ObjectIdentitiesPageInfo:
 
 @strawberry.type
 class ObjectIdentitiesConnection:
-    edges: list[ObjectIdentitiesEdge] = strawberry.field(default_factory=list)
+    edges: list[ObjectIdentitiesEdge | None] = strawberry.field(default_factory=list)
     # Modern Relay-spec camelCase (preferred)
     page_info: ObjectIdentitiesPageInfo = strawberry.field(
         name="pageInfo", default_factory=ObjectIdentitiesPageInfo

--- a/spike/strawberry_poc/models/openquake_hazard_config.py
+++ b/spike/strawberry_poc/models/openquake_hazard_config.py
@@ -41,11 +41,11 @@ class OpenquakeHazardConfig(relay.Node, Thing):
     pk: relay.NodeID[str]
     created: DateTime | None = None
 
-    source_models_raw_ids: strawberry.Private[list[str] | None] = None
+    source_models_raw_ids: strawberry.Private[list[str | None] | None] = None
     template_archive_raw_id: strawberry.Private[str | None] = None
 
     @strawberry.field
-    def source_models(self, info: Info) -> list[OpenquakeNrmlUnion] | None:
+    def source_models(self, info: Info) -> list[OpenquakeNrmlUnion | None] | None:
         if not self.source_models_raw_ids:
             return None
         results = []
@@ -89,7 +89,7 @@ class OpenquakeHazardConfig(relay.Node, Thing):
 @strawberry.input
 class CreateOpenquakeHazardConfigInput:
     template_archive: strawberry.ID
-    source_models: list[strawberry.ID] | None = None
+    source_models: list[strawberry.ID | None] | None = None
     created: DateTime | None = None
     created: str | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()

--- a/spike/strawberry_poc/models/openquake_hazard_solution.py
+++ b/spike/strawberry_poc/models/openquake_hazard_solution.py
@@ -27,8 +27,8 @@ class OpenquakeHazardSolution(relay.Node, PredecessorsInterface, Thing):
     pk: relay.NodeID[str]
     created: DateTime | None = None
     task_type: OpenquakeTaskType | None = None
-    metrics: list[KeyValuePair] | None = None
-    meta: list[KeyValuePair] | None = None
+    metrics: list[KeyValuePair | None] | None = None
+    meta: list[KeyValuePair | None] | None = None
 
     produced_by_raw_id: strawberry.Private[str | None] = None
     csv_archive_raw_id: strawberry.Private[str | None] = None
@@ -102,9 +102,9 @@ class CreateOpenquakeHazardSolutionInput:
     csv_archive: strawberry.ID | None = None
     hdf5_archive: strawberry.ID | None = None
     task_args: strawberry.ID | None = None
-    metrics: list[KeyValuePairInput] | None = None
-    meta: list[KeyValuePairInput] | None = None
-    predecessors: list[PredecessorInput] | None = None
+    metrics: list[KeyValuePairInput | None] | None = None
+    meta: list[KeyValuePairInput | None] | None = None
+    predecessors: list[PredecessorInput | None] | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
 
 def resolve_openquake_hazard_solutions(info: Info) -> Iterable[OpenquakeHazardSolution]:

--- a/spike/strawberry_poc/models/openquake_hazard_task.py
+++ b/spike/strawberry_poc/models/openquake_hazard_task.py
@@ -38,9 +38,9 @@ class OpenquakeHazardTask(relay.Node, Thing, AutomationTaskInterface):
     created: DateTime | None = None
     duration: float | None = None
     general_task_id: strawberry.ID | None = None
-    arguments: list[KeyValuePair] | None = None
-    environment: list[KeyValuePair] | None = None
-    metrics: list[KeyValuePair] | None = None
+    arguments: list[KeyValuePair | None] | None = None
+    environment: list[KeyValuePair | None] | None = None
+    metrics: list[KeyValuePair | None] | None = None
     executor: str | None = None
     srm_logic_tree: JSONString | None = None
     gmcm_logic_tree: JSONString | None = None
@@ -52,15 +52,15 @@ class OpenquakeHazardTask(relay.Node, Thing, AutomationTaskInterface):
     hazard_solution_raw_id: strawberry.Private[str | None] = None
 
     @relay.connection(FileRelationsConnection)
-    def files(self, info: Info) -> list[FileRelation]:
+    def files(self, info: Info) -> list[FileRelation | None]:
         return build_file_relations_for_thing(self.pk, self.files_raw or [])
 
     @relay.connection(TaskRelationsConnection)
-    def parents(self, info: Info) -> list[TaskTaskRelation]:
+    def parents(self, info: Info) -> list[TaskTaskRelation | None]:
         return build_task_parents(self.pk, self.parents_raw or [])
 
     @relay.connection(TaskRelationsConnection)
-    def children(self, info: Info) -> list[TaskTaskRelation]:
+    def children(self, info: Info) -> list[TaskTaskRelation | None]:
         return build_task_children(self.pk, self.children_raw or [])
 
     @strawberry.field
@@ -118,9 +118,9 @@ class CreateOpenquakeHazardTaskInput:
     task_type: TaskSubType
     duration: float | None = None
     model_type: ModelType | None = None
-    arguments: list[KeyValuePairInput] | None = None
-    environment: list[KeyValuePairInput] | None = None
-    metrics: list[KeyValuePairInput] | None = None
+    arguments: list[KeyValuePairInput | None] | None = None
+    environment: list[KeyValuePairInput | None] | None = None
+    metrics: list[KeyValuePairInput | None] | None = None
     executor: str | None = None
     srm_logic_tree: JSONString | None = None
     gmcm_logic_tree: JSONString | None = None
@@ -134,9 +134,9 @@ class UpdateOpenquakeHazardTaskInput:
     state: EventState | None = None
     result: EventResult | None = None
     duration: float | None = None
-    arguments: list[KeyValuePairInput] | None = None
-    environment: list[KeyValuePairInput] | None = None
-    metrics: list[KeyValuePairInput] | None = None
+    arguments: list[KeyValuePairInput | None] | None = None
+    environment: list[KeyValuePairInput | None] | None = None
+    metrics: list[KeyValuePairInput | None] | None = None
     hazard_solution: strawberry.ID | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
 

--- a/spike/strawberry_poc/models/predecessors_interface.py
+++ b/spike/strawberry_poc/models/predecessors_interface.py
@@ -10,7 +10,7 @@ class PredecessorsInterface:
     """Shared by types that carry an inline provenance chain."""
 
     @strawberry.field
-    def predecessors(self) -> list[Predecessor] | None:
+    def predecessors(self) -> list[Predecessor | None] | None:
         if not self.predecessors_raw:  # type: ignore[attr-defined]
             return None
         return [Predecessor(id=p["id"], depth=p["depth"]) for p in self.predecessors_raw]  # type: ignore[attr-defined]

--- a/spike/strawberry_poc/models/relations.py
+++ b/spike/strawberry_poc/models/relations.py
@@ -155,9 +155,15 @@ class TaskTaskRelation:
 # Overriding resolve_connection lets us count BEFORE that optimisation fires.
 
 
-@strawberry.type
+@strawberry.type(name="FileRelationConnection")
 class FileRelationsConnection(CompatListConnection[FileRelation]):
-    """Relay connection for FileRelation that exposes total_count + camelCase PageInfo."""
+    """Relay connection for FileRelation that exposes total_count + camelCase PageInfo.
+
+    SDL name `FileRelationConnection` (no plural "s") matches legacy. The Python
+    class keeps the "Relations" name because the un-plural form collides with
+    Strawberry's auto-generated per-node Connection type.
+    See docs/smoke-test-learnings.md.
+    """
 
     _total: strawberry.Private[int] = 0
 
@@ -173,9 +179,12 @@ class FileRelationsConnection(CompatListConnection[FileRelation]):
         return conn
 
 
-@strawberry.type
+@strawberry.type(name="TaskTaskRelationConnection")
 class TaskRelationsConnection(CompatListConnection[TaskTaskRelation]):
-    """Relay connection for TaskTaskRelation that exposes total_count + camelCase PageInfo."""
+    """Relay connection for TaskTaskRelation that exposes total_count + camelCase PageInfo.
+
+    SDL name `TaskTaskRelationConnection` (double "Task") matches legacy.
+    """
 
     _total: strawberry.Private[int] = 0
 

--- a/spike/strawberry_poc/models/rupture_set.py
+++ b/spike/strawberry_poc/models/rupture_set.py
@@ -30,8 +30,8 @@ class RuptureSet(relay.Node, FileInterface):
     """A RuptureSet file produced by a RuptureGenerationTask."""
 
     pk: relay.NodeID[str]
-    fault_models: list[str] | None = None
-    metrics: list[KeyValuePair] | None = None
+    fault_models: list[str | None] | None = None
+    metrics: list[KeyValuePair | None] | None = None
     # stored as raw object_id; resolved lazily (hidden from GraphQL schema)
     produced_by_raw_id: strawberry.Private[str | None] = None
 
@@ -81,9 +81,9 @@ class CreateRuptureSetInput:
     produced_by: strawberry.ID
     # Optional in legacy.
     created: DateTime | None = None
-    meta: list[KeyValuePairInput] | None = None
-    fault_models: list[str] | None = None
-    metrics: list[KeyValuePairInput] | None = None
+    meta: list[KeyValuePairInput | None] | None = None
+    fault_models: list[str | None] | None = None
+    metrics: list[KeyValuePairInput | None] | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
 
 

--- a/spike/strawberry_poc/models/scaled_inversion_solution.py
+++ b/spike/strawberry_poc/models/scaled_inversion_solution.py
@@ -57,7 +57,7 @@ def dispatch_source_solution(data: dict):
 @strawberry.type
 class ScaledInversionSolution(relay.Node, FileInterface, InversionSolutionInterface, PredecessorsInterface):
     pk: relay.NodeID[str]
-    metrics: list[KeyValuePair] | None = None
+    metrics: list[KeyValuePair | None] | None = None
     # tables, produced_by, mfd_table, mfd_table_id, hazard_table_id, relations
     # are all inherited from InversionSolutionInterface.
 
@@ -108,9 +108,9 @@ class CreateScaledInversionSolutionInput:
     produced_by: strawberry.ID | None = None
     md5_digest: str | None = None
     file_size: BigInt | None = None
-    meta: list[KeyValuePairInput] | None = None
+    meta: list[KeyValuePairInput | None] | None = None
     created: DateTime | None = None
-    predecessors: list[PredecessorInput] | None = None
+    predecessors: list[PredecessorInput | None] | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
 
 

--- a/spike/strawberry_poc/models/sms_file.py
+++ b/spike/strawberry_poc/models/sms_file.py
@@ -27,7 +27,7 @@ class SmsFile(relay.Node, FileInterface):
     relations_raw: strawberry.Private[list | None] = None
 
     @relay.connection(FileRelationsConnection)
-    def relations(self, info: Info) -> list[FileRelation]:
+    def relations(self, info: Info) -> list[FileRelation | None]:
         return build_file_relations_for_file(self.pk, self.relations_raw or [])
 
     @classmethod

--- a/spike/strawberry_poc/models/strong_motion_station.py
+++ b/spike/strawberry_poc/models/strong_motion_station.py
@@ -25,8 +25,8 @@ class StrongMotionStation(relay.Node, Thing):
     site_code: str | None = None
     site_class: SmsSiteClass | None = None
     site_class_basis: SmsSiteClassBasis | None = None
-    Vs30_mean: list[float] | None = None
-    Vs30_std_dev: list[float] | None = None
+    Vs30_mean: list[float | None] | None = None
+    Vs30_std_dev: list[float | None] | None = None
     liquefiable: bool | None = None
     bedrock_encountered: bool | None = None
     soft_clay_or_peat: bool | None = None
@@ -66,8 +66,8 @@ class CreateStrongMotionStationInput:
     site_code: str | None = None
     site_class: SmsSiteClass | None = None
     site_class_basis: SmsSiteClassBasis | None = None
-    Vs30_mean: list[float] | None = None
-    Vs30_std_dev: list[float] | None = None
+    Vs30_mean: list[float | None] | None = None
+    Vs30_std_dev: list[float | None] | None = None
     liquefiable: bool | None = None
     bedrock_encountered: bool | None = None
     soft_clay_or_peat: bool | None = None

--- a/spike/strawberry_poc/models/table.py
+++ b/spike/strawberry_poc/models/table.py
@@ -27,12 +27,12 @@ class Table(relay.Node):
     object_id: strawberry.ID | None = None
     name: str | None = None
     created: DateTime | None = None
-    column_headers: list[str] | None = None
-    column_types: list[RowItemType] | None = None
-    rows: list[list[str]] | None = None
-    meta: list[KeyValuePair] | None = None
+    column_headers: list[str | None] | None = None
+    column_types: list[RowItemType | None] | None = None
+    rows: list[list[str | None] | None] | None = None
+    meta: list[KeyValuePair | None] | None = None
     table_type: TableType | None = None
-    dimensions: list[KeyValueListPair] | None = None
+    dimensions: list[KeyValueListPair | None] | None = None
 
     @classmethod
     def resolve_node(cls, node_id: str, *, info: Info, **kwargs) -> Optional["Table"]:
@@ -63,12 +63,12 @@ class CreateTableInput:
     object_id: strawberry.ID
     name: str | None = None
     created: DateTime | None = None
-    column_headers: list[str] | None = None
-    column_types: list[RowItemType] | None = None
-    rows: list[list[str]] | None = None
-    meta: list[KeyValuePairInput] | None = None
+    column_headers: list[str | None] | None = None
+    column_types: list[RowItemType | None] | None = None
+    rows: list[list[str | None] | None] | None = None
+    meta: list[KeyValuePairInput | None] | None = None
     table_type: TableType | None = None
-    dimensions: list[KeyValueListPairInput] | None = None
+    dimensions: list[KeyValueListPairInput | None] | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
 
 def mutate_create_table(info: Info, input: CreateTableInput) -> Table:

--- a/spike/strawberry_poc/models/thing.py
+++ b/spike/strawberry_poc/models/thing.py
@@ -64,15 +64,15 @@ class Thing:
     children_raw: strawberry.Private[list | None] = None
 
     @relay.connection(FileRelationsConnection)
-    def files(self, info: Info) -> list[FileRelation]:
+    def files(self, info: Info) -> list[FileRelation | None]:
         return build_file_relations_for_thing(self.pk, self.files_raw or [])
 
     @relay.connection(TaskRelationsConnection)
-    def parents(self, info: Info) -> list[TaskTaskRelation]:
+    def parents(self, info: Info) -> list[TaskTaskRelation | None]:
         return build_task_parents(self.pk, self.parents_raw or [])
 
     @relay.connection(TaskRelationsConnection)
-    def children(self, info: Info) -> list[TaskTaskRelation]:
+    def children(self, info: Info) -> list[TaskTaskRelation | None]:
         return build_task_children(self.pk, self.children_raw or [])
 
 
@@ -103,12 +103,12 @@ class AutomationTaskInterface:
     general_task_id: strawberry.ID | None = None
     task_type: TaskSubType | None = None
     model_type: ModelType | None = None
-    arguments: list[KeyValuePair] | None = None
-    environment: list[KeyValuePair] | None = None
-    metrics: list[KeyValuePair] | None = None
+    arguments: list[KeyValuePair | None] | None = None
+    environment: list[KeyValuePair | None] | None = None
+    metrics: list[KeyValuePair | None] | None = None
 
     parents_raw: strawberry.Private[list | None] = None
 
     @relay.connection(TaskRelationsConnection)
-    def parents(self, info: Info) -> list[TaskTaskRelation]:
+    def parents(self, info: Info) -> list[TaskTaskRelation | None]:
         return build_task_parents(self.pk, self.parents_raw or [])

--- a/spike/strawberry_poc/models/time_dependent_inversion_solution.py
+++ b/spike/strawberry_poc/models/time_dependent_inversion_solution.py
@@ -25,7 +25,7 @@ _InversionSolution = Annotated["InversionSolution", strawberry.lazy("models.inve
 @strawberry.type
 class TimeDependentInversionSolution(relay.Node, FileInterface, InversionSolutionInterface, PredecessorsInterface):
     pk: relay.NodeID[str]
-    metrics: list[KeyValuePair] | None = None
+    metrics: list[KeyValuePair | None] | None = None
     # tables, produced_by, mfd_table, mfd_table_id, hazard_table_id, relations
     # are all inherited from InversionSolutionInterface.
 
@@ -76,9 +76,9 @@ class CreateTimeDependentInversionSolutionInput:
     produced_by: strawberry.ID | None = None
     md5_digest: str | None = None
     file_size: BigInt | None = None
-    meta: list[KeyValuePairInput] | None = None
+    meta: list[KeyValuePairInput | None] | None = None
     created: DateTime | None = None
-    predecessors: list[PredecessorInput] | None = None
+    predecessors: list[PredecessorInput | None] | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
 
 

--- a/spike/strawberry_poc/schema.py
+++ b/spike/strawberry_poc/schema.py
@@ -163,7 +163,9 @@ class SearchResultEdge:
 
 @strawberry.type
 class SearchResultConnection:
-    edges: list[SearchResultEdge] = strawberry.field(default_factory=list)
+    # Matches legacy `[SearchResultEdge]!` — non-null outer list, nullable elements.
+    # See docs/smoke-test-learnings.md §1 on Strawberry's `list[T] → [T!]` default.
+    edges: list[SearchResultEdge | None] = strawberry.field(default_factory=list)
 
 
 @strawberry.type(name="Search")
@@ -324,14 +326,22 @@ class CreateOpenquakeHazardSolutionPayload:
 @strawberry.type(name="CreateOpenquakeHazardTask")
 class CreateOpenquakeHazardTaskPayload:
     ok: bool | None = None
-    task_result: OpenquakeHazardTask | None = None
+    # Field name matches legacy SDL — `openquake_hazard_task`, not the
+    # POC-original `task_result` (chris's audit Problem 2 #1).
+    openquake_hazard_task: OpenquakeHazardTask | None = strawberry.field(
+        default=None, name="openquake_hazard_task"
+    )
     client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
 @strawberry.type(name="UpdateOpenquakeHazardTask")
 class UpdateOpenquakeHazardTaskPayload:
     ok: bool | None = None
-    task_result: OpenquakeHazardTask | None = None
+    # Legacy uses `openquake_hazard_task` not `task_result` on the OQ task
+    # payloads (chris's Problem 2 #1).
+    openquake_hazard_task: OpenquakeHazardTask | None = strawberry.field(
+        default=None, name="openquake_hazard_task"
+    )
     client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
@@ -678,7 +688,7 @@ class Mutation:
     ) -> CreateOpenquakeHazardTaskPayload:
         return CreateOpenquakeHazardTaskPayload(
             ok=True,
-            task_result=mutate_create_openquake_hazard_task(info, input),
+            openquake_hazard_task=mutate_create_openquake_hazard_task(info, input),
             client_mutation_id=input.client_mutation_id,
         )
 
@@ -688,7 +698,7 @@ class Mutation:
     ) -> UpdateOpenquakeHazardTaskPayload:
         return UpdateOpenquakeHazardTaskPayload(
             ok=True,
-            task_result=mutate_update_openquake_hazard_task(info, input),
+            openquake_hazard_task=mutate_update_openquake_hazard_task(info, input),
             client_mutation_id=input.client_mutation_id,
         )
 
@@ -709,10 +719,16 @@ class Mutation:
 
     @strawberry.mutation
     def create_task_relation(
-        self, info: strawberry.types.Info, input: CreateTaskRelationInput
+        self,
+        info: strawberry.types.Info,
+        child_id: strawberry.ID,
+        parent_id: strawberry.ID,
     ) -> CreateTaskRelationPayload:
-        relation = mutate_create_task_relation(info, input)
-        return CreateTaskRelationPayload(ok=True, thing_relation=relation, client_mutation_id=input.client_mutation_id)
+        # Positional signature mirrors legacy `create_task_relation(child_id, parent_id)`.
+        # Sibling to create_file_relation (which #320 fixed) — runzi sends both.
+        input_obj = CreateTaskRelationInput(parent_id=parent_id, child_id=child_id)
+        relation = mutate_create_task_relation(info, input_obj)
+        return CreateTaskRelationPayload(ok=True, thing_relation=relation, client_mutation_id=None)
 
     @strawberry.mutation
     def reindex(self, info: strawberry.types.Info, id_in: list[strawberry.ID]) -> ReindexPayload:

--- a/spike/strawberry_poc/tests/test_general_task.py
+++ b/spike/strawberry_poc/tests/test_general_task.py
@@ -88,8 +88,8 @@ mutation CreateTask($input: CreateAutomationTaskInput!) {
 """
 
 CREATE_TASK_RELATION_MUTATION = """
-mutation CreateRelation($input: CreateTaskRelationInput!) {
-    create_task_relation(input: $input) {
+mutation CreateRelation($child_id: ID!, $parent_id: ID!) {
+    create_task_relation(child_id: $child_id, parent_id: $parent_id) {
         ok
     }
 }
@@ -247,7 +247,7 @@ def test_children_total_count_after_relation(gql_context, created_task):
 
     rel_result = schema.execute_sync(
         CREATE_TASK_RELATION_MUTATION,
-        variable_values={"input": {"parent_id": created_task["id"], "child_id": child_id}},
+        variable_values={"parent_id": created_task["id"], "child_id": child_id},
         context_value=gql_context,
     )
     assert rel_result.errors is None, rel_result.errors

--- a/spike/strawberry_poc/tests/test_nodes_query.py
+++ b/spike/strawberry_poc/tests/test_nodes_query.py
@@ -121,8 +121,8 @@ mutation($input: CreateScaledInversionSolutionInput!) {
 """
 
 CREATE_TASK_RELATION_MUTATION = """
-mutation($input: CreateTaskRelationInput!) {
-    create_task_relation(input: $input) { ok }
+mutation($child_id: ID!, $parent_id: ID!) {
+    create_task_relation(child_id: $child_id, parent_id: $parent_id) { ok }
 }
 """
 
@@ -158,7 +158,7 @@ def chain(gql_context):
 
     rel_result = schema.execute_sync(
         CREATE_TASK_RELATION_MUTATION,
-        variable_values={"input": {"parent_id": gt_id, "child_id": at_id}},
+        variable_values={"parent_id": gt_id, "child_id": at_id},
         context_value=gql_context,
     )
     assert rel_result.errors is None, rel_result.errors

--- a/spike/strawberry_poc/tests/test_openquake.py
+++ b/spike/strawberry_poc/tests/test_openquake.py
@@ -21,7 +21,7 @@ CREATE_OQ_TASK_MUTATION = """
 mutation CreateOQTask($input: CreateOpenquakeHazardTaskInput!) {
     create_openquake_hazard_task(input: $input) {
         ok
-        task_result {
+        openquake_hazard_task {
             id
             state
             result
@@ -57,7 +57,7 @@ UPDATE_OQ_TASK_MUTATION = """
 mutation UpdateOQTask($input: UpdateOpenquakeHazardTaskInput!) {
     update_openquake_hazard_task(input: $input) {
         ok
-        task_result {
+        openquake_hazard_task {
             id
             state
             result
@@ -150,7 +150,7 @@ def created_oq_task(gql_context):
         context_value=gql_context,
     )
     assert result.errors is None, result.errors
-    return result.data["create_openquake_hazard_task"]["task_result"]
+    return result.data["create_openquake_hazard_task"]["openquake_hazard_task"]
 
 
 @pytest.fixture(scope="module")
@@ -241,7 +241,7 @@ def updated_oq_task(gql_context, created_oq_task, created_oq_solution):
         context_value=gql_context,
     )
     assert result.errors is None, result.errors
-    return result.data["update_openquake_hazard_task"]["task_result"]
+    return result.data["update_openquake_hazard_task"]["openquake_hazard_task"]
 
 
 def test_update_oq_task_state(updated_oq_task):
@@ -339,7 +339,7 @@ CREATE_OQ_TASK_DISAGG_MUTATION = """
 mutation CreateDisaggTask($input: CreateOpenquakeHazardTaskInput!) {
     create_openquake_hazard_task(input: $input) {
         ok
-        task_result { id task_type state result }
+        openquake_hazard_task { id task_type state result }
     }
 }
 """
@@ -370,7 +370,7 @@ def disagg_oq_task(gql_context):
         context_value=gql_context,
     )
     assert result.errors is None, result.errors
-    return result.data["create_openquake_hazard_task"]["task_result"]
+    return result.data["create_openquake_hazard_task"]["openquake_hazard_task"]
 
 
 def test_create_disagg_oq_task(disagg_oq_task):
@@ -395,7 +395,7 @@ CREATE_OQ_TASK_WITH_TREES_MUTATION = """
 mutation CreateTaskTrees($input: CreateOpenquakeHazardTaskInput!) {
     create_openquake_hazard_task(input: $input) {
         ok
-        task_result {
+        openquake_hazard_task {
             id
             task_type
             model_type
@@ -429,7 +429,7 @@ def oq_task_with_trees(gql_context):
         context_value=gql_context,
     )
     assert result.errors is None, result.errors
-    return result.data["create_openquake_hazard_task"]["task_result"]
+    return result.data["create_openquake_hazard_task"]["openquake_hazard_task"]
 
 
 def test_oq_task_srm_logic_tree_round_trip(oq_task_with_trees):

--- a/spike/strawberry_poc/tests/test_sdl_emission_invariants.py
+++ b/spike/strawberry_poc/tests/test_sdl_emission_invariants.py
@@ -1,0 +1,155 @@
+"""SDL emission invariants — catches Strawberry-default footguns before they ship.
+
+The list-element nullability gotcha (documented in `docs/smoke-test-learnings.md`)
+slipped through because no test caught it at the schema-build layer. This file
+fills that gap: pure SDL inspection, runs as a unit test, no GraphQL execution
+required.
+
+The invariants we lock in here exist because:
+
+1. Strawberry's `list[T]` emits `[T!]` (non-null elements) by default.
+2. Legacy Graphene emits `[T]` (nullable elements) by default.
+3. The two are NOT wire-equivalent for input variables — GraphQL's
+   variable-type subsumption check rejects `$x: [T]!` flowing into a `[T!]!`
+   position.
+
+Any time a contributor writes `list[T]` in an `@strawberry.input` class, the
+SDL drifts further from legacy. This file fails loudly so we notice.
+"""
+
+import re
+
+import pytest
+
+from schema import schema
+
+
+@pytest.fixture(scope="module")
+def sdl() -> str:
+    return schema.as_str()
+
+
+# ── Invariant 1: every `input` type's list field uses nullable elements ───────
+
+
+def test_no_input_type_uses_non_null_list_elements(sdl):
+    """Every list-typed field inside an `input` block matches legacy `[T]`,
+    not Strawberry's default `[T!]`.
+
+    Failure here is almost certainly because a new `@strawberry.input` class
+    declared `list[T]` rather than `list[T | None]`. Fix the Python type
+    annotation in the model file, then re-run.
+    """
+    # Find every `input <Name> { ... }` block
+    for input_block in re.finditer(r"input \w+ \{[^}]+\}", sdl, re.DOTALL):
+        body = input_block.group(0)
+        type_name = re.match(r"input (\w+)", body).group(1)
+        # Find every list-typed field
+        for field_match in re.finditer(r"^\s+(\w+):\s*(\[[^\]]+\]!?)", body, re.M):
+            field_name, field_type = field_match.group(1), field_match.group(2)
+            inner = field_type.strip("[]!")
+            if inner.endswith("!"):
+                pytest.fail(
+                    f"Input {type_name}.{field_name} uses non-null list elements "
+                    f"({field_type}). Legacy Graphene emits `[T]` (nullable "
+                    f"elements). Fix the Python type to `list[T | None]` so "
+                    f"runzi-style variables `${field_name}: [T]!` validate. "
+                    f"See docs/smoke-test-learnings.md §1."
+                )
+
+
+# ── Invariant 2: critical mutations remain positional, not input-wrapped ──────
+
+
+def test_create_file_uses_positional_args(sdl):
+    """create_file's positional shape must not regress to `input: CreateFileInput!`.
+
+    nshm-toshi-client sends it as `create_file(file_name:, md5_digest:, …)`.
+    """
+    m = re.search(r"create_file\([^)]+\)[^\n]+", sdl, re.S)
+    assert m, "create_file disappeared from SDL"
+    sig = m.group(0)
+    assert "file_name: String!" in sig, f"create_file lost positional file_name: {sig}"
+    assert "input: CreateFileInput" not in sig, (
+        f"create_file regressed to input wrapper — would break nshm-toshi-client: {sig}"
+    )
+
+
+def test_create_file_relation_uses_positional_args(sdl):
+    """Sibling mutation also stays positional."""
+    m = re.search(r"create_file_relation\([^)]+\)[^\n]+", sdl, re.S)
+    assert m, "create_file_relation disappeared from SDL"
+    sig = m.group(0)
+    assert "file_id: ID!" in sig, f"create_file_relation lost positional file_id: {sig}"
+    assert "input: CreateFileRelationInput" not in sig, (
+        f"create_file_relation regressed: {sig}"
+    )
+
+
+def test_create_task_relation_uses_positional_args(sdl):
+    """create_task_relation matches `(child_id, parent_id)` legacy shape."""
+    m = re.search(r"create_task_relation\([^)]+\)[^\n]+", sdl, re.S)
+    assert m, "create_task_relation disappeared from SDL"
+    sig = m.group(0)
+    assert "child_id: ID!" in sig, f"create_task_relation lost positional child_id: {sig}"
+    assert "parent_id: ID!" in sig, f"create_task_relation lost positional parent_id: {sig}"
+    assert "input: CreateTaskRelationInput" not in sig, (
+        f"create_task_relation regressed: {sig}"
+    )
+
+
+# ── Invariant 3: Connection type names match legacy ──────────────────────────
+
+
+def test_connection_type_names_match_legacy(sdl):
+    """Connection types use legacy names — clients embed these in fragments."""
+    # Legacy: FileRelationConnection (no plural "s"), TaskTaskRelationConnection (double "Task")
+    assert "type FileRelationConnection " in sdl, "FileRelationConnection missing"
+    assert "type TaskTaskRelationConnection " in sdl, "TaskTaskRelationConnection missing"
+    # POC-original names should be gone
+    assert "type FileRelationsConnection " not in sdl, (
+        "FileRelationsConnection (plural) regressed into SDL — clients break"
+    )
+    assert "type TaskRelationsConnection " not in sdl, (
+        "TaskRelationsConnection (single Task) regressed into SDL"
+    )
+
+
+# ── Invariant 4: OQ task payloads use `openquake_hazard_task` not `task_result` ──
+
+
+def test_openquake_hazard_task_payload_field_name(sdl):
+    """Create/Update OQ task payloads must expose `openquake_hazard_task`,
+    not the POC-original `task_result`. Legacy contract; runzi depends on it.
+    """
+    for type_name in ("CreateOpenquakeHazardTask", "UpdateOpenquakeHazardTask"):
+        m = re.search(rf"type {type_name} \{{[^}}]+\}}", sdl, re.DOTALL)
+        assert m, f"{type_name} missing from SDL"
+        body = m.group(0)
+        assert "openquake_hazard_task:" in body, (
+            f"{type_name} missing `openquake_hazard_task` field — legacy contract: {body}"
+        )
+
+
+# ── Invariant 5: chris's audit Problem 2 — specific missing-field regressions ──
+
+
+def test_labelled_table_relation_has_table_field(sdl):
+    """LabelledTableRelation must expose `table` so runzi's
+    `tables { table { id } }` query resolves.
+    """
+    m = re.search(r"type LabelledTableRelation \{[^}]+\}", sdl, re.DOTALL)
+    assert m, "LabelledTableRelation missing"
+    assert "table: Table" in m.group(0) or "table:" in m.group(0).split("table_type")[0], (
+        f"LabelledTableRelation missing `table` field: {m.group(0)}"
+    )
+
+
+def test_create_inversion_solution_input_has_mfd_table_id(sdl):
+    """CreateInversionSolutionInput must accept `mfd_table_id` — runzi sends it."""
+    m = re.search(r"input CreateInversionSolutionInput \{[^}]+\}", sdl, re.DOTALL)
+    assert m, "CreateInversionSolutionInput missing"
+    body = m.group(0)
+    assert "mfd_table_id:" in body, (
+        f"CreateInversionSolutionInput missing mfd_table_id: {body}"
+    )

--- a/spike/strawberry_poc/tests/test_smoketest_ab.py
+++ b/spike/strawberry_poc/tests/test_smoketest_ab.py
@@ -188,10 +188,8 @@ def ids(gql_context):
     data = run(
         """
         mutation new_task_subtask_relation($child_id: ID!, $parent_id: ID!) {
-            create_task_relation(input: {
-                child_id: $child_id
-                parent_id: $parent_id
-            }) {
+            create_task_relation(child_id: $child_id
+                parent_id: $parent_id) {
                 thing_relation {
                     parent { ... on GeneralTask { id } }
                     child  { ... on RuptureGenerationTask { id } }

--- a/spike/strawberry_poc/tests/test_thing_interface.py
+++ b/spike/strawberry_poc/tests/test_thing_interface.py
@@ -24,8 +24,8 @@ mutation($input: CreateAutomationTaskInput!) {
 """
 
 CREATE_TASK_RELATION_MUTATION = """
-mutation($input: CreateTaskRelationInput!) {
-    create_task_relation(input: $input) { ok }
+mutation($child_id: ID!, $parent_id: ID!) {
+    create_task_relation(child_id: $child_id, parent_id: $parent_id) { ok }
 }
 """
 
@@ -93,7 +93,7 @@ def gt_with_child_at(gql_context):
 
     rel = schema.execute_sync(
         CREATE_TASK_RELATION_MUTATION,
-        variable_values={"input": {"parent_id": gt_id, "child_id": at_id}},
+        variable_values={"parent_id": gt_id, "child_id": at_id},
         context_value=gql_context,
     )
     assert rel.errors is None, rel.errors


### PR DESCRIPTION
> **Stacked above:** #323 — legacy-test port + 4 follow-up parity gaps. Use it as the proof harness for this PR.

> **Blocks #319** — the ADR-004 code reorganization should land only after the runzi-breaking SDL gaps in this PR are merged and confirmed against `chrisdicaprio`'s mini-Phase-4 testing. Reorganizing the tree before parity is restored would just move broken paths around.

## Summary

Closes the wire-impacting Strawberry POC ↔ legacy SDL divergences that the runzi end-to-end smoke test surfaced.

The headline regression: every `@strawberry.input` list field declared as `list[T] | None = None` emits `[T!]` in the SDL, whereas legacy Graphene emits `[T]`. GraphQL's variable-type subsumption rejects runzi-style `\$meta: [KeyValuePair]!` flowing into a `[KeyValuePair!]!` position even though the JSON payloads are byte-identical. Same gotcha applies to output types for typed-codegen clients.

See [#321 — smoke-test-learnings](../pull/321) for the full root-cause analysis and the gaps in the test regime that let this through.

## What's in this PR

**List-element nullability** — all 34 input mismatches and all output mismatches except 5 intentional auto-gen Connection types fixed. Each `list[T] | None = None` → `list[T | None] | None = None`.

**Connection type renames** via `@strawberry.type(name=...)` decorators (Python class keeps plural form to avoid colliding with Strawberry's per-node Connection):
- `FileRelationsConnection` → SDL `FileRelationConnection`
- `TaskRelationsConnection` → SDL `TaskTaskRelationConnection`

**Mutation shape fixes**:
- `create_task_relation` → positional `(child_id, parent_id)`
- `CreateOpenquakeHazardTaskPayload.task_result` → `openquake_hazard_task`
- `UpdateOpenquakeHazardTaskPayload.task_result` → `openquake_hazard_task`

**Missing fields** (chris's Problem 2 audit):
- `LabelledTableRelation.table: Table` resolver
- `CreateInversionSolutionInput.mfd_table_id` + `.hazard_table_id`
- `SearchResultConnection.edges` legacy shape

**New `tests/test_sdl_emission_invariants.py`** (8 tests, pure SDL inspection) locks in five invariants so regressions fail loudly at the unit-test layer:
1. No `@strawberry.input` uses non-null list elements
2. `create_file` / `create_file_relation` / `create_task_relation` stay positional
3. Connection type names match legacy
4. OQ task payloads expose `openquake_hazard_task` not `task_result`
5. `LabelledTableRelation.table` + `CreateInversionSolutionInput.mfd_table_id` present

**Docs**: `ADR-002` gains a round-2 audit section that supersedes the original §3a framing. "Wire compat" is now explicitly defined to cover input variable types and SDL fragment-spread names, not just response JSON.

## Test plan

- [x] Full POC suite passes: 269 tests pass, 1 skipped
- [x] New SDL emission invariants test: 8 passing
- [x] Existing test files updated for the positional `create_task_relation` shape and renamed OQ payload field
- [x] No legacy `graphql_api/` changes — this PR is POC-only
- [ ] Reviewer: confirm runzi can complete an end-to-end ingestion against the POC SDL emitted by this branch

