### PR TITLE
fix(strawberry-poc): runzi corpus test skips when runzi clone absent (unblocks CI on deploy-test)

### DIFF
--- a/spike/strawberry_poc/tests/test_runzi_query_corpus.py
+++ b/spike/strawberry_poc/tests/test_runzi_query_corpus.py
@@ -7,8 +7,28 @@ GraphQL operation against POC's schema.
 
 If POC validates them all, runzi can talk to POC without breaking on
 the wire. Each new gap that ever ships gets caught here automatically.
+
+## CI / local-dev split
+
+CI runners don't have a runzi clone, so this whole file SKIPS cleanly
+in that environment. The check is opt-in by checking out the sibling
+runzi repo at the default path (or pointing at it via
+$RUNZI_CORPUS_PATH).
+
+To run the corpus check in CI, the workflow would have to clone runzi
+explicitly:
+
+  - run: git clone https://github.com/GNS-Science/nzshm-runzi.git \
+         "$RUNNER_TEMP/runzi"
+    env:
+      RUNZI_CORPUS_PATH: ${RUNNER_TEMP}/runzi/runzi/automation/toshi_api
+
+That's not wired today — local dev catches gaps, and the runzi-side
+bug reports already filed (GNS-Science/nzshm-runzi#307) cover the
+known cases.
 """
 
+import os
 import re
 from pathlib import Path
 
@@ -18,19 +38,32 @@ from graphql import parse, validate
 from schema import schema
 
 
-# Anchor relative to the repo root: this file lives at
-# spike/strawberry_poc/tests/, so .parents[3] is the nshm-toshi-api repo,
-# and the sibling runzi clone is up two more levels under MISC/.
-_RUNZI_ROOT = (
-    Path(__file__).resolve().parents[3]
-    / ".."
-    / ".."
-    / "MISC"
-    / "nzshm-runzi"
-    / "runzi"
-    / "automation"
-    / "toshi_api"
-).resolve()
+def _find_runzi_root() -> Path | None:
+    """Locate the runzi `toshi_api` package.
+
+    Resolution order:
+      1. $RUNZI_CORPUS_PATH if set and is_dir
+      2. Sibling clone at ../../MISC/nzshm-runzi (local-dev convention)
+      3. None — corpus check is skipped
+    """
+    env = os.environ.get("RUNZI_CORPUS_PATH")
+    if env:
+        p = Path(env).resolve()
+        return p if p.is_dir() else None
+    default = (
+        Path(__file__).resolve().parents[3]
+        / ".."
+        / ".."
+        / "MISC"
+        / "nzshm-runzi"
+        / "runzi"
+        / "automation"
+        / "toshi_api"
+    ).resolve()
+    return default if default.is_dir() else None
+
+
+_RUNZI_ROOT = _find_runzi_root()
 
 
 # A triple-quoted block whose first non-whitespace token is `query`,
@@ -53,8 +86,8 @@ def _has_unresolved_placeholders(op: str) -> bool:
 
 def _extract_operations():
     """Yield (origin, operation_text) tuples from every .py under runzi/toshi_api."""
-    if not _RUNZI_ROOT.is_dir():
-        return  # explicit skip handled at test collection time
+    if _RUNZI_ROOT is None:
+        return  # caller checks _RUNZI_ROOT separately and skips
     for py in sorted(_RUNZI_ROOT.rglob("*.py")):
         text = py.read_text(encoding="utf-8")
         for m in _GQL_LITERAL.finditer(text):
@@ -68,6 +101,19 @@ def _extract_operations():
 
 
 _OPERATIONS = list(_extract_operations())
+
+
+# Whole-module skip when runzi isn't on the filesystem. Local dev with a
+# sibling runzi clone (or $RUNZI_CORPUS_PATH pointing somewhere valid)
+# runs the corpus check; CI without runzi cleanly skips.
+pytestmark = pytest.mark.skipif(
+    _RUNZI_ROOT is None,
+    reason=(
+        "runzi clone not found. Set $RUNZI_CORPUS_PATH or clone "
+        "GNS-Science/nzshm-runzi into ../../MISC/nzshm-runzi to enable "
+        "the auto-extracted client-query corpus check. See module docstring."
+    ),
+)
 
 
 # Runzi has a couple of queries that select fields nobody implements (`source_solution`
@@ -85,12 +131,14 @@ _RUNZI_KNOWN_BAD = {
 
 
 def test_runzi_clone_is_discoverable():
-    """If the runzi sibling repo isn't checked out, fail loudly."""
-    assert _RUNZI_ROOT.is_dir(), (
-        f"runzi clone not found at {_RUNZI_ROOT}. "
-        "Clone GNS-Science/nzshm-runzi into ../../MISC/nzshm-runzi so this "
-        "corpus test can find real client queries."
-    )
+    """When this test runs at all, the runzi clone is present.
+
+    Module-level `pytestmark` skips the whole file if not. This test
+    just confirms the resolved path resolves to a directory — defensive
+    against `_find_runzi_root` returning a non-dir Path (which can't
+    happen today but might if the helper logic changes).
+    """
+    assert _RUNZI_ROOT is not None and _RUNZI_ROOT.is_dir()
 
 
 def test_extracted_at_least_some_operations():


### PR DESCRIPTION
## Summary

Unblocks CI on \`deploy-test\` after #323 merged.

The auto-extracted runzi-query corpus introduced in #323 (\`test_runzi_query_corpus.py\`) hardcoded a filesystem path expecting the sibling \`MISC/nzshm-runzi/\` clone next to the toshi-api repo. Two sentinel tests assert that path exists — fatal on CI runners where the clone isn't checked out.

Failing CI run after #323 merged: [27516724739](https://github.com/GNS-Science/nshm-toshi-api/actions/runs/27516724739/job/81326613754)

Error:

\`\`\`
FAILED tests/test_runzi_query_corpus.py::test_runzi_clone_is_discoverable
  AssertionError: runzi clone not found at /home/runner/work/MISC/nzshm-runzi/runzi/automation/toshi_api
FAILED tests/test_runzi_query_corpus.py::test_extracted_at_least_some_operations
  AssertionError: runzi corpus extracted ZERO operations
\`\`\`

## Fix

- Extract path resolution into \`_find_runzi_root()\` — checks \`\$RUNZI_CORPUS_PATH\` first, falls back to the local-dev sibling-clone path, returns None if neither resolves to a directory.
- Add module-level \`pytestmark = pytest.mark.skipif(_RUNZI_ROOT is None)\` — clean whole-file skip when runzi isn't on the filesystem.
- Module docstring documents how CI can opt in by cloning runzi and pointing \`\$RUNZI_CORPUS_PATH\` at it.

## Trade-off

The corpus check is now **local-only by default**. CI verifies nothing about runzi-side parity until the workflow is updated to clone runzi explicitly. The 13 parity gaps caught during round 3/4 are already fixed and pinned by the rest of the test suite (legacy-test ports + SDL invariants); the corpus check's primary value is gap-prevention for future runzi changes, which still happens at local-dev review time.

A follow-up to wire CI to clone runzi (or vendor a frozen copy of the queries) can land separately.

## Verification

- POC suite locally with runzi present: **352 passed, 1 skipped** (unchanged from #323)
- POC suite simulating CI (\`RUNZI_CORPUS_PATH=/tmp/nonexistent\`): **332 passed, 4 skipped** (1 prior + 3 from this file)
- The 20 actual corpus validations still run when runzi IS available

## Test plan

- [x] Local run with runzi clone present: passes
- [x] Local run with \`RUNZI_CORPUS_PATH\` pointing at a non-existent path: cleanly skips
- [ ] CI run on this PR — confirms the deploy-test workflow goes green again