### PR TITLE
fix(strawberry-poc): legacy-test port + 4 follow-up parity gaps (#322-proof)

### DIFF
--- a/spike/strawberry_poc/data/models.py
+++ b/spike/strawberry_poc/data/models.py
@@ -25,7 +25,10 @@ class KVPairModel(BaseModel):
 
 class KVListPairModel(BaseModel):
     k: str
-    v: list[str]
+    # Legacy data shape allows null elements inside `v` (e.g. `v: [null]` for
+    # an unswept argument with no recorded value). Mirror that here so the
+    # Pydantic validator doesn't reject what the SDL `list[str | None]` accepts.
+    v: list[str | None]
 
 
 # ── Thing types (ToshiThingObject) ────────────────────────────────────────────

--- a/spike/strawberry_poc/data/models.py
+++ b/spike/strawberry_poc/data/models.py
@@ -91,6 +91,11 @@ class StrongMotionStationData(BaseModel):
 # ── File types (ToshiFileObject) ──────────────────────────────────────────────
 
 
+class PredecessorEntry(BaseModel):
+    id: str  # relay GlobalID string
+    depth: int
+
+
 class ToshiFileData(BaseModel):
     object_id: str
     clazz_name: str | None = None
@@ -100,6 +105,9 @@ class ToshiFileData(BaseModel):
     meta: list[KVPairModel] | None = None
     created: str | None = None
     relations: list[dict] | None = None
+    # Plain File supports predecessors (legacy parity — File ships
+    # `PredecessorsInterface` and `create_file(predecessors:)` accepts them).
+    predecessors: list[PredecessorEntry] | None = None
 
 
 class SmsFileData(ToshiFileData):
@@ -114,11 +122,6 @@ class LabelledTableRelationEntry(BaseModel):
     table_id: str | None = None
     table_type: str | None = None
     dimensions: list[KVListPairModel] | None = None
-
-
-class PredecessorEntry(BaseModel):
-    id: str  # relay GlobalID string
-    depth: int
 
 
 class InversionSolutionData(ToshiFileData):

--- a/spike/strawberry_poc/models/common.py
+++ b/spike/strawberry_poc/models/common.py
@@ -28,6 +28,31 @@ BigInt = strawberry.scalar(
     "Used for file_size where production values can exceed 2GB.",
 )
 
+def _parse_datetime(value):
+    """Validate an inbound DateTime value, matching legacy Graphene semantics:
+      - must parse as ISO 8601
+      - must be timezone-aware (naive datetimes are rejected)
+    Returns the string unchanged so downstream resolvers see a `str` (the rest
+    of the codebase treats DateTime values as strings end-to-end).
+    """
+    import datetime as _dt  # noqa: PLC0415
+
+    if value is None:
+        return None
+    if isinstance(value, _dt.datetime):
+        if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+            raise ValueError("DateTime value must have a timezone (naive datetimes are rejected)")
+        return value.isoformat()
+    s = str(value)
+    try:
+        parsed = _dt.datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"DateTime value {value!r} is not a valid ISO 8601 datetime") from exc
+    if parsed.tzinfo is None or parsed.tzinfo.utcoffset(parsed) is None:
+        raise ValueError("DateTime value must have a timezone (naive datetimes are rejected)")
+    return s
+
+
 # ADR-001 Phase 1: restore the legacy typed scalars. Wire format is an ISO 8601
 # string (DateTime) or a JSON-encoded string (JSONString). Python type stays as
 # `str` so we don't force every resolver to construct typed values; the scalar
@@ -35,9 +60,11 @@ BigInt = strawberry.scalar(
 DateTime = strawberry.scalar(
     NewType("DateTime", str),
     serialize=str,
-    parse_value=str,
-    description="An ISO 8601 datetime string. Wire-compatible with the legacy graphene "
-    "DateTime scalar; typed clients get a `DateTime` rather than a plain `String`.",
+    parse_value=_parse_datetime,
+    description="An ISO 8601 datetime string with timezone. Wire-compatible "
+    "with the legacy graphene DateTime scalar (which rejected naive and "
+    "malformed values); typed clients get a `DateTime` rather than a "
+    "plain `String`.",
 )
 
 JSONString = strawberry.scalar(

--- a/spike/strawberry_poc/models/file.py
+++ b/spike/strawberry_poc/models/file.py
@@ -19,16 +19,19 @@ from data.s3 import presigned_post_for_file
 
 from .common import BigInt, DateTime, KeyValuePair, KeyValuePairInput, client_mutation_id_input_field
 from .file_interface import FileInterface
+from .predecessor import PredecessorInput
+from .predecessors_interface import PredecessorsInterface
 from .relations import FileRelation, FileRelationsConnection, build_file_relations_for_file
 
 
 @strawberry.type(name="File")
-class ToshiFile(relay.Node, FileInterface):
+class ToshiFile(relay.Node, FileInterface, PredecessorsInterface):
     """A file stored in S3 and indexed in DynamoDB."""
 
     pk: relay.NodeID[str]
 
     relations_raw: strawberry.Private[list | None] = None
+    predecessors_raw: strawberry.Private[list | None] = None
 
     @relay.connection(FileRelationsConnection)
     def relations(self, info: Info) -> list[FileRelation | None]:
@@ -56,6 +59,7 @@ class ToshiFile(relay.Node, FileInterface):
             meta=[KeyValuePair(k=i.k, v=i.v) for i in d.meta] if d.meta else None,
             created=d.created,
             relations_raw=d.relations,
+            predecessors_raw=[p.model_dump() for p in d.predecessors] if d.predecessors else None,
         )
 
 
@@ -66,7 +70,9 @@ class CreateFileInput:
     file_size: BigInt | None = None
     meta: list[KeyValuePairInput | None] | None = None
     created: DateTime | None = None
-    created: str | None = None
+    # Legacy parity: plain File accepts predecessors. Persisted on the
+    # ToshiFileObject row alongside meta/relations.
+    predecessors: list[PredecessorInput | None] | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
 
 
@@ -77,12 +83,16 @@ def resolve_files(info: Info) -> Iterable[ToshiFile]:
 
 def mutate_create_file(info: Info, input: CreateFileInput) -> ToshiFile:
     meta = [{"k": i.k, "v": i.v} for i in input.meta] if input.meta else None
+    predecessors = (
+        [{"id": str(p.id), "depth": p.depth} for p in input.predecessors] if input.predecessors else None
+    )
     payload = {
         "file_name": input.file_name,
         "md5_digest": input.md5_digest,
         "file_size": input.file_size,
         "meta": meta,
         "created": input.created,
+        "predecessors": predecessors,
     }
     data = create_file(info.context["dynamodb"], "File", payload)
     instance = ToshiFile.from_dict(data)

--- a/spike/strawberry_poc/models/inversion_solution_interface.py
+++ b/spike/strawberry_poc/models/inversion_solution_interface.py
@@ -131,6 +131,26 @@ class InversionSolutionInterface:
         return None
 
     @strawberry.field
+    def hazard_table(self, info: Info) -> _Table | None:
+        """Resolved Table reference for the embedded HAZARD_* table, if any.
+        Mirrors `mfd_table` — legacy SDL ships both.
+        """
+        if not self.tables:
+            return None
+        for t in self.tables:  # type: ignore[union-attr]
+            if t.table_type in (TableType.HAZARD_GRIDDED, TableType.HAZARD_SITES) and t.table_id:  # type: ignore[attr-defined]
+                try:
+                    raw_id = GlobalID.from_id(str(t.table_id)).node_id  # type: ignore[attr-defined]
+                except Exception:
+                    raw_id = str(t.table_id)  # type: ignore[attr-defined]
+                data = get_table(info.context["dynamodb"], raw_id)
+                if data:
+                    from models.table import Table  # noqa: PLC0415
+
+                    return Table.from_dict(data)
+        return None
+
+    @strawberry.field
     def hazard_table_id(self) -> str | None:
         if not self.tables:
             return None

--- a/spike/strawberry_poc/models/openquake_hazard_config.py
+++ b/spike/strawberry_poc/models/openquake_hazard_config.py
@@ -91,7 +91,6 @@ class CreateOpenquakeHazardConfigInput:
     template_archive: strawberry.ID
     source_models: list[strawberry.ID | None] | None = None
     created: DateTime | None = None
-    created: str | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
 
 

--- a/spike/strawberry_poc/models/openquake_hazard_task.py
+++ b/spike/strawberry_poc/models/openquake_hazard_task.py
@@ -138,6 +138,8 @@ class UpdateOpenquakeHazardTaskInput:
     environment: list[KeyValuePairInput | None] | None = None
     metrics: list[KeyValuePairInput | None] | None = None
     hazard_solution: strawberry.ID | None = None
+    # Legacy parity: runzi's `complete_task` mutation sets executor on update.
+    executor: str | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
 
 def resolve_openquake_hazard_tasks(info: Info) -> Iterable[OpenquakeHazardTask]:
@@ -176,6 +178,7 @@ def mutate_update_openquake_hazard_task(
         "environment": [{"k": i.k, "v": i.v} for i in input.environment] if input.environment else None,
         "metrics": [{"k": i.k, "v": i.v} for i in input.metrics] if input.metrics else None,
         "hazard_solution": str(input.hazard_solution) if input.hazard_solution else None,
+        "executor": input.executor,
     }
     data = update_thing(info.context["dynamodb"], gid.node_id, payload)
     return OpenquakeHazardTask.from_dict(data) if data else None

--- a/spike/strawberry_poc/models/predecessor.py
+++ b/spike/strawberry_poc/models/predecessor.py
@@ -1,9 +1,36 @@
 """Predecessor — embedded provenance type (not a relay.Node)."""
 
+from typing import Annotated
+
 import strawberry
 from strawberry.relay import GlobalID
+from strawberry.types import Info
 
 from .common import AncestryLabel
+
+# Legacy PredecessorUnion = (File, InversionSolution, ScaledInversionSolution,
+# AggregateInversionSolution, TimeDependentInversionSolution, InversionSolutionNrml).
+# All file-like; reuse the lazy refs pattern from relations.py.
+_File = Annotated["ToshiFile", strawberry.lazy("models.file")]
+_InversionSolution = Annotated["InversionSolution", strawberry.lazy("models.inversion_solution")]
+_ScaledInversionSolution = Annotated["ScaledInversionSolution", strawberry.lazy("models.scaled_inversion_solution")]
+_AggregateInversionSolution = Annotated[
+    "AggregateInversionSolution", strawberry.lazy("models.aggregate_inversion_solution")
+]
+_TimeDependentInversionSolution = Annotated[
+    "TimeDependentInversionSolution", strawberry.lazy("models.time_dependent_inversion_solution")
+]
+_InversionSolutionNrml = Annotated["InversionSolutionNrml", strawberry.lazy("models.inversion_solution_nrml")]
+
+PredecessorUnion = Annotated[
+    _File
+    | _InversionSolution
+    | _ScaledInversionSolution
+    | _AggregateInversionSolution
+    | _TimeDependentInversionSolution
+    | _InversionSolutionNrml,
+    strawberry.union(name="PredecessorUnion"),
+]
 
 
 @strawberry.type
@@ -22,10 +49,33 @@ class Predecessor:
 
     @strawberry.field
     def relationship(self) -> str | None:
+        """Title-cased ancestry label. Matches legacy `.name.title()` output —
+        e.g. depth=-1 → "Parent", not "parent". Clients (legacy + nshm) expect
+        the Title Case form.
+        """
         try:
-            return AncestryLabel(self.depth).name.lower()
+            return AncestryLabel(self.depth).name.title()
         except ValueError:
             return None
+
+    @strawberry.field
+    def node(self, info: Info) -> PredecessorUnion | None:
+        """Resolved node behind the predecessor id. Legacy SDL ships this on
+        Predecessor; clients use it to selection-spread into the underlying
+        file's fields without a separate node(id:) lookup.
+        """
+        from data.dynamo import get_file  # noqa: PLC0415
+
+        try:
+            raw_id = GlobalID.from_id(str(self.id)).node_id
+        except Exception:
+            raw_id = str(self.id)
+        data = get_file(info.context["dynamodb"], raw_id)
+        if not data:
+            return None
+        from ._dispatch import dispatch_file as _dispatch_file  # noqa: PLC0415
+
+        return _dispatch_file(data)
 
 
 @strawberry.input

--- a/spike/strawberry_poc/models/relations.py
+++ b/spike/strawberry_poc/models/relations.py
@@ -111,6 +111,16 @@ class FileRelation:
     thing_raw_id: strawberry.Private[str]
 
     @strawberry.field
+    def file_id(self) -> str | None:
+        """Raw file ID. Legacy SDL exposes this as a public String."""
+        return self.file_raw_id
+
+    @strawberry.field
+    def thing_id(self) -> str | None:
+        """Raw thing ID. Legacy SDL exposes this as a public String."""
+        return self.thing_raw_id
+
+    @strawberry.field
     def file(self, info: Info) -> FileUnion | None:
         data = get_file(info.context["dynamodb"], self.file_raw_id)
         return _dispatch_file(data) if data else None
@@ -134,6 +144,18 @@ class TaskTaskRelation:
     parent_raw_id: strawberry.Private[str]
     child_raw_id: strawberry.Private[str]
     child_clazz: strawberry.Private[str]
+
+    @strawberry.field
+    def parent_id(self) -> str | None:
+        """Raw parent ID. Legacy SDL exposes this as a public String;
+        clients read it without traversing through `parent { id }`.
+        """
+        return self.parent_raw_id
+
+    @strawberry.field
+    def child_id(self) -> str | None:
+        """Raw child ID. Legacy SDL exposes this as a public String."""
+        return self.child_raw_id
 
     @strawberry.field
     def parent(self, info: Info) -> _GeneralTask | None:

--- a/spike/strawberry_poc/schema.py
+++ b/spike/strawberry_poc/schema.py
@@ -100,6 +100,7 @@ from models.page_info import CompatListConnection
 from models.relations import (
     CreateFileRelationInput,
     CreateTaskRelationInput,
+    FileRelation,
     TaskTaskRelation,
     mutate_create_file_relation,
     mutate_create_task_relation,
@@ -257,6 +258,7 @@ class CreateRuptureSetPayload:
 @strawberry.type(name="CreateFileRelation")
 class CreateFileRelationPayload:
     ok: bool | None = None
+    file_relation: FileRelation | None = None
     client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
@@ -715,7 +717,14 @@ class Mutation:
         # both send this shape; the `input:` wrapper form would be rejected.
         input_obj = CreateFileRelationInput(file_id=file_id, role=role, thing_id=thing_id)
         mutate_create_file_relation(info, input_obj)
-        return CreateFileRelationPayload(ok=True, client_mutation_id=None)
+        # Legacy returns the constructed FileRelation so clients can introspect
+        # the link before requerying.
+        relation = FileRelation(
+            role=role,
+            file_raw_id=GlobalID.from_id(str(file_id)).node_id,
+            thing_raw_id=GlobalID.from_id(str(thing_id)).node_id,
+        )
+        return CreateFileRelationPayload(ok=True, file_relation=relation, client_mutation_id=None)
 
     @strawberry.mutation
     def create_task_relation(

--- a/spike/strawberry_poc/schema.py
+++ b/spike/strawberry_poc/schema.py
@@ -468,7 +468,7 @@ class Query:
         return make_object_identities_connection(items, has_more, last_id)
 
     @strawberry.field
-    def nodes(self, info: strawberry.types.Info, id_in: list[strawberry.ID]) -> NodeFilterPayload:
+    def nodes(self, info: strawberry.types.Info, id_in: list[strawberry.ID | None] | None = None) -> NodeFilterPayload:
         edges = []
         for gid_str in id_in:
             try:
@@ -532,7 +532,7 @@ class Mutation:
         md5_digest: str,
         file_size: BigInt,
         created: DateTime | None = None,
-        meta: list[KeyValuePairInput] | None = None,
+        meta: list[KeyValuePairInput | None] | None = None,
     ) -> CreateFilePayload:
         # Positional signature mirrors the legacy SDL `create_file(file_name,
         # md5_digest, file_size, created, meta, predecessors): CreateFile`.
@@ -740,7 +740,7 @@ class Mutation:
         return CreateTaskRelationPayload(ok=True, thing_relation=relation, client_mutation_id=None)
 
     @strawberry.mutation
-    def reindex(self, info: strawberry.types.Info, id_in: list[strawberry.ID]) -> ReindexPayload:
+    def reindex(self, info: strawberry.types.Info, id_in: list[strawberry.ID | None] | None = None) -> ReindexPayload:
         ctx = info.context
         dynamodb = ctx["dynamodb"]
         ep = ctx.get("es_endpoint", "")

--- a/spike/strawberry_poc/schema.py
+++ b/spike/strawberry_poc/schema.py
@@ -201,6 +201,7 @@ class CreateGeneralTaskPayload:
 
 @strawberry.type(name="UpdateGeneralTaskPayload")
 class UpdateGeneralTaskPayload:
+    ok: bool | None = None
     general_task: GeneralTask | None = None
     client_mutation_id: str | None = client_mutation_id_payload_field()
 

--- a/spike/strawberry_poc/schema.py
+++ b/spike/strawberry_poc/schema.py
@@ -49,6 +49,7 @@ from models.common import (
     client_mutation_id_payload_field,
 )
 from models.file import CreateFileInput, ToshiFile, mutate_create_file, resolve_files
+from models.predecessor import PredecessorInput
 from models.general_task import (
     CreateGeneralTaskInput,
     GeneralTask,
@@ -533,21 +534,19 @@ class Mutation:
         file_size: BigInt,
         created: DateTime | None = None,
         meta: list[KeyValuePairInput | None] | None = None,
+        predecessors: list[PredecessorInput | None] | None = None,
     ) -> CreateFilePayload:
         # Positional signature mirrors the legacy SDL `create_file(file_name,
         # md5_digest, file_size, created, meta, predecessors): CreateFile`.
         # nshm-toshi-client sends this shape directly; the `input:` wrapper
         # form would reject the client's query at validation time.
-        #
-        # `predecessors` is in legacy SDL but no current client (nshm-toshi-
-        # client/runzi/weka) uses it on plain File create — omitted for now;
-        # add back if a client surfaces a need.
         input_obj = CreateFileInput(
             file_name=file_name,
             md5_digest=md5_digest,
             file_size=file_size,
             created=created,
             meta=meta,
+            predecessors=predecessors,
         )
         return CreateFilePayload(ok=True, file_result=mutate_create_file(info, input_obj), client_mutation_id=None)
 

--- a/spike/strawberry_poc/tests/test_aggregate_inversion_solution.py
+++ b/spike/strawberry_poc/tests/test_aggregate_inversion_solution.py
@@ -239,4 +239,4 @@ def test_with_predecessors(gql_context, automation_task_id, source_solution_ids,
     preds = result.data["create_aggregate_inversion_solution"]["solution"]["predecessors"]
     assert len(preds) == 1
     assert preds[0]["id"] == source_solution_ids[0]
-    assert preds[0]["relationship"] == "parent"
+    assert preds[0]["relationship"] == "Parent"

--- a/spike/strawberry_poc/tests/test_automation_task_schema_legacy.py
+++ b/spike/strawberry_poc/tests/test_automation_task_schema_legacy.py
@@ -1,0 +1,101 @@
+"""Ported from graphql_api/tests/test_automation_task_schema.py.
+
+Covers cases the existing POC test_automation_task.py doesn't:
+  - Naive datetime is rejected (must include timezone)
+  - Malformed datetime string is rejected
+  - GraphQL input coercion: `metrics: {k:.. v:..}` (single object) accepted
+    where `metrics: [..]` (list) is expected
+"""
+
+import datetime as dt
+
+import pytest
+from dateutil.tz import tzutc
+
+from schema import schema
+
+
+CREATE_AT = """
+mutation ($created: DateTime!) {
+  create_automation_task(input: {
+    task_type: INVERSION
+    state: UNDEFINED
+    result: UNDEFINED
+    created: $created
+    duration: 600
+  })
+  { task_result { id } }
+}
+"""
+
+
+CREATE_AT_INLINE_DATE = """
+mutation {
+  create_automation_task(input: {
+    task_type: INVERSION
+    state: UNDEFINED
+    result: UNDEFINED
+    created: "September 5th, 1999"
+    duration: 600
+  })
+  { task_result { id } }
+}
+"""
+
+
+CREATE_AT_WITH_SCALAR_METRICS = """
+mutation ($created: DateTime!) {
+  create_automation_task(input: {
+    task_type: INVERSION
+    state: UNDEFINED
+    result: UNDEFINED
+    created: $created
+    duration: 600
+    # GraphQL input coercion: single object should be auto-wrapped to list.
+    metrics: { k: "rupture_count" v: "206776" }
+  })
+  { task_result { id metrics { k v } } }
+}
+"""
+
+
+def test_naive_datetime_rejected(gql_context):
+    """Bare datetime (no tz) should fail at the DateTime scalar layer."""
+    naive = dt.datetime.now()  # no tz
+    res = schema.execute_sync(
+        CREATE_AT, variable_values={"created": naive.isoformat()}, context_value=gql_context
+    )
+    assert res.errors is not None, "expected naive datetime to be rejected"
+    # The legacy error said "must have a timezone". Strawberry's may differ; we
+    # accept any error referencing timezone or aware/naive distinction.
+    err_text = " ".join(str(e) for e in res.errors).lower()
+    assert any(token in err_text for token in ("timezone", "tz", "aware", "naive")), (
+        f"DateTime rejection error didn't mention tz/timezone: {res.errors}"
+    )
+
+
+def test_malformed_datetime_rejected(gql_context):
+    """A clearly-non-iso string should be rejected by the DateTime scalar."""
+    res = schema.execute_sync(CREATE_AT_INLINE_DATE, context_value=gql_context)
+    assert res.errors is not None
+    # The legacy error included the offending string in the message. POC may
+    # too — accept either way as long as there's some validation error.
+    err_text = " ".join(str(e) for e in res.errors)
+    assert err_text  # any non-empty error message is fine
+
+
+def test_single_object_coerces_to_list(gql_context):
+    """GraphQL input coercion: passing `metrics: { k: ..., v: ... }` (a single
+    object) at a position expecting `[KeyValuePairInput]` is valid GraphQL — the
+    spec mandates the value be wrapped into a single-element list. Legacy
+    accepted this; POC should too.
+    """
+    created = dt.datetime.now(tzutc()).isoformat()
+    res = schema.execute_sync(
+        CREATE_AT_WITH_SCALAR_METRICS,
+        variable_values={"created": created},
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    task = res.data["create_automation_task"]["task_result"]
+    assert task["metrics"] == [{"k": "rupture_count", "v": "206776"}]

--- a/spike/strawberry_poc/tests/test_bugfix_167_fileunion_aggregate.py
+++ b/spike/strawberry_poc/tests/test_bugfix_167_fileunion_aggregate.py
@@ -1,0 +1,175 @@
+"""Ported from graphql_api/tests/hazard/test_bugfix_167_missing_fileunion.py.
+
+Bug #167: AutomationTask.files traversal `... on FileInterface { file_name }`
+must resolve when the file is an AggregateInversionSolution. Original bug:
+FileUnion didn't include AggregateInversionSolution, so the link couldn't be
+resolved.
+
+POC's FileUnion already includes AggregateInversionSolution; this test
+verifies the integration works end-to-end.
+"""
+
+import datetime as dt
+
+import pytest
+from dateutil.tz import tzutc
+
+from schema import schema
+
+
+CREATE_AT_AGGREGATE = """
+mutation ($created: DateTime!) {
+  create_automation_task(input: {
+    state: UNDEFINED
+    result: UNDEFINED
+    task_type: AGGREGATE_SOLUTION
+    model_type: CRUSTAL
+    created: $created
+    duration: 1
+  }) { task_result { id } }
+}
+"""
+
+CREATE_RGT = """
+mutation ($created: DateTime!) {
+  create_rupture_generation_task(input: {
+    state: UNDEFINED
+    result: UNDEFINED
+    task_type: RUPTURE_SET
+    created: $created
+    duration: 1
+  }) { task_result { id } }
+}
+"""
+
+CREATE_INVERSION = """
+mutation ($input: CreateInversionSolutionInput!) {
+  create_inversion_solution(input: $input) { inversion_solution { id } }
+}
+"""
+
+CREATE_FILE = """
+mutation ($file_name: String!, $md5: String!, $size: BigInt!) {
+  create_file(file_name: $file_name, md5_digest: $md5, file_size: $size) {
+    file_result { id }
+  }
+}
+"""
+
+CREATE_AGGREGATE = """
+mutation ($input: CreateAggregateInversionSolutionInput!) {
+  create_aggregate_inversion_solution(input: $input) {
+    solution { id file_name }
+  }
+}
+"""
+
+CREATE_FILE_RELATION = """
+mutation ($thing_id: ID!, $file_id: ID!, $role: FileRole!) {
+  create_file_relation(thing_id: $thing_id, file_id: $file_id, role: $role) { ok }
+}
+"""
+
+QUERY_AT_FILES = """
+query ($id: ID!) {
+  node(id: $id) {
+    ... on AutomationTask {
+      id
+      model_type
+      files {
+        total_count
+        edges {
+          node {
+            role
+            file {
+              __typename
+              ... on Node { id }
+              ... on FileInterface { file_name }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def scenario(gql_context):
+    created = dt.datetime.now(tzutc()).isoformat()
+
+    rgt = schema.execute_sync(CREATE_RGT, variable_values={"created": created}, context_value=gql_context)
+    assert rgt.errors is None, rgt.errors
+    rgt_id = rgt.data["create_rupture_generation_task"]["task_result"]["id"]
+
+    at = schema.execute_sync(CREATE_AT_AGGREGATE, variable_values={"created": created}, context_value=gql_context)
+    assert at.errors is None, at.errors
+    at_id = at.data["create_automation_task"]["task_result"]["id"]
+
+    common_ruptset = schema.execute_sync(
+        CREATE_FILE,
+        variable_values={"file_name": "common_ruptset.zip", "md5": "ccrr", "size": 1000},
+        context_value=gql_context,
+    )
+    assert common_ruptset.errors is None, common_ruptset.errors
+    common_ruptset_id = common_ruptset.data["create_file"]["file_result"]["id"]
+
+    upstream = schema.execute_sync(
+        CREATE_INVERSION,
+        variable_values={
+            "input": {
+                "file_name": "upstream.zip",
+                "produced_by": rgt_id,
+                "md5_digest": "aabb",
+                "file_size": 1024,
+                "created": created,
+            }
+        },
+        context_value=gql_context,
+    )
+    assert upstream.errors is None, upstream.errors
+    upstream_id = upstream.data["create_inversion_solution"]["inversion_solution"]["id"]
+
+    agg = schema.execute_sync(
+        CREATE_AGGREGATE,
+        variable_values={
+            "input": {
+                "file_name": "agg.zip",
+                "produced_by": at_id,
+                "source_solutions": [upstream_id],
+                "common_rupture_set": common_ruptset_id,
+                "aggregation_fn": "MEAN",
+                "md5_digest": "ccdd",
+                "file_size": 2048,
+                "created": created,
+            }
+        },
+        context_value=gql_context,
+    )
+    assert agg.errors is None, agg.errors
+    agg_id = agg.data["create_aggregate_inversion_solution"]["solution"]["id"]
+
+    rel = schema.execute_sync(
+        CREATE_FILE_RELATION,
+        variable_values={"thing_id": at_id, "file_id": agg_id, "role": "WRITE"},
+        context_value=gql_context,
+    )
+    assert rel.errors is None, rel.errors
+
+    return {"at_id": at_id, "agg_id": agg_id}
+
+
+def test_files_resolves_aggregate_inversion_solution(scenario, gql_context):
+    """The FileUnion must dispatch to AggregateInversionSolution typename."""
+    res = schema.execute_sync(
+        QUERY_AT_FILES, variable_values={"id": scenario["at_id"]}, context_value=gql_context
+    )
+    assert res.errors is None, res.errors
+    node = res.data["node"]
+    assert node["files"]["total_count"] == 1
+    edge = node["files"]["edges"][0]["node"]
+    assert edge["role"] == "WRITE"
+    assert edge["file"]["__typename"] == "AggregateInversionSolution"
+    assert edge["file"]["id"] == scenario["agg_id"]
+    assert edge["file"]["file_name"] == "agg.zip"

--- a/spike/strawberry_poc/tests/test_file_predecessors_legacy.py
+++ b/spike/strawberry_poc/tests/test_file_predecessors_legacy.py
@@ -1,0 +1,163 @@
+"""Ported from graphql_api/tests/hazard/test_file.py.
+
+Bug #10 (caught by porting): plain File needs `predecessors` parity with
+legacy. Legacy SDL:
+  - CreateFile accepts `predecessors: [PredecessorInput]`
+  - File implements PredecessorsInterface (selectable as
+    `... on PredecessorsInterface { predecessors { ... } }`)
+
+POC originally omitted both with a comment that no client used them.
+The legacy test shows that File-with-predecessors is a real shape —
+clients chaining files via predecessor edges need it to work.
+"""
+
+import datetime as dt
+
+import pytest
+from dateutil.tz import tzutc
+
+from schema import schema
+
+
+CREATE_FILE_NO_PRED = """
+mutation ($file_name: String!, $md5: String!, $size: BigInt!) {
+  create_file(file_name: $file_name, md5_digest: $md5, file_size: $size) {
+    file_result { id }
+  }
+}
+"""
+
+CREATE_FILE_WITH_PRED = """
+mutation (
+  $file_name: String!,
+  $md5: String!,
+  $size: BigInt!,
+  $predecessors: [PredecessorInput],
+) {
+  create_file(
+    file_name: $file_name,
+    md5_digest: $md5,
+    file_size: $size,
+    predecessors: $predecessors,
+  ) {
+    file_result {
+      id
+      file_name
+      predecessors {
+        id
+        depth
+        relationship
+        typename
+      }
+    }
+  }
+}
+"""
+
+QUERY_FILE_PREDECESSORS_VIA_INTERFACE = """
+query ($id: ID!) {
+  node(id: $id) {
+    __typename
+    ... on FileInterface { file_name }
+    ... on PredecessorsInterface {
+      predecessors {
+        id
+        depth
+        relationship
+        typename
+        node {
+          __typename
+          ... on FileInterface { file_name }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def upstream_file_id(gql_context):
+    res = schema.execute_sync(
+        CREATE_FILE_NO_PRED,
+        variable_values={"file_name": "source_solution.zip", "md5": "ssss", "size": 1000},
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    return res.data["create_file"]["file_result"]["id"]
+
+
+def test_create_file_with_predecessors_returns_chain(upstream_file_id, gql_context):
+    """Legacy regression: create_file accepts predecessors and returns them."""
+    res = schema.execute_sync(
+        CREATE_FILE_WITH_PRED,
+        variable_values={
+            "file_name": "downstream.zip",
+            "md5": "dddd",
+            "size": 2000,
+            "predecessors": [{"id": upstream_file_id, "depth": -1}],
+        },
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    result = res.data["create_file"]["file_result"]
+    preds = result["predecessors"]
+    assert len(preds) == 1
+    assert preds[0]["id"] == upstream_file_id
+    assert preds[0]["depth"] == -1
+    assert preds[0]["relationship"] == "Parent"
+    assert preds[0]["typename"] == "File"
+
+
+def test_file_via_predecessors_interface(upstream_file_id, gql_context):
+    """File must be selectable via `... on PredecessorsInterface`."""
+    create = schema.execute_sync(
+        CREATE_FILE_WITH_PRED,
+        variable_values={
+            "file_name": "downstream2.zip",
+            "md5": "dd22",
+            "size": 2048,
+            "predecessors": [{"id": upstream_file_id, "depth": -1}],
+        },
+        context_value=gql_context,
+    )
+    assert create.errors is None, create.errors
+    downstream_id = create.data["create_file"]["file_result"]["id"]
+
+    res = schema.execute_sync(
+        QUERY_FILE_PREDECESSORS_VIA_INTERFACE,
+        variable_values={"id": downstream_id},
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    node = res.data["node"]
+    assert node["__typename"] == "File"
+    assert node["file_name"] == "downstream2.zip"
+    preds = node["predecessors"]
+    assert len(preds) == 1
+    assert preds[0]["relationship"] == "Parent"
+    # The resolved Predecessor.node points back at the upstream File
+    assert preds[0]["node"]["__typename"] == "File"
+    assert preds[0]["node"]["file_name"] == "source_solution.zip"
+
+
+def test_file_without_predecessors_returns_null(gql_context):
+    """A File created without predecessors returns null/empty when queried."""
+    create = schema.execute_sync(
+        CREATE_FILE_NO_PRED,
+        variable_values={"file_name": "no_predecessors.zip", "md5": "nnnn", "size": 512},
+        context_value=gql_context,
+    )
+    assert create.errors is None, create.errors
+    file_id = create.data["create_file"]["file_result"]["id"]
+
+    res = schema.execute_sync(
+        QUERY_FILE_PREDECESSORS_VIA_INTERFACE,
+        variable_values={"id": file_id},
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    preds = res.data["node"]["predecessors"]
+    # Legacy returns null/None when no predecessors; either an empty list or
+    # null is acceptable as long as no GraphQLError surfaces.
+    assert preds is None or preds == []

--- a/spike/strawberry_poc/tests/test_file_relation_bugfix_126.py
+++ b/spike/strawberry_poc/tests/test_file_relation_bugfix_126.py
@@ -1,0 +1,103 @@
+"""Ported from graphql_api/tests/test_file_relation_bugfix_126.py.
+
+Exercises:
+  - `create_file_relation(file_id:, role:, thing_id:)` positional (#322)
+  - `CreateFileRelationPayload { ok, file_relation { file_id thing_id role } }`
+    — file_relation field on the payload (legacy parity gap caught by this port)
+  - `FileRelation.file_id` / `FileRelation.thing_id` as public Strings
+    (sibling to TaskTaskRelation.parent_id / child_id)
+"""
+
+import datetime as dt
+
+import pytest
+from dateutil.tz import tzutc
+
+from schema import schema
+
+
+CREATE_AT = """
+mutation ($created: DateTime!) {
+  create_automation_task(input: {
+    state: UNDEFINED
+    result: UNDEFINED
+    task_type: INVERSION
+    created: $created
+    duration: 600
+  })
+  { task_result { id } }
+}
+"""
+
+CREATE_FILE = """
+mutation ($file_name: String!, $md5: String!, $size: BigInt!) {
+  create_file(file_name: $file_name, md5_digest: $md5, file_size: $size) {
+    ok
+    file_result { id }
+  }
+}
+"""
+
+CREATE_AT_RELATION = """
+mutation ($thing_id: ID!, $file_id: ID!) {
+  create_file_relation(
+    thing_id: $thing_id
+    file_id: $file_id
+    role: READ
+  )
+  {
+    ok
+    file_relation {
+      file_id
+      thing_id
+      role
+    }
+  }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def at_id(gql_context):
+    created = dt.datetime.now(tzutc()).isoformat()
+    res = schema.execute_sync(CREATE_AT, variable_values={"created": created}, context_value=gql_context)
+    assert res.errors is None, res.errors
+    return res.data["create_automation_task"]["task_result"]["id"]
+
+
+@pytest.fixture(scope="module")
+def file_id(gql_context):
+    res = schema.execute_sync(
+        CREATE_FILE,
+        variable_values={"file_name": "ruptset.zip", "md5": "abcd", "size": 32045903},
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    return res.data["create_file"]["file_result"]["id"]
+
+
+def test_create_file_relation_returns_ok(at_id, file_id, gql_context):
+    """create_file_relation positional mutation returns ok=true."""
+    res = schema.execute_sync(
+        CREATE_AT_RELATION,
+        variable_values={"thing_id": at_id, "file_id": file_id},
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    assert res.data["create_file_relation"]["ok"] is True
+
+
+def test_create_file_relation_payload_includes_file_relation(at_id, file_id, gql_context):
+    """Legacy parity: payload exposes `file_relation { file_id thing_id role }`."""
+    res = schema.execute_sync(
+        CREATE_AT_RELATION,
+        variable_values={"thing_id": at_id, "file_id": file_id},
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    fr = res.data["create_file_relation"]["file_relation"]
+    assert fr is not None
+    assert fr["role"] == "READ"
+    # IDs come back as raw (post-decoded) — they're the underlying object IDs.
+    assert fr["file_id"] is not None
+    assert fr["thing_id"] is not None

--- a/spike/strawberry_poc/tests/test_general_task_schema_legacy.py
+++ b/spike/strawberry_poc/tests/test_general_task_schema_legacy.py
@@ -1,0 +1,145 @@
+"""Ported from graphql_api/tests/test_general_task_schema.py.
+
+Covers cases the existing POC `test_general_task.py` doesn't:
+  - `argument_lists` with `v: [null]` (a single-element list containing null) —
+    tests the inner-null path of `list[str | None]` that #322 was supposed to fix
+  - `swept_arguments` resolver returning ONLY the keys whose `v` has > 1 element
+    (so `v: [null]` should NOT make a key "swept")
+  - `meta` round-trip on update mutation
+"""
+
+import datetime as dt
+
+import pytest
+from dateutil.tz import tzutc
+
+from schema import schema
+
+
+CREATE_GT = """
+mutation ($created: DateTime!, $argument_lists: [KeyValueListPairInput], $meta: [KeyValuePairInput]) {
+  create_general_task(input: {
+    agent_name: "DonDuck"
+    title: "host"
+    description: "host"
+    created: $created
+    argument_lists: $argument_lists
+    meta: $meta
+  })
+  {
+    general_task {
+      id
+      argument_lists { k v }
+      swept_arguments
+      meta { k v }
+    }
+  }
+}
+"""
+
+NODE_QUERY_GT = """
+query ($id: ID!) {
+  node(id: $id) {
+    __typename
+    ... on GeneralTask {
+      id
+      argument_lists { k v }
+      swept_arguments
+      meta { k v }
+    }
+  }
+}
+"""
+
+UPDATE_GT = """
+mutation ($task_id: ID!, $updated: DateTime!, $meta: [KeyValuePairInput]) {
+  update_general_task(input: {
+    task_id: $task_id
+    updated: $updated
+    meta: $meta
+  })
+  {
+    general_task {
+      id
+      updated
+      meta { k v }
+      argument_lists { k v }
+      swept_arguments
+    }
+  }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def created(gql_context):
+    """GT created with mixed argument_lists — one swept ([20,25]), one unswept
+    with explicit null element ([null]).
+    """
+    res = schema.execute_sync(
+        CREATE_GT,
+        variable_values={
+            "created": dt.datetime.now(tzutc()).isoformat(),
+            "argument_lists": [
+                {"k": "bogus_metric", "v": ["20", "25"]},
+                {"k": "unswept_metric", "v": [None]},
+            ],
+            "meta": [{"k": "some_metric", "v": "55.5"}],
+        },
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    return res.data["create_general_task"]["general_task"]
+
+
+def test_argument_lists_inner_null_round_trip(created):
+    """`v: [null]` survives mutation round-trip — exercises #322's inner-null."""
+    al = {item["k"]: item["v"] for item in created["argument_lists"]}
+    assert al["bogus_metric"] == ["20", "25"]
+    assert al["unswept_metric"] == [None]
+
+
+def test_swept_arguments_excludes_single_null_list(created):
+    """A key with `v: [null]` (one element) is NOT swept — only keys with len(v) > 1.
+    """
+    assert created["swept_arguments"] == ["bogus_metric"]
+
+
+def test_meta_round_trip(created):
+    """meta list-of-KeyValuePair round-trips."""
+    meta = {item["k"]: item["v"] for item in created["meta"]}
+    assert meta["some_metric"] == "55.5"
+
+
+def test_node_lookup_preserves_argument_lists(created, gql_context):
+    """Same shape via node(id:) lookup — separate code path."""
+    res = schema.execute_sync(
+        NODE_QUERY_GT, variable_values={"id": created["id"]}, context_value=gql_context
+    )
+    assert res.errors is None, res.errors
+    node = res.data["node"]
+    al = {item["k"]: item["v"] for item in node["argument_lists"]}
+    assert al["unswept_metric"] == [None]
+    assert node["swept_arguments"] == ["bogus_metric"]
+
+
+def test_update_with_meta_preserves_argument_lists(created, gql_context):
+    """Update modifying only meta must preserve argument_lists / swept_arguments."""
+    res = schema.execute_sync(
+        UPDATE_GT,
+        variable_values={
+            "task_id": created["id"],
+            "updated": dt.datetime.now(tzutc()).isoformat(),
+            "meta": [{"k": "balderdash", "v": "20"}],
+        },
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    gt = res.data["update_general_task"]["general_task"]
+    new_meta = {item["k"]: item["v"] for item in gt["meta"]}
+    assert new_meta["balderdash"] == "20"
+    # argument_lists must be preserved by the update path
+    al = {item["k"]: item["v"] for item in gt["argument_lists"]}
+    assert al["bogus_metric"] == ["20", "25"]
+    assert al["unswept_metric"] == [None]
+    assert gt["swept_arguments"] == ["bogus_metric"]

--- a/spike/strawberry_poc/tests/test_inversion_solution.py
+++ b/spike/strawberry_poc/tests/test_inversion_solution.py
@@ -302,4 +302,4 @@ def test_scaled_predecessor_relationship(created_scaled, created_inversion_solut
     assert p["id"] == created_inversion_solution["id"]
     assert p["depth"] == -1
     assert p["typename"] == "InversionSolution"
-    assert p["relationship"] == "parent"
+    assert p["relationship"] == "Parent"

--- a/spike/strawberry_poc/tests/test_inversion_solution_bug_93.py
+++ b/spike/strawberry_poc/tests/test_inversion_solution_bug_93.py
@@ -1,0 +1,152 @@
+"""Ported from graphql_api/tests/test_inversion_solution_bug_93.py.
+
+Bug #93: when an AutomationTask has multiple WRITE-role file relations,
+the `inversion_solution` resolver must SKIP files whose clazz_name isn't
+an InversionSolution subtype, not return the first WRITE file.
+
+POC's test_weka_parity.py covers the simple case (one WRITE file = IS)
+and the no-write case. This port adds the discriminating case from the
+original production bug.
+"""
+
+import datetime as dt
+
+import pytest
+from dateutil.tz import tzutc
+
+from schema import schema
+
+
+CREATE_AT = """
+mutation ($created: DateTime!) {
+  create_automation_task(input: {
+    state: UNDEFINED
+    result: UNDEFINED
+    task_type: INVERSION
+    created: $created
+    duration: 97
+  }) { task_result { id } }
+}
+"""
+
+CREATE_FILE = """
+mutation ($file_name: String!, $md5: String!, $size: BigInt!) {
+  create_file(file_name: $file_name, md5_digest: $md5, file_size: $size) {
+    file_result { id }
+  }
+}
+"""
+
+CREATE_INVERSION = """
+mutation ($file_name: String!, $produced_by: ID!, $md5: String!, $size: BigInt!, $created: DateTime!) {
+  create_inversion_solution(input: {
+    file_name: $file_name
+    produced_by: $produced_by
+    md5_digest: $md5
+    file_size: $size
+    created: $created
+  }) { inversion_solution { id } }
+}
+"""
+
+CREATE_FILE_RELATION = """
+mutation ($thing_id: ID!, $file_id: ID!, $role: FileRole!) {
+  create_file_relation(thing_id: $thing_id, file_id: $file_id, role: $role) { ok }
+}
+"""
+
+QUERY_AT_INVERSION = """
+query ($id: ID!) {
+  node(id: $id) {
+    __typename
+    ... on AutomationTask {
+      id
+      inversion_solution {
+        __typename
+        ... on Node { id }
+        ... on FileInterface { file_name }
+      }
+    }
+  }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def scenario(gql_context):
+    """Replicate bug #93's data shape:
+      - 1 AutomationTask
+      - 1 READ file (plain File)
+      - 1 WRITE file (plain File, NOT an InversionSolution)
+      - 1 WRITE file (InversionSolution)
+    Resolver must return the IS, not the plain WRITE File.
+    """
+    created = dt.datetime.now(tzutc()).isoformat()
+
+    at = schema.execute_sync(CREATE_AT, variable_values={"created": created}, context_value=gql_context)
+    assert at.errors is None, at.errors
+    at_id = at.data["create_automation_task"]["task_result"]["id"]
+
+    read_file = schema.execute_sync(
+        CREATE_FILE,
+        variable_values={"file_name": "input.csv", "md5": "rrrr", "size": 100},
+        context_value=gql_context,
+    )
+    assert read_file.errors is None, read_file.errors
+    read_id = read_file.data["create_file"]["file_result"]["id"]
+
+    write_other = schema.execute_sync(
+        CREATE_FILE,
+        variable_values={"file_name": "Wellington.geojson", "md5": "wwww", "size": 725970},
+        context_value=gql_context,
+    )
+    assert write_other.errors is None, write_other.errors
+    write_other_id = write_other.data["create_file"]["file_result"]["id"]
+
+    inv = schema.execute_sync(
+        CREATE_INVERSION,
+        variable_values={
+            "file_name": "solution.zip",
+            "produced_by": at_id,
+            "md5": "iiii",
+            "size": 29144881,
+            "created": created,
+        },
+        context_value=gql_context,
+    )
+    assert inv.errors is None, inv.errors
+    inv_id = inv.data["create_inversion_solution"]["inversion_solution"]["id"]
+
+    for file_id, role in [(read_id, "READ"), (write_other_id, "WRITE"), (inv_id, "WRITE")]:
+        rel = schema.execute_sync(
+            CREATE_FILE_RELATION,
+            variable_values={"thing_id": at_id, "file_id": file_id, "role": role},
+            context_value=gql_context,
+        )
+        assert rel.errors is None, rel.errors
+
+    return {"at_id": at_id, "read_id": read_id, "write_other_id": write_other_id, "inv_id": inv_id}
+
+
+def test_inversion_solution_skips_non_is_write_files(scenario, gql_context):
+    """Bug #93 regression: with multiple WRITE files, only the IS is selected."""
+    res = schema.execute_sync(
+        QUERY_AT_INVERSION, variable_values={"id": scenario["at_id"]}, context_value=gql_context
+    )
+    assert res.errors is None, res.errors
+    sol = res.data["node"]["inversion_solution"]
+    assert sol is not None
+    assert sol["__typename"] == "InversionSolution"
+    assert sol["id"] == scenario["inv_id"]
+    assert sol["file_name"] == "solution.zip"
+
+
+def test_inversion_solution_not_the_non_is_write_file(scenario, gql_context):
+    """Explicit assertion the resolver did NOT return the plain WRITE File."""
+    res = schema.execute_sync(
+        QUERY_AT_INVERSION, variable_values={"id": scenario["at_id"]}, context_value=gql_context
+    )
+    assert res.errors is None, res.errors
+    sol = res.data["node"]["inversion_solution"]
+    assert sol["id"] != scenario["write_other_id"]
+    assert sol["id"] != scenario["read_id"]

--- a/spike/strawberry_poc/tests/test_inversion_solution_predecessors_legacy.py
+++ b/spike/strawberry_poc/tests/test_inversion_solution_predecessors_legacy.py
@@ -1,0 +1,164 @@
+"""Ported from graphql_api/tests/hazard/test_inversion_solution.py.
+
+Exercises legacy Predecessor surface area:
+  - `Predecessor.relationship` returns Title Case ("Parent", not "parent")
+  - `Predecessor.node { ... on FileInterface { file_name meta } }` resolves
+    the predecessor's underlying file
+  - Via `PredecessorsInterface` fragment
+"""
+
+import datetime as dt
+
+import pytest
+from dateutil.tz import tzutc
+
+from schema import schema
+
+
+CREATE_RGT = """
+mutation ($created: DateTime!) {
+  create_rupture_generation_task(input: {
+    state: UNDEFINED
+    result: UNDEFINED
+    task_type: RUPTURE_SET
+    created: $created
+    duration: 1
+  }) { task_result { id } }
+}
+"""
+
+CREATE_FILE = """
+mutation ($file_name: String!, $md5: String!, $size: BigInt!, $meta: [KeyValuePairInput]) {
+  create_file(file_name: $file_name, md5_digest: $md5, file_size: $size, meta: $meta) {
+    file_result { id }
+  }
+}
+"""
+
+CREATE_INVERSION_WITH_PREDECESSORS = """
+mutation (
+  $file_name: String!,
+  $md5: String!,
+  $size: BigInt!,
+  $produced_by: ID!,
+  $created: DateTime!,
+  $predecessors: [PredecessorInput]
+) {
+  create_inversion_solution(input: {
+    file_name: $file_name
+    md5_digest: $md5
+    file_size: $size
+    produced_by: $produced_by
+    created: $created
+    predecessors: $predecessors
+  }) {
+    inversion_solution {
+      id
+      predecessors {
+        id
+        typename
+        depth
+        relationship
+        node {
+          ... on FileInterface { file_name meta { k v } }
+        }
+      }
+    }
+  }
+}
+"""
+
+NODE_QUERY = """
+query ($id: ID!) {
+  node(id: $id) {
+    __typename
+    ... on PredecessorsInterface {
+      predecessors {
+        id
+        typename
+        depth
+        relationship
+        node {
+          __typename
+          ... on FileInterface { file_name }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def scenario(gql_context):
+    created = dt.datetime.now(tzutc()).isoformat()
+
+    rgt = schema.execute_sync(CREATE_RGT, variable_values={"created": created}, context_value=gql_context)
+    assert rgt.errors is None, rgt.errors
+    rgt_id = rgt.data["create_rupture_generation_task"]["task_result"]["id"]
+
+    ruptset = schema.execute_sync(
+        CREATE_FILE,
+        variable_values={
+            "file_name": "myruptset.zip",
+            "md5": "rsrs",
+            "size": 5000,
+            "meta": [{"k": "label", "v": "rupset"}],
+        },
+        context_value=gql_context,
+    )
+    assert ruptset.errors is None, ruptset.errors
+    ruptset_id = ruptset.data["create_file"]["file_result"]["id"]
+
+    inv = schema.execute_sync(
+        CREATE_INVERSION_WITH_PREDECESSORS,
+        variable_values={
+            "file_name": "MyInversion.zip",
+            "md5": "iiii",
+            "size": 1000,
+            "produced_by": rgt_id,
+            "created": created,
+            "predecessors": [{"id": ruptset_id, "depth": -1}],
+        },
+        context_value=gql_context,
+    )
+    assert inv.errors is None, inv.errors
+    inv_data = inv.data["create_inversion_solution"]["inversion_solution"]
+
+    return {"inv_id": inv_data["id"], "ruptset_id": ruptset_id, "inv_data": inv_data}
+
+
+def test_predecessor_relationship_is_title_case_on_create(scenario):
+    """relationship `Parent` (capitalized), not `parent`."""
+    pred = scenario["inv_data"]["predecessors"][0]
+    assert pred["depth"] == -1
+    assert pred["relationship"] == "Parent"
+
+
+def test_predecessor_node_resolves_to_underlying_file_on_create(scenario):
+    """Predecessor.node { ... on FileInterface { file_name } } resolves."""
+    pred = scenario["inv_data"]["predecessors"][0]
+    assert pred["node"] is not None
+    assert pred["node"]["file_name"] == "myruptset.zip"
+
+
+def test_predecessor_node_meta_round_trips(scenario):
+    """The resolved node carries the underlying file's meta."""
+    pred = scenario["inv_data"]["predecessors"][0]
+    meta = {m["k"]: m["v"] for m in pred["node"]["meta"]}
+    assert meta["label"] == "rupset"
+
+
+def test_predecessors_interface_node_lookup(scenario, gql_context):
+    """Same shape via `... on PredecessorsInterface` fragment on node(id:)."""
+    res = schema.execute_sync(
+        NODE_QUERY, variable_values={"id": scenario["inv_id"]}, context_value=gql_context
+    )
+    assert res.errors is None, res.errors
+    preds = res.data["node"]["predecessors"]
+    assert len(preds) == 1
+    p = preds[0]
+    assert p["depth"] == -1
+    assert p["relationship"] == "Parent"
+    assert p["node"]["__typename"] == "File"
+    assert p["node"]["file_name"] == "myruptset.zip"

--- a/spike/strawberry_poc/tests/test_inversion_solution_schema_legacy.py
+++ b/spike/strawberry_poc/tests/test_inversion_solution_schema_legacy.py
@@ -1,0 +1,244 @@
+"""Ported from graphql_api/tests/test_inversion_solution_schema.py.
+
+Exercises #322's surface on InversionSolution:
+  - `create_inversion_solution(input: { mfd_table_id: ... })` — new input field
+  - `InversionSolution.mfd_table { id }`, `.hazard_table { id }` — Table resolvers
+  - `InversionSolution.mfd_table_id`, `.hazard_table_id` — ID fields
+  - `LabelledTableRelation.table { id }` — new resolver
+  - `tables { identity, table_id, table_type, label, dimensions, table { id } }`
+
+Legacy tests mocked DynamoDB reads; this port seeds via real mutations.
+"""
+
+import datetime as dt
+
+import pytest
+from dateutil.tz import tzutc
+
+from schema import schema
+
+
+CREATE_TABLE = """
+mutation ($name: String, $object_id: ID!, $rows: [[String]], $column_headers: [String], $column_types: [RowItemType]) {
+  create_table(input: {
+    name: $name
+    object_id: $object_id
+    rows: $rows
+    column_headers: $column_headers
+    column_types: $column_types
+    table_type: MFD_CURVES_V2
+  }) {
+    table { id }
+  }
+}
+"""
+
+CREATE_HAZARD_TABLE = """
+mutation ($name: String, $object_id: ID!) {
+  create_table(input: {
+    name: $name
+    object_id: $object_id
+    rows: [["0.1","0.2"]]
+    column_headers: ["x","y"]
+    column_types: [double, double]
+    table_type: HAZARD_GRIDDED
+  }) {
+    table { id }
+  }
+}
+"""
+
+CREATE_GT = """
+mutation ($created: DateTime!) {
+  create_general_task(input:{
+    created: $created
+    title: "host"
+    description: "host"
+    agent_name: "tester"
+  })
+  { general_task { id } }
+}
+"""
+
+CREATE_AT = """
+mutation ($created: DateTime!) {
+  create_automation_task(input: {
+    state: UNDEFINED
+    result: UNDEFINED
+    created: $created
+    duration: 1
+    task_type: INVERSION
+  })
+  { task_result { id } }
+}
+"""
+
+CREATE_INVERSION = """
+mutation (
+  $file_name: String!,
+  $md5: String!,
+  $size: BigInt!,
+  $produced_by: ID!,
+  $created: DateTime!,
+  $mfd_table_id: ID!,
+  $hazard_table_id: ID!,
+) {
+  create_inversion_solution(input: {
+    file_name: $file_name
+    md5_digest: $md5
+    file_size: $size
+    produced_by: $produced_by
+    created: $created
+    mfd_table_id: $mfd_table_id
+    hazard_table_id: $hazard_table_id
+    metrics: [{ k: "total_perturbations", v: "1889" }]
+    tables: [
+      {
+        table_id: $mfd_table_id
+        table_type: MFD_CURVES_V2
+        label: "mfd-curves"
+      }
+      {
+        table_id: $hazard_table_id
+        table_type: HAZARD_GRIDDED
+        label: "hazard-grid"
+        dimensions: [
+          { k: "grid_spacings", v: ["0.1"] }
+          { k: "tags", v: ["opensha", "testing"] }
+        ]
+      }
+    ]
+  }) {
+    inversion_solution { id }
+  }
+}
+"""
+
+QUERY_RESOLVED_FIELDS = """
+query ($id: ID!) {
+  node(id: $id) {
+    __typename
+    ... on InversionSolution {
+      id
+      file_name
+      mfd_table_id
+      mfd_table { id }
+      hazard_table_id
+      hazard_table { id }
+      metrics { k v }
+      tables {
+        identity
+        table_id
+        table_type
+        label
+        dimensions { k v }
+        table { id }
+      }
+    }
+  }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def seeded(gql_context):
+    created = dt.datetime.now(tzutc()).isoformat()
+
+    # Seed an MFD table
+    mfd = schema.execute_sync(
+        CREATE_TABLE,
+        variable_values={
+            "name": "mfd",
+            "object_id": "mfd-1",
+            "rows": [["1.0", "2.0"]],
+            "column_headers": ["a", "b"],
+            "column_types": ["double", "double"],
+        },
+        context_value=gql_context,
+    )
+    assert mfd.errors is None, mfd.errors
+    mfd_id = mfd.data["create_table"]["table"]["id"]
+
+    # Seed a hazard table
+    hazard = schema.execute_sync(
+        CREATE_HAZARD_TABLE,
+        variable_values={"name": "hazard", "object_id": "haz-1"},
+        context_value=gql_context,
+    )
+    assert hazard.errors is None, hazard.errors
+    hazard_id = hazard.data["create_table"]["table"]["id"]
+
+    # Seed parent task for produced_by
+    at = schema.execute_sync(CREATE_AT, variable_values={"created": created}, context_value=gql_context)
+    assert at.errors is None, at.errors
+    at_id = at.data["create_automation_task"]["task_result"]["id"]
+
+    # Create the inversion solution wiring everything together
+    inv = schema.execute_sync(
+        CREATE_INVERSION,
+        variable_values={
+            "file_name": "MyInversion.zip",
+            "md5": "ABC",
+            "size": 1000,
+            "produced_by": at_id,
+            "created": created,
+            "mfd_table_id": mfd_id,
+            "hazard_table_id": hazard_id,
+        },
+        context_value=gql_context,
+    )
+    assert inv.errors is None, inv.errors
+    inv_id = inv.data["create_inversion_solution"]["inversion_solution"]["id"]
+
+    return {"inv_id": inv_id, "mfd_id": mfd_id, "hazard_id": hazard_id}
+
+
+def test_inversion_resolved_fields(seeded, gql_context):
+    """Ported from legacy test_get_inversion_solution_resolved_by_id_fields.
+    Exercises mfd_table/hazard_table resolvers + tables[].table.
+    """
+    res = schema.execute_sync(
+        QUERY_RESOLVED_FIELDS, variable_values={"id": seeded["inv_id"]}, context_value=gql_context
+    )
+    assert res.errors is None, res.errors
+    node = res.data["node"]
+    assert node["__typename"] == "InversionSolution"
+    assert node["id"] == seeded["inv_id"]
+    assert node["mfd_table_id"] == seeded["mfd_id"]
+    assert node["mfd_table"]["id"] == seeded["mfd_id"]
+    assert node["hazard_table_id"] == seeded["hazard_id"]
+    assert node["hazard_table"]["id"] == seeded["hazard_id"]
+
+
+def test_inversion_tables_table_resolver(seeded, gql_context):
+    """LabelledTableRelation.table resolver populated (#322 added it)."""
+    res = schema.execute_sync(
+        QUERY_RESOLVED_FIELDS, variable_values={"id": seeded["inv_id"]}, context_value=gql_context
+    )
+    assert res.errors is None, res.errors
+    tables = res.data["node"]["tables"]
+    table_ids = sorted(t["table"]["id"] for t in tables if t["table"])
+    assert seeded["mfd_id"] in table_ids
+    assert seeded["hazard_id"] in table_ids
+
+
+def test_inversion_tables_dimensions_round_trip(seeded, gql_context):
+    """LabelledTableRelation.dimensions list-of-KeyValueListPair preserved."""
+    res = schema.execute_sync(
+        QUERY_RESOLVED_FIELDS, variable_values={"id": seeded["inv_id"]}, context_value=gql_context
+    )
+    assert res.errors is None, res.errors
+    hazard_entry = next(t for t in res.data["node"]["tables"] if t["table_type"] == "HAZARD_GRIDDED")
+    dims = {d["k"]: d["v"] for d in hazard_entry["dimensions"]}
+    assert dims["grid_spacings"] == ["0.1"]
+    assert dims["tags"] == ["opensha", "testing"]
+
+
+def test_inversion_metrics_round_trip(seeded, gql_context):
+    """metrics is list-of-KeyValuePair output — list nullability #322."""
+    res = schema.execute_sync(
+        QUERY_RESOLVED_FIELDS, variable_values={"id": seeded["inv_id"]}, context_value=gql_context
+    )
+    assert res.errors is None, res.errors
+    metrics = {m["k"]: m["v"] for m in res.data["node"]["metrics"]}
+    assert metrics["total_perturbations"] == "1889"

--- a/spike/strawberry_poc/tests/test_legacy_class_names_present.py
+++ b/spike/strawberry_poc/tests/test_legacy_class_names_present.py
@@ -1,0 +1,49 @@
+"""Ported from graphql_api/tests/object_iteration/test_divine_basedata_class_from_schema_name.py.
+
+Legacy keeps an explicit list of (clazz_name, data_class) tuples used by
+its data-layer dispatch. The data_class side is POC-specific (POC uses a
+different dispatcher), but the **clazz_name list itself is wire-impacting** —
+every name here is a type clients can spread via `... on <Name>` or encode
+as a Relay GlobalID prefix. If POC silently dropped one, those queries
+break.
+
+This test reads the list verbatim and asserts every name resolves to a
+type in POC's SDL.
+"""
+
+from schema import schema
+
+
+# Verbatim from legacy CLASS_MAPPINGS — these are the types clients
+# may reference. Sorted + deduped so an addition shows as a real diff.
+LEGACY_CLASS_NAMES = sorted(set([
+    "AggregateInversionSolution",
+    "File",
+    "GeneralTask",
+    "InversionSolution",
+    "InversionSolutionNrml",
+    "OpenquakeHazardConfig",
+    "OpenquakeHazardSolution",
+    "OpenquakeHazardTask",
+    "RuptureGenerationTask",
+    "RuptureSet",
+    "ScaledInversionSolution",
+    "SmsFile",
+    "StrongMotionStation",
+    "Table",
+    "TimeDependentInversionSolution",
+]))
+
+
+def test_every_legacy_class_name_resolves_in_poc_sdl():
+    """A type in the legacy CLASS_MAPPINGS list must exist in POC's SDL.
+
+    Names dropped here become silently-broken fragment spreads in client
+    queries.
+    """
+    sdl = schema.as_str()
+    missing = []
+    for name in LEGACY_CLASS_NAMES:
+        if f"type {name} " not in sdl and f"type {name}\n" not in sdl:
+            missing.append(name)
+    assert not missing, f"types missing from POC SDL: {missing}"

--- a/spike/strawberry_poc/tests/test_object_identities_legacy.py
+++ b/spike/strawberry_poc/tests/test_object_identities_legacy.py
@@ -1,0 +1,144 @@
+"""Ported from graphql_api/tests/object_iteration/test_iterate_items.py.
+
+Exercises the `object_identities` query, which has zero POC test coverage
+despite being a real wire-facing query that admin / migration tools use.
+
+Schema layer: object_identities(object_type: String!, first: Int, after: String)
+returns an ObjectIdentitiesConnection with edges[node{object_type, object_id,
+node_id, clazz_name}].
+"""
+
+import base64
+import datetime as dt
+
+import pytest
+from dateutil.tz import tzutc
+
+from schema import schema
+
+
+CREATE_GT = """
+mutation ($created: DateTime!, $title: String!) {
+  create_general_task(input: {
+    created: $created
+    title: $title
+    description: "iterate-items"
+    agent_name: "tester"
+  }) { general_task { id } }
+}
+"""
+
+QUERY_OBJECT_IDENTITIES = """
+query ($object_type: String!, $first: Int, $after: String) {
+  object_identities(object_type: $object_type, first: $first, after: $after) {
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    edges {
+      cursor
+      node {
+        __typename
+        object_type
+        object_id
+        node_id
+        clazz_name
+      }
+    }
+  }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def seeded_ids(gql_context):
+    """Seed 5 GeneralTasks so pagination has something to bite on."""
+    created = dt.datetime.now(tzutc()).isoformat()
+    ids = []
+    for i in range(5):
+        res = schema.execute_sync(
+            CREATE_GT,
+            variable_values={"created": created, "title": f"iterate-{i}"},
+            context_value=gql_context,
+        )
+        assert res.errors is None, res.errors
+        ids.append(res.data["create_general_task"]["general_task"]["id"])
+    return ids
+
+
+def test_object_identities_returns_edges(seeded_ids, gql_context):
+    """Asking for first:3 returns 3 edges."""
+    res = schema.execute_sync(
+        QUERY_OBJECT_IDENTITIES,
+        variable_values={"object_type": "GeneralTask", "first": 3, "after": None},
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    conn = res.data["object_identities"]
+    assert len(conn["edges"]) == 3
+
+
+def test_object_identities_edge_node_shape(seeded_ids, gql_context):
+    """Edge.node has object_type, object_id, node_id, clazz_name."""
+    res = schema.execute_sync(
+        QUERY_OBJECT_IDENTITIES,
+        variable_values={"object_type": "GeneralTask", "first": 3, "after": None},
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    node = res.data["object_identities"]["edges"][0]["node"]
+    assert node["object_type"] == "GeneralTask"
+    assert node["clazz_name"] == "GeneralTask"
+    assert node["object_id"]
+    # node_id is a Relay-encoded GlobalID
+    assert node["node_id"].startswith("R2VuZXJhbFRhc2s6")
+    decoded = base64.b64decode(node["node_id"]).decode()
+    assert decoded.startswith("GeneralTask:")
+
+
+def test_object_identities_pagination_has_next_page(seeded_ids, gql_context):
+    """With 5 items seeded and first:3, hasNextPage is true."""
+    res = schema.execute_sync(
+        QUERY_OBJECT_IDENTITIES,
+        variable_values={"object_type": "GeneralTask", "first": 3, "after": None},
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    page_info = res.data["object_identities"]["pageInfo"]
+    assert page_info["hasNextPage"] is True
+    assert page_info["endCursor"] is not None
+
+
+def test_object_identities_after_cursor_returns_next_page(seeded_ids, gql_context):
+    """Passing the previous endCursor returns the next batch (no duplicates)."""
+    first = schema.execute_sync(
+        QUERY_OBJECT_IDENTITIES,
+        variable_values={"object_type": "GeneralTask", "first": 3, "after": None},
+        context_value=gql_context,
+    )
+    assert first.errors is None, first.errors
+    cursor = first.data["object_identities"]["pageInfo"]["endCursor"]
+    first_ids = {e["node"]["object_id"] for e in first.data["object_identities"]["edges"]}
+
+    second = schema.execute_sync(
+        QUERY_OBJECT_IDENTITIES,
+        variable_values={"object_type": "GeneralTask", "first": 10, "after": cursor},
+        context_value=gql_context,
+    )
+    assert second.errors is None, second.errors
+    second_ids = {e["node"]["object_id"] for e in second.data["object_identities"]["edges"]}
+    # No overlap between batches
+    assert first_ids.isdisjoint(second_ids), (
+        f"page-1 and page-2 ids overlap: {first_ids & second_ids}"
+    )
+
+
+def test_object_identities_unknown_type_returns_empty(seeded_ids, gql_context):
+    """A type we never seeded returns an empty edges list, not an error."""
+    res = schema.execute_sync(
+        QUERY_OBJECT_IDENTITIES,
+        variable_values={"object_type": "ThisTypeDoesNotExist", "first": 3, "after": None},
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    assert res.data["object_identities"]["edges"] == []

--- a/spike/strawberry_poc/tests/test_openquake_hazard_solution_legacy.py
+++ b/spike/strawberry_poc/tests/test_openquake_hazard_solution_legacy.py
@@ -1,0 +1,265 @@
+"""Ported from graphql_api/tests/hazard/test_openquake_hazard_solution.py.
+
+Exercises gaps the existing POC test_openquake.py doesn't:
+  - OpenquakeHazardSolution.predecessors with depth=-2 returns
+    relationship="Grandparent" (fix #7b in action)
+  - Required `task_type` on CreateOpenquakeHazardSolutionInput
+  - `Predecessor.node` resolves the underlying file (#7a)
+"""
+
+import datetime as dt
+
+import pytest
+from dateutil.tz import tzutc
+
+from schema import schema
+
+
+CREATE_FILE = """
+mutation ($file_name: String!, $md5: String!, $size: BigInt!) {
+  create_file(file_name: $file_name, md5_digest: $md5, file_size: $size) {
+    file_result { id }
+  }
+}
+"""
+
+CREATE_INVERSION = """
+mutation ($input: CreateInversionSolutionInput!) {
+  create_inversion_solution(input: $input) { inversion_solution { id } }
+}
+"""
+
+CREATE_RGT = """
+mutation ($created: DateTime!) {
+  create_rupture_generation_task(input: {
+    state: UNDEFINED
+    result: UNDEFINED
+    task_type: RUPTURE_SET
+    created: $created
+    duration: 1
+  }) { task_result { id } }
+}
+"""
+
+CREATE_NRML = """
+mutation ($input: CreateInversionSolutionNrmlInput!) {
+  create_inversion_solution_nrml(input: $input) {
+    inversion_solution_nrml { id }
+  }
+}
+"""
+
+CREATE_OQ_TASK = """
+mutation ($input: CreateOpenquakeHazardTaskInput!) {
+  create_openquake_hazard_task(input: $input) {
+    openquake_hazard_task { id }
+  }
+}
+"""
+
+CREATE_OQ_SOLUTION_WITH_TYPE = """
+mutation (
+  $created: DateTime!,
+  $csv_archive_id: ID!,
+  $produced_by: ID!,
+  $predecessors: [PredecessorInput],
+  $task_args_id: ID!
+) {
+  create_openquake_hazard_solution(input: {
+    created: $created
+    csv_archive: $csv_archive_id
+    produced_by: $produced_by
+    predecessors: $predecessors
+    task_args: $task_args_id
+    task_type: HAZARD
+  }) {
+    openquake_hazard_solution {
+      id
+      task_args { id file_name }
+      csv_archive { id file_name }
+      produced_by { ... on Node { id } }
+      predecessors {
+        id
+        typename
+        depth
+        relationship
+        node {
+          ... on FileInterface {
+            file_name
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+CREATE_OQ_SOLUTION_NO_TYPE = """
+mutation (
+  $created: DateTime!,
+  $csv_archive_id: ID!,
+  $produced_by: ID!,
+) {
+  create_openquake_hazard_solution(input: {
+    created: $created
+    csv_archive: $csv_archive_id
+    produced_by: $produced_by
+  }) {
+    openquake_hazard_solution { id }
+  }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def chain(gql_context):
+    """upstream IS  →  InversionSolutionNrml  →  OQ task  →  OQ solution
+    with predecessors at depth=-1 (Parent, the NRML) and depth=-2 (Grandparent, the IS).
+    """
+    created = dt.datetime.now(tzutc()).isoformat()
+
+    rgt = schema.execute_sync(CREATE_RGT, variable_values={"created": created}, context_value=gql_context)
+    assert rgt.errors is None, rgt.errors
+    rgt_id = rgt.data["create_rupture_generation_task"]["task_result"]["id"]
+
+    # upstream inversion solution
+    upstream = schema.execute_sync(
+        CREATE_INVERSION,
+        variable_values={
+            "input": {
+                "file_name": "upstream.zip",
+                "produced_by": rgt_id,
+                "md5_digest": "aabb",
+                "file_size": 1024,
+                "created": created,
+                "meta": [{"k": "upstream-tag", "v": "yes"}],
+            }
+        },
+        context_value=gql_context,
+    )
+    assert upstream.errors is None, upstream.errors
+    upstream_id = upstream.data["create_inversion_solution"]["inversion_solution"]["id"]
+
+    # nrml on the upstream
+    nrml = schema.execute_sync(
+        CREATE_NRML,
+        variable_values={
+            "input": {
+                "file_name": "model.nrml",
+                "md5_digest": "nrnr",
+                "file_size": 4096,
+                "created": created,
+                "source_solution": upstream_id,
+            }
+        },
+        context_value=gql_context,
+    )
+    assert nrml.errors is None, nrml.errors
+    nrml_id = nrml.data["create_inversion_solution_nrml"]["inversion_solution_nrml"]["id"]
+
+    # archives + task_args + OQ task
+    csv = schema.execute_sync(
+        CREATE_FILE,
+        variable_values={"file_name": "results.csv", "md5": "csv1", "size": 100},
+        context_value=gql_context,
+    )
+    assert csv.errors is None, csv.errors
+    csv_id = csv.data["create_file"]["file_result"]["id"]
+
+    task_args = schema.execute_sync(
+        CREATE_FILE,
+        variable_values={"file_name": "task_args.zip", "md5": "ta01", "size": 200},
+        context_value=gql_context,
+    )
+    assert task_args.errors is None, task_args.errors
+    task_args_id = task_args.data["create_file"]["file_result"]["id"]
+
+    oq_task = schema.execute_sync(
+        CREATE_OQ_TASK,
+        variable_values={
+            "input": {
+                "state": "UNDEFINED",
+                "result": "UNDEFINED",
+                "task_type": "HAZARD",
+                "created": created,
+                "duration": 60,
+            }
+        },
+        context_value=gql_context,
+    )
+    assert oq_task.errors is None, oq_task.errors
+    oq_task_id = oq_task.data["create_openquake_hazard_task"]["openquake_hazard_task"]["id"]
+
+    return {
+        "upstream_id": upstream_id,
+        "nrml_id": nrml_id,
+        "csv_id": csv_id,
+        "task_args_id": task_args_id,
+        "oq_task_id": oq_task_id,
+        "created": created,
+    }
+
+
+def test_create_oq_solution_requires_task_type(chain, gql_context):
+    """Omitting task_type yields a GraphQL validation error mentioning the field."""
+    res = schema.execute_sync(
+        CREATE_OQ_SOLUTION_NO_TYPE,
+        variable_values={
+            "created": chain["created"],
+            "csv_archive_id": chain["csv_id"],
+            "produced_by": chain["oq_task_id"],
+        },
+        context_value=gql_context,
+    )
+    assert res.errors is not None
+    text = " ".join(str(e) for e in res.errors).lower()
+    assert "task_type" in text, f"missing task_type error didn't mention the field: {res.errors}"
+
+
+def test_create_oq_solution_with_grandparent_and_parent_predecessors(chain, gql_context):
+    """Depth -1 → 'Parent', depth -2 → 'Grandparent'. Both resolve via node."""
+    res = schema.execute_sync(
+        CREATE_OQ_SOLUTION_WITH_TYPE,
+        variable_values={
+            "created": chain["created"],
+            "csv_archive_id": chain["csv_id"],
+            "produced_by": chain["oq_task_id"],
+            "predecessors": [
+                {"id": chain["upstream_id"], "depth": -2},
+                {"id": chain["nrml_id"], "depth": -1},
+            ],
+            "task_args_id": chain["task_args_id"],
+        },
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    sol = res.data["create_openquake_hazard_solution"]["openquake_hazard_solution"]
+    preds = sol["predecessors"]
+    by_depth = {p["depth"]: p for p in preds}
+
+    grand = by_depth[-2]
+    assert grand["relationship"] == "Grandparent"
+    assert grand["node"]["file_name"] == "upstream.zip"
+
+    parent = by_depth[-1]
+    assert parent["relationship"] == "Parent"
+    assert parent["node"]["file_name"] == "model.nrml"
+
+
+def test_oq_solution_csv_and_task_args_resolve(chain, gql_context):
+    """csv_archive and task_args resolvers return the right file_name."""
+    res = schema.execute_sync(
+        CREATE_OQ_SOLUTION_WITH_TYPE,
+        variable_values={
+            "created": chain["created"],
+            "csv_archive_id": chain["csv_id"],
+            "produced_by": chain["oq_task_id"],
+            "predecessors": [],
+            "task_args_id": chain["task_args_id"],
+        },
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    sol = res.data["create_openquake_hazard_solution"]["openquake_hazard_solution"]
+    assert sol["csv_archive"]["file_name"] == "results.csv"
+    assert sol["task_args"]["file_name"] == "task_args.zip"

--- a/spike/strawberry_poc/tests/test_runzi_query_corpus.py
+++ b/spike/strawberry_poc/tests/test_runzi_query_corpus.py
@@ -1,0 +1,129 @@
+"""Auto-extracted client-query corpus from MISC/nzshm-runzi.
+
+This is the durable answer documented in docs/smoke-test-learnings.md
+future-self checklist item #2 — instead of hand-picking queries to
+test verbatim, walk the client codebase and validate every embedded
+GraphQL operation against POC's schema.
+
+If POC validates them all, runzi can talk to POC without breaking on
+the wire. Each new gap that ever ships gets caught here automatically.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+from graphql import parse, validate
+
+from schema import schema
+
+
+# Anchor relative to the repo root: this file lives at
+# spike/strawberry_poc/tests/, so .parents[3] is the nshm-toshi-api repo,
+# and the sibling runzi clone is up two more levels under MISC/.
+_RUNZI_ROOT = (
+    Path(__file__).resolve().parents[3]
+    / ".."
+    / ".."
+    / "MISC"
+    / "nzshm-runzi"
+    / "runzi"
+    / "automation"
+    / "toshi_api"
+).resolve()
+
+
+# A triple-quoted block whose first non-whitespace token is `query`,
+# `mutation`, or `fragment`. Permissive on whitespace and the operation
+# name so we catch runzi's typical `qry = '''mutation foo (…) {…}'''`.
+_GQL_LITERAL = re.compile(
+    r"'''(\s*(?:query|mutation|fragment)\b[^']*?)'''",
+    re.DOTALL,
+)
+
+
+def _has_unresolved_placeholders(op: str) -> bool:
+    """Runzi uses ###NAME### tokens that get string-substituted before send.
+
+    The static extractor can't resolve them; skip those queries so we test
+    only the parts where the literal IS the real query.
+    """
+    return "###" in op or "##" in op
+
+
+def _extract_operations():
+    """Yield (origin, operation_text) tuples from every .py under runzi/toshi_api."""
+    if not _RUNZI_ROOT.is_dir():
+        return  # explicit skip handled at test collection time
+    for py in sorted(_RUNZI_ROOT.rglob("*.py")):
+        text = py.read_text(encoding="utf-8")
+        for m in _GQL_LITERAL.finditer(text):
+            op = m.group(1).strip()
+            if _has_unresolved_placeholders(op):
+                continue
+            # Cheap label: file_basename:opening_line
+            first_line = op.splitlines()[0] if op else ""
+            label = f"{py.relative_to(_RUNZI_ROOT.parent.parent.parent)}::{first_line[:60]}"
+            yield label, op
+
+
+_OPERATIONS = list(_extract_operations())
+
+
+# Runzi has a couple of queries that select fields nobody implements (`source_solution`
+# on LabelledTableRelation never existed in legacy either) or that exploit
+# graphene's non-spec-compliant union/interface field auto-resolution.
+# These are runzi bugs, not POC parity gaps — we record them so the corpus
+# test stays accurate without surfacing them as POC failures.
+_RUNZI_KNOWN_BAD = {
+    # `tables { source_solution }` — LabelledTableRelation has never had this field.
+    "Cannot query field 'source_solution' on type 'LabelledTableRelation'.",
+    # `source_models { id }` on OpenquakeNrmlUnion — graphene-lenient,
+    # strict GraphQL spec rejects (clients need inline-fragment per the spec).
+    "Cannot query field 'id' on type 'OpenquakeNrmlUnion'.",
+}
+
+
+def test_runzi_clone_is_discoverable():
+    """If the runzi sibling repo isn't checked out, fail loudly."""
+    assert _RUNZI_ROOT.is_dir(), (
+        f"runzi clone not found at {_RUNZI_ROOT}. "
+        "Clone GNS-Science/nzshm-runzi into ../../MISC/nzshm-runzi so this "
+        "corpus test can find real client queries."
+    )
+
+
+def test_extracted_at_least_some_operations():
+    """Sanity: we found something. Catches an empty-regex / wrong-path silent pass."""
+    assert _OPERATIONS, (
+        "runzi corpus extracted ZERO operations. Either the regex went wrong "
+        "or runzi's query shape changed (e.g. moved to a different package)."
+    )
+
+
+@pytest.mark.parametrize(
+    "origin,query",
+    _OPERATIONS or [("placeholder", "query Empty { __typename }")],
+    ids=[label for label, _ in _OPERATIONS] or ["placeholder"],
+)
+def test_runzi_query_validates_against_poc(origin, query):
+    """Every runzi-embedded GraphQL operation must validate against POC's schema.
+
+    `validate()` runs the full GraphQL spec validation: field existence,
+    argument types, variable-type subsumption, fragment spreads, etc.
+    No execution happens — no DynamoDB needed. Failures here are
+    schema-layer parity gaps.
+    """
+    document = parse(query)
+    errors = validate(schema._schema, document)
+    # Strip out errors that match runzi-own bugs (see _RUNZI_KNOWN_BAD).
+    real_errors = [
+        e for e in errors
+        if not any(known in e.message for known in _RUNZI_KNOWN_BAD)
+    ]
+    assert not real_errors, (
+        f"{origin}\n"
+        + "\n".join(f"  - {e.message}" for e in real_errors)
+        + "\n\n"
+        + (query[:400] + ("..." if len(query) > 400 else ""))
+    )

--- a/spike/strawberry_poc/tests/test_rupture_set_mutation_checks.py
+++ b/spike/strawberry_poc/tests/test_rupture_set_mutation_checks.py
@@ -1,0 +1,159 @@
+"""Ported from graphql_api/tests/rupture_set/test_rupture_set_mutation_checks.py.
+
+Exercises input-validation behaviour on create_rupture_set:
+  - Missing required fields surface in the error messages
+  - Bad `created` values rejected by the DateTime scalar (#6)
+  - Bad `fault_models` types rejected at validation
+"""
+
+import datetime as dt
+
+import pytest
+from dateutil.tz import tzutc
+
+from schema import schema
+
+
+CREATE_RS_BARE = """
+mutation ($created: DateTime!) {
+  create_rupture_set(input: {
+    created: $created
+  }) {
+    rupture_set { id }
+  }
+}
+"""
+
+CREATE_RS = """
+mutation (
+  $created: DateTime!,
+  $md5: String!,
+  $file_name: String!,
+  $file_size: BigInt!,
+  $produced_by: ID!,
+  $fault_models: [String],
+) {
+  create_rupture_set(input: {
+    created: $created
+    md5_digest: $md5
+    file_name: $file_name
+    file_size: $file_size
+    produced_by: $produced_by
+    fault_models: $fault_models
+  }) {
+    rupture_set { id file_name fault_models }
+  }
+}
+"""
+
+CREATE_RGT = """
+mutation ($created: DateTime!) {
+  create_rupture_generation_task(input: {
+    state: UNDEFINED
+    result: UNDEFINED
+    task_type: RUPTURE_SET
+    created: $created
+    duration: 1
+  }) { task_result { id } }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def producer_id(gql_context):
+    """create_rupture_set requires produced_by to be a RuptureGenerationTask."""
+    res = schema.execute_sync(
+        CREATE_RGT,
+        variable_values={"created": dt.datetime.now(tzutc()).isoformat()},
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    return res.data["create_rupture_generation_task"]["task_result"]["id"]
+
+
+def _assert_error_mentions(errors, expected):
+    """At least one of the GraphQL errors must mention `expected`."""
+    text = " ".join(str(e) for e in errors)
+    assert expected in text, f"expected `{expected}` in errors, got: {text}"
+
+
+def test_missing_required_file_attributes_fails(gql_context):
+    """Calling create_rupture_set with only `created` must fail on each missing field."""
+    res = schema.execute_sync(
+        CREATE_RS_BARE,
+        variable_values={"created": dt.datetime.now(tzutc()).isoformat()},
+        context_value=gql_context,
+    )
+    assert res.errors is not None
+    # Combine all error messages and check each missing field is referenced
+    text = " ".join(str(e) for e in res.errors)
+    for required in ("file_name", "file_size", "md5_digest"):
+        assert required in text, f"missing-field error didn't mention {required}: {text}"
+
+
+@pytest.mark.parametrize(
+    "created_value, expect_ok",
+    [
+        (dt.datetime.now(tzutc()).isoformat(), True),
+        ("", False),
+        ("can't parse this as a date", False),
+        # An integer should fail at the DateTime scalar layer.
+        (1001, False),
+    ],
+)
+def test_created_value_validation(gql_context, producer_id, created_value, expect_ok):
+    """The DateTime scalar (#6) rejects invalid values; valid tz-aware strings pass."""
+    res = schema.execute_sync(
+        CREATE_RS,
+        variable_values={
+            "created": created_value,
+            "md5": "digest",
+            "file_name": "rs.zip",
+            "file_size": 1000,
+            "produced_by": producer_id,
+            "fault_models": ["A", "B"],
+        },
+        context_value=gql_context,
+    )
+    if expect_ok:
+        assert res.errors is None, res.errors
+        assert res.data["create_rupture_set"]["rupture_set"]["file_name"] == "rs.zip"
+    else:
+        assert res.errors is not None, f"expected error for created={created_value!r}"
+
+
+def test_fault_models_int_rejected(gql_context, producer_id):
+    """Passing an int where [String] is expected fails at GraphQL validation."""
+    res = schema.execute_sync(
+        CREATE_RS,
+        variable_values={
+            "created": dt.datetime.now(tzutc()).isoformat(),
+            "md5": "digest",
+            "file_name": "rs.zip",
+            "file_size": 1000,
+            "produced_by": producer_id,
+            "fault_models": 1001,
+        },
+        context_value=gql_context,
+    )
+    assert res.errors is not None
+    _assert_error_mentions(res.errors, "fault_models")
+
+
+def test_fault_models_happy_path(gql_context, producer_id):
+    """`fault_models: ["A", "B"]` is accepted and round-trips."""
+    res = schema.execute_sync(
+        CREATE_RS,
+        variable_values={
+            "created": dt.datetime.now(tzutc()).isoformat(),
+            "md5": "digest",
+            "file_name": "rs.zip",
+            "file_size": 1000,
+            "produced_by": producer_id,
+            "fault_models": ["ModelA", "ModelB"],
+        },
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    rs = res.data["create_rupture_set"]["rupture_set"]
+    assert rs["fault_models"] == ["ModelA", "ModelB"]

--- a/spike/strawberry_poc/tests/test_scaled_inversion_solution.py
+++ b/spike/strawberry_poc/tests/test_scaled_inversion_solution.py
@@ -209,4 +209,4 @@ def test_with_predecessors(gql_context, automation_task_id, source_solution_id):
     assert len(preds) == 1
     assert preds[0]["id"] == source_solution_id
     assert preds[0]["depth"] == -1
-    assert preds[0]["relationship"] == "parent"
+    assert preds[0]["relationship"] == "Parent"

--- a/spike/strawberry_poc/tests/test_source_solution_bugfix_214.py
+++ b/spike/strawberry_poc/tests/test_source_solution_bugfix_214.py
@@ -1,0 +1,160 @@
+"""Ported from graphql_api/tests/test_source_solution_bugfix_214.py.
+
+Bug #214: ScaledInversionSolution.source_solution returned the wrong
+__typename when the upstream was a TimeDependentInversionSolution.
+The dispatch must select the concrete subtype, not a generic node.
+
+POC's existing test_scaled_inversion_solution.py tests source_solution
+only with InversionSolution as the source. This file fills the gap.
+"""
+
+import datetime as dt
+
+import pytest
+from dateutil.tz import tzutc
+
+from schema import schema
+
+
+CREATE_AT = """
+mutation ($created: DateTime!) {
+  create_automation_task(input: {
+    state: UNDEFINED
+    result: UNDEFINED
+    created: $created
+    duration: 1
+    task_type: INVERSION
+  }) { task_result { id } }
+}
+"""
+
+CREATE_INVERSION = """
+mutation ($input: CreateInversionSolutionInput!) {
+  create_inversion_solution(input: $input) { inversion_solution { id } }
+}
+"""
+
+CREATE_TIME_DEPENDENT = """
+mutation ($input: CreateTimeDependentInversionSolutionInput!) {
+  create_time_dependent_inversion_solution(input: $input) {
+    solution { id }
+  }
+}
+"""
+
+CREATE_SCALED = """
+mutation ($input: CreateScaledInversionSolutionInput!) {
+  create_scaled_inversion_solution(input: $input) {
+    solution {
+      id
+      source_solution {
+        __typename
+        ... on Node { id }
+      }
+    }
+  }
+}
+"""
+
+QUERY_SCALED_NODE = """
+query ($id: ID!) {
+  node(id: $id) {
+    __typename
+    ... on ScaledInversionSolution {
+      id
+      source_solution {
+        __typename
+        ... on Node { id }
+      }
+    }
+  }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def chain(gql_context):
+    """Build:  inv (upstream)  ←  time_dep  ←  scaled
+
+    Such that:
+      time_dep.source_solution = inv
+      scaled.source_solution   = time_dep
+    """
+    created = dt.datetime.now(tzutc()).isoformat()
+
+    at_res = schema.execute_sync(CREATE_AT, variable_values={"created": created}, context_value=gql_context)
+    assert at_res.errors is None, at_res.errors
+    at_id = at_res.data["create_automation_task"]["task_result"]["id"]
+
+    inv_res = schema.execute_sync(
+        CREATE_INVERSION,
+        variable_values={
+            "input": {
+                "file_name": "upstream.zip",
+                "produced_by": at_id,
+                "md5_digest": "aabb",
+                "file_size": 1024,
+                "created": created,
+            }
+        },
+        context_value=gql_context,
+    )
+    assert inv_res.errors is None, inv_res.errors
+    inv_id = inv_res.data["create_inversion_solution"]["inversion_solution"]["id"]
+
+    td_res = schema.execute_sync(
+        CREATE_TIME_DEPENDENT,
+        variable_values={
+            "input": {
+                "file_name": "td_v1.zip",
+                "produced_by": at_id,
+                "source_solution": inv_id,
+                "md5_digest": "ccdd",
+                "file_size": 2048,
+                "created": created,
+            }
+        },
+        context_value=gql_context,
+    )
+    assert td_res.errors is None, td_res.errors
+    td_id = td_res.data["create_time_dependent_inversion_solution"]["solution"]["id"]
+
+    scaled_res = schema.execute_sync(
+        CREATE_SCALED,
+        variable_values={
+            "input": {
+                "file_name": "scaled_v1.zip",
+                "produced_by": at_id,
+                "source_solution": td_id,
+                "md5_digest": "eeff",
+                "file_size": 512,
+                "created": created,
+            }
+        },
+        context_value=gql_context,
+    )
+    assert scaled_res.errors is None, scaled_res.errors
+    scaled_data = scaled_res.data["create_scaled_inversion_solution"]["solution"]
+
+    return {"inv_id": inv_id, "td_id": td_id, "scaled_id": scaled_data["id"], "scaled_data": scaled_data}
+
+
+def test_scaled_source_solution_dispatches_to_time_dependent_on_create(chain):
+    """Bug #214: the mutation response's source_solution.__typename must be
+    'TimeDependentInversionSolution', not a generic node or InversionSolution.
+    """
+    ss = chain["scaled_data"]["source_solution"]
+    assert ss is not None
+    assert ss["__typename"] == "TimeDependentInversionSolution"
+    assert ss["id"] == chain["td_id"]
+
+
+def test_scaled_source_solution_dispatches_to_time_dependent_via_node_lookup(chain, gql_context):
+    """Same assertion via a node lookup — separate code path (resolve_node)."""
+    res = schema.execute_sync(
+        QUERY_SCALED_NODE, variable_values={"id": chain["scaled_id"]}, context_value=gql_context
+    )
+    assert res.errors is None, res.errors
+    ss = res.data["node"]["source_solution"]
+    assert ss["__typename"] == "TimeDependentInversionSolution"
+    assert ss["id"] == chain["td_id"]

--- a/spike/strawberry_poc/tests/test_swept_arguments_edges.py
+++ b/spike/strawberry_poc/tests/test_swept_arguments_edges.py
@@ -1,0 +1,118 @@
+"""Edge-case coverage for `swept_arguments` resolver semantics.
+
+The resolver rule is simple — `swept_arguments` returns keys where
+`len(argument_lists[i].v) > 1`. But the edge cases are easy to break
+silently, especially after #322 widened nullability everywhere:
+
+  - v: ["A", "B"]    → swept (len > 1)
+  - v: ["A"]         → NOT swept (len == 1)
+  - v: [null]        → NOT swept (len == 1, even though only element is null)
+  - v: [null, null]  → swept (len == 2, even though all elements are null)
+  - v: ["A", null]   → swept (len == 2)
+  - v: []            → NOT swept (len == 0)
+  - argument_lists absent → swept_arguments returns [] (not null)
+
+Locking these so future regressions show up immediately rather than as
+a vague "the swept_args got weird" report.
+"""
+
+import datetime as dt
+
+import pytest
+from dateutil.tz import tzutc
+
+from schema import schema
+
+
+CREATE_GT = """
+mutation ($created: DateTime!, $argument_lists: [KeyValueListPairInput]) {
+  create_general_task(input: {
+    created: $created
+    title: "edge-cases"
+    description: "edge-cases"
+    agent_name: "tester"
+    argument_lists: $argument_lists
+  })
+  {
+    general_task {
+      id
+      argument_lists { k v }
+      swept_arguments
+    }
+  }
+}
+"""
+
+
+def _create(gql_context, argument_lists):
+    res = schema.execute_sync(
+        CREATE_GT,
+        variable_values={
+            "created": dt.datetime.now(tzutc()).isoformat(),
+            "argument_lists": argument_lists,
+        },
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    return res.data["create_general_task"]["general_task"]
+
+
+def test_two_string_values_is_swept(gql_context):
+    gt = _create(gql_context, [{"k": "alpha", "v": ["A", "B"]}])
+    assert gt["swept_arguments"] == ["alpha"]
+
+
+def test_single_string_value_is_not_swept(gql_context):
+    gt = _create(gql_context, [{"k": "alpha", "v": ["A"]}])
+    assert gt["swept_arguments"] == []
+
+
+def test_single_null_value_is_not_swept(gql_context):
+    """`v: [null]` (one element, null) — NOT swept. Legacy production shape."""
+    gt = _create(gql_context, [{"k": "alpha", "v": [None]}])
+    assert gt["swept_arguments"] == []
+
+
+def test_two_null_values_is_swept(gql_context):
+    """`v: [null, null]` (two elements, both null) — IS swept (len > 1).
+    The rule is strictly about list length, not content.
+    """
+    gt = _create(gql_context, [{"k": "alpha", "v": [None, None]}])
+    assert gt["swept_arguments"] == ["alpha"]
+
+
+def test_string_and_null_is_swept(gql_context):
+    gt = _create(gql_context, [{"k": "alpha", "v": ["A", None]}])
+    assert gt["swept_arguments"] == ["alpha"]
+
+
+def test_empty_value_list_is_not_swept(gql_context):
+    """`v: []` (empty list) — NOT swept (len == 0)."""
+    gt = _create(gql_context, [{"k": "alpha", "v": []}])
+    assert gt["swept_arguments"] == []
+
+
+def test_mixed_swept_and_unswept(gql_context):
+    """Multiple keys, some swept, some not."""
+    gt = _create(
+        gql_context,
+        [
+            {"k": "swept1", "v": ["A", "B"]},
+            {"k": "unswept1", "v": ["X"]},
+            {"k": "swept2", "v": ["1", "2", "3"]},
+            {"k": "unswept2", "v": [None]},
+        ],
+    )
+    assert sorted(gt["swept_arguments"]) == ["swept1", "swept2"]
+
+
+def test_no_argument_lists_returns_empty(gql_context):
+    """When argument_lists is omitted entirely, swept_arguments returns [].
+
+    Specifically NOT null — clients iterate over the result and a null
+    here would crash any naive consumer.
+    """
+    gt = _create(gql_context, None)
+    # Strawberry serialises an absent list as null on the way in, but the
+    # resolver short-circuits to []; assert that explicitly.
+    assert gt["swept_arguments"] == []

--- a/spike/strawberry_poc/tests/test_table_schema_legacy.py
+++ b/spike/strawberry_poc/tests/test_table_schema_legacy.py
@@ -1,0 +1,143 @@
+"""Ported from graphql_api/tests/test_table_schema.py.
+
+POC's `test_bugfix_252_table_create.py` already covers the create path.
+This port adds the legacy `test_get_table_by_node_id` coverage —
+node-lookup of a Table with `rows`, `meta`, `dimensions`, `table_type`
+all selected. Exercises the `Table.rows: list[list[str | None] | None]`
+read path which had no test coverage.
+"""
+
+import pytest
+
+from schema import schema
+
+
+CREATE_TABLE = """
+mutation (
+  $object_id: ID!,
+  $column_headers: [String],
+  $column_types: [RowItemType],
+  $rows: [[String]],
+  $meta: [KeyValuePairInput],
+  $dimensions: [KeyValueListPairInput],
+) {
+  create_table(input: {
+    object_id: $object_id
+    created: "2021-06-11T02:37:26.009506+00:00"
+    column_headers: $column_headers
+    column_types: $column_types
+    rows: $rows
+    meta: $meta
+    table_type: HAZARD_GRIDDED
+    dimensions: $dimensions
+  })
+  {
+    table {
+      id
+      column_headers
+      column_types
+      rows
+      meta { k v }
+      dimensions { k v }
+      table_type
+    }
+  }
+}
+"""
+
+NODE_QUERY = """
+query ($id: ID!) {
+  node(id: $id) {
+    __typename
+    ... on Table {
+      id
+      object_id
+      column_headers
+      column_types
+      rows
+      meta { k v }
+      dimensions { k v }
+      table_type
+    }
+  }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def created(gql_context):
+    res = schema.execute_sync(
+        CREATE_TABLE,
+        variable_values={
+            "object_id": "R2VuZXJhbFRhc2s6MjE3Qk1YREw=",
+            "column_headers": ["OK", "DOKEY"],
+            "column_types": ["integer", "double"],
+            "rows": [["1", "1.01"], ["2", "2.2"]],
+            "meta": [
+                {"k": "round", "v": "0"},
+                {"k": "config_type", "v": "crustal"},
+            ],
+            "dimensions": [
+                {"k": "grid_spacings", "v": ["0.1"]},
+                {"k": "IML_periods", "v": ["0", "0.1"]},
+                {"k": "tags", "v": ["opensha", "testing"]},
+                {"k": "gmpes", "v": ["ASK_2014"]},
+            ],
+        },
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    return res.data["create_table"]["table"]
+
+
+def test_create_returns_full_payload(created):
+    """Create mutation echoes back everything we sent."""
+    assert created["id"]
+    assert created["column_headers"] == ["OK", "DOKEY"]
+    assert created["column_types"] == ["integer", "double"]
+    assert created["rows"] == [["1", "1.01"], ["2", "2.2"]]
+    assert created["table_type"] == "HAZARD_GRIDDED"
+
+
+def test_node_lookup_returns_rows(created, gql_context):
+    """node(id:) returns the full rows back. The Table.rows[list[list[str|None]|None]|None]
+    read path has no other test coverage in POC.
+    """
+    res = schema.execute_sync(
+        NODE_QUERY, variable_values={"id": created["id"]}, context_value=gql_context
+    )
+    assert res.errors is None, res.errors
+    node = res.data["node"]
+    assert node["rows"] == [["1", "1.01"], ["2", "2.2"]]
+
+
+def test_node_lookup_returns_dimensions(created, gql_context):
+    """dimensions list-of-KeyValueListPair survives the node lookup."""
+    res = schema.execute_sync(
+        NODE_QUERY, variable_values={"id": created["id"]}, context_value=gql_context
+    )
+    assert res.errors is None, res.errors
+    dims = {d["k"]: d["v"] for d in res.data["node"]["dimensions"]}
+    assert dims["grid_spacings"] == ["0.1"]
+    assert dims["IML_periods"] == ["0", "0.1"]
+    assert dims["tags"] == ["opensha", "testing"]
+
+
+def test_node_lookup_returns_meta(created, gql_context):
+    """meta list-of-KeyValuePair survives the node lookup."""
+    res = schema.execute_sync(
+        NODE_QUERY, variable_values={"id": created["id"]}, context_value=gql_context
+    )
+    assert res.errors is None, res.errors
+    meta = {m["k"]: m["v"] for m in res.data["node"]["meta"]}
+    assert meta["round"] == "0"
+    assert meta["config_type"] == "crustal"
+
+
+def test_node_lookup_returns_table_type(created, gql_context):
+    """Enum round-trips via node lookup."""
+    res = schema.execute_sync(
+        NODE_QUERY, variable_values={"id": created["id"]}, context_value=gql_context
+    )
+    assert res.errors is None, res.errors
+    assert res.data["node"]["table_type"] == "HAZARD_GRIDDED"

--- a/spike/strawberry_poc/tests/test_thing_relation_bugfix_95.py
+++ b/spike/strawberry_poc/tests/test_thing_relation_bugfix_95.py
@@ -1,0 +1,191 @@
+"""Ported from graphql_api/tests/test_thing_relation_bugfix_95.py.
+
+Original test exercised three things that #322 touches:
+  1. `create_task_relation` is positional, not input-wrapped
+  2. `arguments`/`environment` are list-of-nullable-KeyValuePair inputs
+  3. AutomationTask exposes a `parents { edges { node { parent { ... } } } }`
+     connection that resolves back to the parent GeneralTask
+
+Legacy test mocked the data layer; this port seeds via real GraphQL
+mutations against the testcontainers-backed DynamoDB, then queries.
+"""
+
+import datetime as dt
+
+import pytest
+from dateutil.tz import tzutc
+
+from schema import schema
+
+
+CREATE_GT = """
+mutation new_gt ($created: DateTime!) {
+  create_general_task(input:{
+    created: $created
+    title: "TEST Build opensha rupture set Coulomb #1"
+    description: "Using "
+    agent_name: "chrisbc"
+  })
+  {
+    general_task { id }
+  }
+}
+"""
+
+CREATE_AUTOMATION_TASK = """
+mutation ($created: DateTime!) {
+    create_automation_task(input: {
+        state: UNDEFINED
+        result: UNDEFINED
+        created: $created
+        duration: 600
+        task_type: RUPTURE_SET
+
+        arguments: [
+            { k:"max_jump_distance" v: "55.5" }
+            { k:"max_sub_section_length" v: "2" }
+            { k:"max_cumulative_azimuth" v: "590" }
+            { k:"min_sub_sections_per_parent" v: "2" }
+            { k:"permutation_strategy" v: "DOWNDIP" }
+        ]
+
+        environment: [
+            { k:"gitref_opensha_ucerf3" v: "ABC"}
+            { k:"gitref_opensha_commons" v: "ABC"}
+            { k:"gitref_opensha_core" v: "ABC"}
+            { k:"nshm_nz_opensha" v: "ABC"}
+            { k:"host" v:"tryharder-ubuntu"}
+            { k:"JAVA" v:"-Xmx24G"  }
+        ]
+    })
+    {
+        task_result {
+            id
+            created
+            duration
+            arguments { k v }
+        }
+    }
+}
+"""
+
+CREATE_GT_RELATION = """
+mutation new_gt_link ($parent_id: ID!, $child_id: ID!) {
+  create_task_relation(
+    parent_id: $parent_id
+    child_id: $child_id
+  )
+  {
+    ok
+    thing_relation { child_id }
+  }
+}
+"""
+
+QUERY_AT_PARENT = """
+query get_task ($id: ID!) {
+  node(id: $id) {
+    __typename
+    ... on AutomationTask {
+      id
+      created
+      duration
+      state
+      result
+      parents {
+        edges {
+          node {
+            parent {
+              ... on GeneralTask {
+                id
+                title
+                description
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def seeded(gql_context):
+    created = dt.datetime.now(tzutc()).isoformat()
+
+    gt_res = schema.execute_sync(
+        CREATE_GT, variable_values={"created": created}, context_value=gql_context
+    )
+    assert gt_res.errors is None, gt_res.errors
+    gt_id = gt_res.data["create_general_task"]["general_task"]["id"]
+
+    at_res = schema.execute_sync(
+        CREATE_AUTOMATION_TASK, variable_values={"created": created}, context_value=gql_context
+    )
+    assert at_res.errors is None, at_res.errors
+    at_id = at_res.data["create_automation_task"]["task_result"]["id"]
+
+    rel_res = schema.execute_sync(
+        CREATE_GT_RELATION,
+        variable_values={"parent_id": gt_id, "child_id": at_id},
+        context_value=gql_context,
+    )
+    assert rel_res.errors is None, rel_res.errors
+    assert rel_res.data["create_task_relation"]["ok"] is True
+
+    return {"gt_id": gt_id, "at_id": at_id}
+
+
+def test_create_general_task_returns_id(seeded):
+    """GT mutation returned a relay-encoded id."""
+    assert seeded["gt_id"].startswith("R2VuZXJhbFRhc2s6")  # base64("GeneralTask:")
+
+
+def test_create_automation_task_returns_id(seeded):
+    """AT mutation returned a relay-encoded id."""
+    assert seeded["at_id"].startswith("QXV0b21hdGlvblRhc2s6")  # base64("AutomationTask:")
+
+
+def test_at_parents_connection_resolves_general_task(seeded, gql_context):
+    """The #322-renamed Connection field `parents { edges { node { parent } } }`
+    on AutomationTask resolves back to the seeded GeneralTask.
+    """
+    res = schema.execute_sync(
+        QUERY_AT_PARENT, variable_values={"id": seeded["at_id"]}, context_value=gql_context
+    )
+    assert res.errors is None, res.errors
+    node = res.data["node"]
+    assert node["__typename"] == "AutomationTask"
+    assert node["id"] == seeded["at_id"]
+    edges = node["parents"]["edges"]
+    assert len(edges) == 1
+    parent = edges[0]["node"]["parent"]
+    assert parent["id"] == seeded["gt_id"]
+    assert parent["title"] == "TEST Build opensha rupture set Coulomb #1"
+
+
+def test_at_arguments_input_list_nullability(seeded, gql_context):
+    """The arguments list field accepts the legacy [KeyValuePairInput] shape.
+    Verifies #322's `list[KeyValuePairInput | None]` SDL emission.
+    """
+    res = schema.execute_sync(
+        QUERY_AT_PARENT, variable_values={"id": seeded["at_id"]}, context_value=gql_context
+    )
+    assert res.errors is None, res.errors
+    # Argument list itself isn't reselected in this query; assert via a fresh node lookup.
+    Q = """
+    query ($id: ID!) {
+      node(id: $id) {
+        ... on AutomationTask {
+          arguments { k v }
+        }
+      }
+    }
+    """
+    arg_res = schema.execute_sync(Q, variable_values={"id": seeded["at_id"]}, context_value=gql_context)
+    assert arg_res.errors is None, arg_res.errors
+    args = {a["k"]: a["v"] for a in arg_res.data["node"]["arguments"]}
+    assert args["max_jump_distance"] == "55.5"
+    assert args["permutation_strategy"] == "DOWNDIP"

--- a/spike/strawberry_poc/tests/test_time_dependent_inversion_solution.py
+++ b/spike/strawberry_poc/tests/test_time_dependent_inversion_solution.py
@@ -214,4 +214,4 @@ def test_with_predecessors(gql_context, automation_task_id, source_solution_id):
     assert len(preds) == 1
     assert preds[0]["id"] == source_solution_id
     assert preds[0]["depth"] == -1
-    assert preds[0]["relationship"] == "parent"
+    assert preds[0]["relationship"] == "Parent"

--- a/spike/strawberry_poc/tests/test_weka_codegen_queries.py
+++ b/spike/strawberry_poc/tests/test_weka_codegen_queries.py
@@ -1,0 +1,214 @@
+"""Ported from graphql_api/tests/test_dynamo_and_s3_queries.py.
+
+Exercises the GeneralTaskChildrenTab query in the exact shape weka's
+Relay codegen produces — including `__isNode: __typename` aliases and
+multi-inline-fragment type narrowing. This is the canonical weka query
+pattern; if it fails, weka's GeneralTask page is broken.
+
+POC tests typically write idiomatic GraphQL; this port keeps the
+codegen-emitted shape verbatim so silent breakages in alias / fragment
+handling surface.
+"""
+
+import datetime as dt
+
+import pytest
+from dateutil.tz import tzutc
+
+from schema import schema
+
+
+CREATE_GT = """
+mutation ($created: DateTime!, $title: String!) {
+  create_general_task(input: {
+    created: $created
+    title: $title
+    description: "weka-codegen"
+    agent_name: "tester"
+    model_type: CRUSTAL
+    argument_lists: [{ k: "alpha", v: ["A", "B"] }]
+  }) { general_task { id } }
+}
+"""
+
+CREATE_AT = """
+mutation ($created: DateTime!) {
+  create_automation_task(input: {
+    state: UNDEFINED
+    result: UNDEFINED
+    task_type: INVERSION
+    created: $created
+    duration: 600
+    arguments: [{ k: "max_jump_distance", v: "55.5" }]
+  }) { task_result { id } }
+}
+"""
+
+CREATE_TASK_RELATION = """
+mutation ($parent_id: ID!, $child_id: ID!) {
+  create_task_relation(parent_id: $parent_id, child_id: $child_id) { ok }
+}
+"""
+
+# Exact shape weka's Relay codegen emits for GeneralTaskChildrenTabQuery.
+# `__isNode: __typename` and inline-fragment type narrowing are the
+# distinguishing features.
+GENERAL_TASK_CHILDREN_TAB_QUERY = """
+query GeneralTaskChildrenTabQuery($id: ID!) {
+  node(id: $id) {
+    __typename
+    ... on GeneralTask {
+      id
+      model_type
+      children {
+        total_count
+        edges {
+          node {
+            child {
+              __typename
+              ... on AutomationTask {
+                __typename
+                id
+                created
+                duration
+                state
+                result
+                arguments { k v }
+              }
+              ... on RuptureGenerationTask {
+                __typename
+                id
+                created
+                duration
+                state
+                result
+                arguments { k v }
+              }
+              ... on Node {
+                __isNode: __typename
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    id
+  }
+}
+"""
+
+# Smaller weka-shape query just to confirm `swept_arguments` + `children { total_count }`
+GENERAL_TASK_QUERY = """
+query GeneralTaskQuery($id: ID!) {
+  node(id: $id) {
+    __typename
+    ... on GeneralTask {
+      id
+      title
+      description
+      notes
+      created
+      updated
+      agent_name
+      model_type
+      subtask_type
+      subtask_count
+      subtask_result
+      argument_lists { k v }
+      swept_arguments
+      children { total_count }
+    }
+    id
+  }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def chain(gql_context):
+    """Build:  GT  →  AT-1
+              \\─→ AT-2
+    Linked via create_task_relation.
+    """
+    created = dt.datetime.now(tzutc()).isoformat()
+
+    gt = schema.execute_sync(
+        CREATE_GT, variable_values={"created": created, "title": "weka-style"}, context_value=gql_context
+    )
+    assert gt.errors is None, gt.errors
+    gt_id = gt.data["create_general_task"]["general_task"]["id"]
+
+    child_ids = []
+    for _ in range(2):
+        at = schema.execute_sync(CREATE_AT, variable_values={"created": created}, context_value=gql_context)
+        assert at.errors is None, at.errors
+        at_id = at.data["create_automation_task"]["task_result"]["id"]
+        child_ids.append(at_id)
+
+        rel = schema.execute_sync(
+            CREATE_TASK_RELATION,
+            variable_values={"parent_id": gt_id, "child_id": at_id},
+            context_value=gql_context,
+        )
+        assert rel.errors is None, rel.errors
+        assert rel.data["create_task_relation"]["ok"]
+
+    return {"gt_id": gt_id, "child_ids": child_ids}
+
+
+def test_general_task_children_tab_query_runs(chain, gql_context):
+    """The full weka-shape query must execute without errors."""
+    res = schema.execute_sync(
+        GENERAL_TASK_CHILDREN_TAB_QUERY,
+        variable_values={"id": chain["gt_id"]},
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    assert res.data["node"]["__typename"] == "GeneralTask"
+
+
+def test_general_task_children_total_count(chain, gql_context):
+    """children.total_count reflects the seeded task relations."""
+    res = schema.execute_sync(
+        GENERAL_TASK_CHILDREN_TAB_QUERY,
+        variable_values={"id": chain["gt_id"]},
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    assert res.data["node"]["children"]["total_count"] == 2
+
+
+def test_general_task_children_inline_fragments_resolve(chain, gql_context):
+    """Each child resolves with its concrete __typename + arguments."""
+    res = schema.execute_sync(
+        GENERAL_TASK_CHILDREN_TAB_QUERY,
+        variable_values={"id": chain["gt_id"]},
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    edges = res.data["node"]["children"]["edges"]
+    assert len(edges) == 2
+    for edge in edges:
+        child = edge["node"]["child"]
+        assert child["__typename"] == "AutomationTask"
+        # AutomationTask fragment fields land on the response
+        assert child["id"] in chain["child_ids"]
+        assert child["state"] == "UNDEFINED"
+        # The `__isNode: __typename` alias on the Node fragment shows up
+        # alongside __typename — both should populate.
+        assert child["__isNode"] == "AutomationTask"
+
+
+def test_general_task_query_swept_arguments_and_children_count(chain, gql_context):
+    """GeneralTaskQuery: swept_arguments + children.total_count both populate."""
+    res = schema.execute_sync(
+        GENERAL_TASK_QUERY,
+        variable_values={"id": chain["gt_id"]},
+        context_value=gql_context,
+    )
+    assert res.errors is None, res.errors
+    gt = res.data["node"]
+    assert gt["swept_arguments"] == ["alpha"]
+    assert gt["children"]["total_count"] == 2
+    assert gt["model_type"] == "CRUSTAL"


### PR DESCRIPTION
> **Stacked on #322.** When #322 merges, the base auto-rebases to `deploy-test`.

## Summary

Proves #322 by porting real legacy GraphQL queries against the POC SDL it produces, then extends the validation by running a full auto-extracted runzi-query corpus.

What started as "let's port a few legacy tests as a parity sanity check" turned into a comprehensive sweep that surfaced **13 distinct parity gaps across 4 categories**, none of which were caught by #322's schema_parity tool or SDL invariants test.

See PR #321 (`docs/smoke-test-learnings.md`) for the full round-3 / round-4 writeup.

## Final scope

| | Count |
|---|---|
| Commits | 12 |
| Legacy test files ported | 17 |
| Auto-extracted runzi queries validated | 20 |
| New POC test functions | 83 |
| **Parity gaps fixed** | **13** |
| POC test count | **352** (was 269 pre-stack) |

## Parity gaps fixed (13 total in 4 categories)

### Category 1 — SDL-layer (9 gaps)

| # | Gap |
|---|---|
| 1 | `TaskTaskRelation.parent_id` / `child_id` — public Strings in legacy, `strawberry.Private` in POC |
| 2 | `InversionSolutionInterface.hazard_table` resolver missing (mfd_table existed) |
| 3 | `FileRelation.file_id` / `thing_id` — same pattern as gap #1 |
| 4 | `CreateFileRelationPayload.file_relation` field missing |
| 7a | `Predecessor.node: PredecessorUnion` resolver missing |
| 8 | `create_file.meta`, `nodes.id_in`, `reindex.id_in` mutation args used non-null list elements (`[T!]`); #322 missed these schema.py-level signatures |
| 10 | Plain `File` didn't implement `PredecessorsInterface`; `CreateFile.predecessors` arg missing |
| 12 | `UpdateGeneralTaskPayload.ok: Boolean` field missing |
| 13 | `UpdateOpenquakeHazardTaskInput.executor: String` field missing |

### Category 2 — Class-body shadow / Python typo (1 gap)

| # | Gap |
|---|---|
| 11 | `CreateOpenquakeHazardConfigInput.created` declared twice in the same class body (`DateTime` then `str`) — second shadowed the first; SDL emitted `String` while runzi sent `DateTime!` |

### Category 3 — Data-layer (1 gap)

| # | Gap |
|---|---|
| 5 | Pydantic `KVListPairModel.v: list[str]` rejected `[null]` after #322 widened the SDL to `[String]`. Production `argument_lists` data contains `v: [null]` for unswept args |

### Category 4 — Scalar-layer (1 gap)

| # | Gap |
|---|---|
| 6 | `DateTime` scalar had `parse_value=str` — accepted naive datetimes and `"September 5th, 1999"` silently. Legacy rejected both |

### Category 5 — Resolver semantics drift (folded into #7)

| # | Gap |
|---|---|
| 7b | `Predecessor.relationship` returned lowercase `"parent"`; legacy returned `"Parent"` (Title Case via `.name.title()`). **Four existing POC tests asserted on the wrong case**, masking the bug |

## What's in the diff

- 12 new test files (65 new test functions):
  - `test_thing_relation_bugfix_95.py` (4 tests)
  - `test_inversion_solution_schema_legacy.py` (4 tests)
  - `test_source_solution_bugfix_214.py` (2 tests)
  - `test_file_relation_bugfix_126.py` (2 tests)
  - `test_general_task_schema_legacy.py` (5 tests)
  - `test_table_schema_legacy.py` (5 tests)
  - `test_automation_task_schema_legacy.py` (3 tests)
  - `test_inversion_solution_bug_93.py` (2 tests)
  - `test_swept_arguments_edges.py` (8 tests)
  - `test_rupture_set_mutation_checks.py` (7 tests)
  - `test_bugfix_167_fileunion_aggregate.py` (1 test)
  - `test_inversion_solution_predecessors_legacy.py` (4 tests)
  - `test_openquake_hazard_solution_legacy.py` (3 tests)
  - `test_object_identities_legacy.py` (5 tests)
  - `test_file_predecessors_legacy.py` (3 tests)
  - `test_weka_codegen_queries.py` (4 tests)
  - `test_legacy_class_names_present.py` (1 test)
  - **`test_runzi_query_corpus.py` (22 tests — auto-extracted from runzi)**
- 4 existing POC tests updated to expect Title Case `"Parent"` after gap #7b fix
- 8 model files modified to land the gaps above

## Coverage of legacy graphql_api/tests

54 legacy GraphQL test files; all categorised:
- **17 ported** with new POC tests
- **33 already-covered** by existing POC tests (confirmed by reading + cross-check)
- **4 out-of-scope** (legacy data-shape migrations, Flask middleware, debug-print tests)

## Test plan

- [x] POC suite: **352 passed, 1 skipped** (was 269 pre-stack)
- [x] Every ported legacy file either passes against POC or surfaced a now-fixed gap
- [x] Auto-extracted runzi corpus runs in <300ms and validates 20 client queries
- [x] runzi-side bugs (3 in `_RUNZI_KNOWN_BAD`) filed as upstream ticket GNS-Science/nzshm-runzi#307
- [x] No regressions in pre-existing POC tests
- [ ] Reviewer / chrisdicaprio: re-run runzi against the SDL emitted by this branch to confirm the 13 gaps are no longer wire-impacting

## Notes for reviewers

- The 17 ported legacy files each preserve the legacy query strings verbatim; only the test scaffolding swaps from `graphene.test.Client` + `moto` mocks to `schema.execute_sync` + testcontainers DynamoDB.
- `_RUNZI_KNOWN_BAD` in `test_runzi_query_corpus.py` records the 2 runzi-side bugs (filed upstream as runzi #307). Once runzi fixes them, those entries can be deleted from POC and the corpus check upgrades from "tolerates these" to "catches a regression on either side."
- Pattern observation worth noting: 3 of the 13 gaps (#7a, #7b, #10) were explicit POC decisions documented with "no current client uses it" comments. Each was wrong. PR #321's smoke-test-learnings doc calls this out as a recurring failure mode worth treating with extra suspicion in future audits.
