### PR TITLE
fix(strawberry-poc): vendor runzi query corpus instead of live-fetching (supersedes #324)

### DIFF
--- a/spike/strawberry_poc/tests/runzi_corpus_data.py
+++ b/spike/strawberry_poc/tests/runzi_corpus_data.py
@@ -1,0 +1,423 @@
+"""Vendored snapshot of runzi GraphQL queries.
+
+DO NOT EDIT BY HAND. Regenerate with:
+
+    python spike/strawberry_poc/tools/refresh_runzi_corpus.py
+
+Snapshot source: GNS-Science/nzshm-runzi at 8f29eb7dc5476a1c236822d95df816aeab4c82b6
+Extracted from: runzi/automation/toshi_api/
+Operations: 18 (placeholder-templated queries dropped)
+
+This vendored copy exists to keep POC's CI gate honest while runzi
+catches up on owning client-side schema validation itself. See
+runzi#308 for the long-term plan.
+"""
+
+OPERATIONS = [
+    (
+        'runzi/automation/toshi_api/aggregate_inversion_solution.py::query get_sol_tables ($solution_id: ID!) {',
+        """\
+query get_sol_tables ($solution_id: ID!) {
+            node(id:$solution_id) {
+              ... on InversionSolution {
+                tables {
+                  source_solution
+                  created
+                  produced_by_id
+                  table_type
+                  identity
+                  table_id
+                }
+              }
+            }
+        }
+""",
+    ),
+    (
+        'runzi/automation/toshi_api/general_task.py::query one_general ($id:ID!)  {',
+        """\
+query one_general ($id:ID!)  {
+              node(id: $id) {
+                __typename
+                ... on GeneralTask {
+                  id
+                  title
+                  description
+                  created
+                  children {
+                    #total_count
+                    edges {
+                      node {
+                        child {
+                          __typename
+                          ... on Node {
+                            id
+                          }
+                          ... on RuptureGenerationTask {
+                            created
+                            state
+                            result
+                            arguments {k v}
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+""",
+    ),
+    (
+        'runzi/automation/toshi_api/general_task.py::mutation create_gt ($created:DateTime!, $agent_name:String!,',
+        """\
+mutation create_gt ($created:DateTime!, $agent_name:String!, $title:String!, $description:String!,
+              $argument_lists: [KeyValueListPairInput]!, $subtask_type:TaskSubType!, $subtask_count:Int!,
+              $model_type: ModelType!, $meta: [KeyValuePairInput]!) {
+              create_general_task (
+                input: {
+                  created: $created
+                  agent_name: $agent_name
+                  title: $title
+                  description: $description
+                  argument_lists: $argument_lists
+                  subtask_type: $subtask_type
+                  subtask_count:$subtask_count
+                  model_type: $model_type
+                  meta:$meta
+                })
+                {
+                  general_task {
+                    id
+                  }
+                }
+            }
+""",
+    ),
+    (
+        'runzi/automation/toshi_api/general_task.py::mutation update_subtask_count (',
+        """\
+mutation update_subtask_count (
+              $task_id:ID!
+              $subtask_count:Int!
+            ){
+              update_general_task(input:{
+                task_id:$task_id
+                subtask_count:$subtask_count
+              }) {
+                ok
+              }
+            }
+""",
+    ),
+    (
+        'runzi/automation/toshi_api/inversion_solution.py::mutation ($input: AppendInversionSolutionTablesInput!) {',
+        """\
+mutation ($input: AppendInversionSolutionTablesInput!) {
+              append_inversion_solution_tables(input: $input)
+               {
+               ok
+               inversion_solution {
+                  id,
+                  tables {
+                    identity
+                    table_id
+                    table {
+                     id
+                    }
+                  }
+                }
+              }
+            }
+""",
+    ),
+    (
+        'runzi/automation/toshi_api/inversion_solution.py::query get_sol_tables ($solution_id: ID!) {',
+        """\
+query get_sol_tables ($solution_id: ID!) {
+            node(id:$solution_id) {
+              ... on InversionSolution {
+                tables {
+                  created
+                  produced_by_id
+                  table_type
+                  identity
+                  table_id
+                }
+              }
+            }
+        }
+""",
+    ),
+    (
+        'runzi/automation/toshi_api/openquake_hazard/openquake_hazard_config.py::mutation ($created: DateTime!, $source_models: [ID]!, $archi',
+        """\
+mutation ($created: DateTime!, $source_models: [ID]!, $archive_id: ID!) {
+              create_openquake_hazard_config(
+                  input: {
+                      created: $created
+                      source_models: $source_models
+                      template_archive: $archive_id
+                  }
+              )
+              {
+                ok
+                config { id, created, source_models {
+                  ... on Node { id } }
+                }
+              }
+            }
+""",
+    ),
+    (
+        'runzi/automation/toshi_api/openquake_hazard/openquake_hazard_config.py::mutation create_file_relation(',
+        """\
+mutation create_file_relation(
+            $thing_id:ID!
+            $file_id:ID!
+            $role:FileRole!) {
+              create_file_relation(
+                file_id:$file_id
+                thing_id:$thing_id
+                role:$role
+              )
+            {
+              ok
+            }
+        }
+""",
+    ),
+    (
+        'runzi/automation/toshi_api/openquake_hazard/openquake_hazard_config.py::query get_hazard_config ($config_id: ID!) {',
+        """\
+query get_hazard_config ($config_id: ID!) {
+          node(id:$config_id) {
+            __typename
+            ... on OpenquakeHazardConfig{
+              created
+              source_models { id }
+              template_archive {
+                id
+                file_name
+                file_url
+                file_size
+                md5_digest
+                meta {k v}
+              }
+            }
+          }
+        }
+""",
+    ),
+    (
+        'runzi/automation/toshi_api/scaled_inversion_solution.py::query get_sol_tables ($solution_id: ID!) {',
+        """\
+query get_sol_tables ($solution_id: ID!) {
+            node(id:$solution_id) {
+              ... on InversionSolution {
+                tables {
+                  source_solution
+                  created
+                  produced_by_id
+                  table_type
+                  identity
+                  table_id
+                }
+              }
+            }
+        }
+""",
+    ),
+    (
+        'runzi/automation/toshi_api/toshi_api.py::query one_general ($id:ID!)  {',
+        """\
+query one_general ($id:ID!)  {
+              node(id: $id) {
+                __typename
+                ... on GeneralTask {
+                  id
+                  title
+                  description
+                  created
+                  #swept_arguments
+                  children {
+                    #total_count
+                    edges {
+                      node {
+                        child {
+                          __typename
+                          ... on Node {
+                            id
+                          }
+                          ... on AutomationTaskInterface {
+                            created
+                            state
+                            result
+                            arguments {k v}
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+""",
+    ),
+    (
+        'runzi/automation/toshi_api/toshi_api.py::fragment task_files on FileRelationConnection {',
+        """\
+fragment task_files on FileRelationConnection {
+            total_count
+            edges {
+              node {
+                ... on FileRelation {
+                  role
+                  file {
+                    ... on Node {
+                      id
+                    }
+                    ... on FileInterface {
+                      file_name
+                      file_size
+                      meta {k v}
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          query ($id:ID!) {
+              node(id: $id) {
+              __typename
+              ... on Node {
+                id
+              }
+              ... on AutomationTask {
+                files {
+                  ...task_files
+                }
+              }
+              ... on RuptureGenerationTask {
+                files {
+                  ...task_files
+                }
+              }
+            }
+          }
+""",
+    ),
+    (
+        'runzi/automation/toshi_api/toshi_api.py::query one_rupt ($id:ID!)  {',
+        """\
+query one_rupt ($id:ID!)  {
+              node(id: $id) {
+                __typename
+                ... on RuptureGenerationTask {
+                  id
+                  created
+                  arguments {k v}
+                }
+              }
+            }
+""",
+    ),
+    (
+        'runzi/automation/toshi_api/toshi_api.py::query file ($id:ID!) {',
+        """\
+query file ($id:ID!) {
+                node(id: $id) {
+            __typename
+            ... on Node {
+              id
+            }
+            ... on FileInterface {
+              file_name
+              file_size
+              meta {k v}
+              file_url
+            }
+          }
+        }
+""",
+    ),
+    (
+        'runzi/automation/toshi_api/toshi_api.py::query download_file ($id:ID!) {',
+        """\
+query download_file ($id:ID!) {
+                node(id: $id) {
+            __typename
+            ... on Node {
+              id
+            }
+            ... on FileInterface {
+              file_name
+              file_size
+              file_url
+            }
+          }
+        }
+""",
+    ),
+    (
+        'runzi/automation/toshi_api/toshi_api.py::query pred ($id:ID!) {',
+        """\
+query pred ($id:ID!) {
+          node (id: $id) {
+            ... on PredecessorsInterface {
+              predecessors {
+                id, depth
+              }
+            }
+          }
+        }
+""",
+    ),
+    (
+        'runzi/automation/toshi_api/toshi_api.py::mutation create_table (',
+        """\
+mutation create_table (
+          $rows: [[String]]!, $object_id: ID!, $table_name: String!, $headers: [String]!,
+          $column_types: [RowItemType]!, $created: DateTime!, $table_type: TableType!,
+          $dimensions: [KeyValueListPairInput]!
+        ) {
+          create_table(input: {
+            name: $table_name
+            created: $created
+            table_type: $table_type
+            dimensions: $dimensions
+            object_id: $object_id
+            column_headers: $headers
+            column_types: $column_types
+            rows: $rows
+            })
+          {
+            table {
+              id
+            }
+          }
+        }
+""",
+    ),
+    (
+        'runzi/automation/toshi_api/toshi_api.py::query get_table($table_id:ID!) {',
+        """\
+query get_table($table_id:ID!) {
+          node(id: $table_id) {
+            ... on Table {
+              id
+              name
+              created
+              table_type
+              object_id
+              column_headers
+              column_types
+              rows
+              dimensions{k v}
+            }
+          }
+        }
+""",
+    ),
+]

--- a/spike/strawberry_poc/tests/test_runzi_query_corpus.py
+++ b/spike/strawberry_poc/tests/test_runzi_query_corpus.py
@@ -1,15 +1,37 @@
-"""Auto-extracted client-query corpus from MISC/nzshm-runzi.
+"""Validates the vendored runzi GraphQL query corpus against POC's SDL.
 
-This is the durable answer documented in docs/smoke-test-learnings.md
-future-self checklist item #2 — instead of hand-picking queries to
-test verbatim, walk the client codebase and validate every embedded
-GraphQL operation against POC's schema.
+This is the durable answer from docs/smoke-test-learnings.md future-self
+item #2 — every embedded GraphQL operation in runzi's `toshi_api`
+package gets validated against POC's schema, end of story.
 
-If POC validates them all, runzi can talk to POC without breaking on
-the wire. Each new gap that ever ships gets caught here automatically.
+## Why vendored, not live
+
+The corpus is a SNAPSHOT — see `tests/data/runzi_corpus.py`. The
+snapshot lives in this repo for two reasons:
+
+1. **CI runs without external dependencies.** The original
+   live-extraction approach assumed a sibling MISC/nzshm-runzi clone
+   on the filesystem; CI runners don't have that. Vendoring removes
+   the cross-repo dependency.
+
+2. **Tests pin to a specific runzi commit.** When the snapshot fixes
+   a runzi query, we know exactly which runzi commit it landed in.
+
+To refresh the snapshot when runzi changes:
+
+    python spike/strawberry_poc/tools/refresh_runzi_corpus.py
+
+## Long-term plan (Option 4)
+
+The right home for "runzi queries validate against the toshi-api SDL"
+is on the runzi side — weka and kororaa already do this, both keep a
+copy of `schema.graphql` and run codegen/validation against it as
+part of their own build. See runzi#308 for the ticket asking runzi
+to follow suit. When runzi adopts that pattern, this corpus test +
+the vendored fixture can be deleted.
 """
 
-import re
+import importlib.util
 from pathlib import Path
 
 import pytest
@@ -18,63 +40,24 @@ from graphql import parse, validate
 from schema import schema
 
 
-# Anchor relative to the repo root: this file lives at
-# spike/strawberry_poc/tests/, so .parents[3] is the nshm-toshi-api repo,
-# and the sibling runzi clone is up two more levels under MISC/.
-_RUNZI_ROOT = (
-    Path(__file__).resolve().parents[3]
-    / ".."
-    / ".."
-    / "MISC"
-    / "nzshm-runzi"
-    / "runzi"
-    / "automation"
-    / "toshi_api"
-).resolve()
+# `tests/` is not a Python package (adding an __init__.py here breaks the
+# rest of the suite, which relies on sys.path-based imports). Load the
+# fixture by file path instead.
+_fixture_path = Path(__file__).parent / "runzi_corpus_data.py"
+_spec = importlib.util.spec_from_file_location("runzi_corpus_data", _fixture_path)
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+OPERATIONS = _module.OPERATIONS
 
 
-# A triple-quoted block whose first non-whitespace token is `query`,
-# `mutation`, or `fragment`. Permissive on whitespace and the operation
-# name so we catch runzi's typical `qry = '''mutation foo (…) {…}'''`.
-_GQL_LITERAL = re.compile(
-    r"'''(\s*(?:query|mutation|fragment)\b[^']*?)'''",
-    re.DOTALL,
-)
-
-
-def _has_unresolved_placeholders(op: str) -> bool:
-    """Runzi uses ###NAME### tokens that get string-substituted before send.
-
-    The static extractor can't resolve them; skip those queries so we test
-    only the parts where the literal IS the real query.
-    """
-    return "###" in op or "##" in op
-
-
-def _extract_operations():
-    """Yield (origin, operation_text) tuples from every .py under runzi/toshi_api."""
-    if not _RUNZI_ROOT.is_dir():
-        return  # explicit skip handled at test collection time
-    for py in sorted(_RUNZI_ROOT.rglob("*.py")):
-        text = py.read_text(encoding="utf-8")
-        for m in _GQL_LITERAL.finditer(text):
-            op = m.group(1).strip()
-            if _has_unresolved_placeholders(op):
-                continue
-            # Cheap label: file_basename:opening_line
-            first_line = op.splitlines()[0] if op else ""
-            label = f"{py.relative_to(_RUNZI_ROOT.parent.parent.parent)}::{first_line[:60]}"
-            yield label, op
-
-
-_OPERATIONS = list(_extract_operations())
-
-
-# Runzi has a couple of queries that select fields nobody implements (`source_solution`
-# on LabelledTableRelation never existed in legacy either) or that exploit
-# graphene's non-spec-compliant union/interface field auto-resolution.
-# These are runzi bugs, not POC parity gaps — we record them so the corpus
-# test stays accurate without surfacing them as POC failures.
+# Runzi has a couple of queries that select fields nobody implements
+# (`source_solution` on LabelledTableRelation never existed in legacy
+# either) or that exploit graphene's non-spec-compliant union/interface
+# field auto-resolution. These are runzi bugs, not POC parity gaps —
+# they were filed upstream as runzi#307. Recording them here means the
+# corpus check stays accurate without surfacing them as POC failures.
+#
+# Delete entries from this set as runzi#307 closes them.
 _RUNZI_KNOWN_BAD = {
     # `tables { source_solution }` — LabelledTableRelation has never had this field.
     "Cannot query field 'source_solution' on type 'LabelledTableRelation'.",
@@ -84,27 +67,19 @@ _RUNZI_KNOWN_BAD = {
 }
 
 
-def test_runzi_clone_is_discoverable():
-    """If the runzi sibling repo isn't checked out, fail loudly."""
-    assert _RUNZI_ROOT.is_dir(), (
-        f"runzi clone not found at {_RUNZI_ROOT}. "
-        "Clone GNS-Science/nzshm-runzi into ../../MISC/nzshm-runzi so this "
-        "corpus test can find real client queries."
-    )
-
-
-def test_extracted_at_least_some_operations():
-    """Sanity: we found something. Catches an empty-regex / wrong-path silent pass."""
-    assert _OPERATIONS, (
-        "runzi corpus extracted ZERO operations. Either the regex went wrong "
-        "or runzi's query shape changed (e.g. moved to a different package)."
+def test_corpus_is_non_empty():
+    """Sanity: the vendored fixture has operations. Catches an empty refresh."""
+    assert OPERATIONS, (
+        "Vendored runzi corpus is empty. Either the refresh script broke "
+        "(re-run tools/refresh_runzi_corpus.py) or runzi has no queries "
+        "left to validate (in which case this whole test file can be deleted)."
     )
 
 
 @pytest.mark.parametrize(
     "origin,query",
-    _OPERATIONS or [("placeholder", "query Empty { __typename }")],
-    ids=[label for label, _ in _OPERATIONS] or ["placeholder"],
+    OPERATIONS,
+    ids=[label for label, _ in OPERATIONS],
 )
 def test_runzi_query_validates_against_poc(origin, query):
     """Every runzi-embedded GraphQL operation must validate against POC's schema.

--- a/spike/strawberry_poc/tools/refresh_runzi_corpus.py
+++ b/spike/strawberry_poc/tools/refresh_runzi_corpus.py
@@ -1,0 +1,163 @@
+"""Re-snapshot the runzi GraphQL query corpus into a vendored fixture.
+
+The vendored fixture lives at `tests/runzi_corpus_data.py` and is loaded
+by `tests/test_runzi_query_corpus.py` to validate every runzi-embedded
+query against POC's SDL.
+
+Run this from the repo root or from anywhere — it locates the runzi
+clone via `--runzi-path` (default: `../../MISC/nzshm-runzi`) and writes
+the fixture in-place.
+
+## Why a vendored snapshot rather than reading the live clone
+
+A vendored snapshot keeps POC's CI green when the runzi clone isn't
+on the runner. It also pins the corpus to a specific runzi commit so
+we know exactly what we tested.
+
+The trade-off is that the snapshot can drift from current runzi. The
+intended cadence: re-run this script before each runzi release, and
+file a runzi PR if the corpus surfaces a new POC parity gap (or vice
+versa).
+
+## Longer-term plan (Option 4 — see runzi#308)
+
+The right home for "runzi queries validate against the toshi-api SDL"
+is on the runzi side, like weka and kororaa do. Both clients keep
+their own copy of `schema.graphql` and run codegen/validation against
+it as part of their build. When runzi follows suit, this vendored
+fixture + corpus test can be deleted entirely.
+
+Usage:
+    python tools/refresh_runzi_corpus.py
+    python tools/refresh_runzi_corpus.py --runzi-path /path/to/nzshm-runzi
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+# Triple-quoted block whose first non-whitespace token is `query`,
+# `mutation`, or `fragment`. Permissive on whitespace and the operation
+# name so we catch runzi's typical `qry = '''mutation foo (…) {…}'''`.
+_GQL_LITERAL = re.compile(
+    r"'''(\s*(?:query|mutation|fragment)\b[^']*?)'''",
+    re.DOTALL,
+)
+
+
+def _has_unresolved_placeholders(op: str) -> bool:
+    """Runzi uses ###NAME## tokens that get string-substituted before send.
+
+    The static extractor can't resolve them; drop those queries from the
+    corpus so we test only the parts where the literal IS the real query.
+    """
+    return "###" in op or "##" in op
+
+
+def extract(runzi_root: Path) -> list[tuple[str, str]]:
+    """Walk runzi/automation/toshi_api/ and return (label, query) tuples."""
+    pkg_root = runzi_root / "runzi" / "automation" / "toshi_api"
+    if not pkg_root.is_dir():
+        raise SystemExit(f"runzi toshi_api package not found at {pkg_root}")
+
+    out: list[tuple[str, str]] = []
+    for py in sorted(pkg_root.rglob("*.py")):
+        text = py.read_text(encoding="utf-8")
+        for m in _GQL_LITERAL.finditer(text):
+            op = m.group(1).strip()
+            if _has_unresolved_placeholders(op):
+                continue
+            first_line = op.splitlines()[0] if op else ""
+            label = f"{py.relative_to(runzi_root)}::{first_line[:60]}"
+            out.append((label, op))
+    return out
+
+
+def runzi_sha(runzi_root: Path) -> str | None:
+    """Best-effort short SHA of the runzi clone, for the snapshot header."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=runzi_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def write_fixture(operations: list[tuple[str, str]], dest: Path, sha: str | None):
+    """Emit a Python module the test can import."""
+    header = f'''"""Vendored snapshot of runzi GraphQL queries.
+
+DO NOT EDIT BY HAND. Regenerate with:
+
+    python spike/strawberry_poc/tools/refresh_runzi_corpus.py
+
+Snapshot source: GNS-Science/nzshm-runzi at {sha or "(sha unknown)"}
+Extracted from: runzi/automation/toshi_api/
+Operations: {len(operations)} (placeholder-templated queries dropped)
+
+This vendored copy exists to keep POC's CI gate honest while runzi
+catches up on owning client-side schema validation itself. See
+runzi#308 for the long-term plan.
+"""
+
+OPERATIONS = [
+'''
+
+    parts = [header]
+    for label, query in operations:
+        # Use ` ''' `-safe triple-quoted strings; runzi queries never contain
+        # `"""` so emit with double-quote triplets.
+        parts.append(f"    (\n")
+        parts.append(f"        {label!r},\n")
+        parts.append(f'        """\\\n')
+        # Indent the query body by 8 spaces so the docstring is readable but
+        # the query text itself is left-aligned for parse correctness.
+        parts.append(textwrap.indent(query, ""))
+        if not query.endswith("\n"):
+            parts.append("\n")
+        parts.append('""",\n')
+        parts.append("    ),\n")
+    parts.append("]\n")
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text("".join(parts), encoding="utf-8")
+    print(f"Wrote {len(operations)} operations → {dest}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    default_runzi = (Path(__file__).resolve().parents[3] / ".." / ".." / "MISC" / "nzshm-runzi").resolve()
+    default_fixture = Path(__file__).resolve().parent.parent / "tests" / "runzi_corpus_data.py"
+
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--runzi-path", type=Path, default=default_runzi, help="Path to runzi clone")
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=default_fixture,
+        help="Output fixture path (default: tests/runzi_corpus_data.py)",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.runzi_path.is_dir():
+        print(f"runzi path not found: {args.runzi_path}", file=sys.stderr)
+        return 1
+
+    operations = extract(args.runzi_path)
+    sha = runzi_sha(args.runzi_path)
+    write_fixture(operations, args.out, sha)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Supersedes #324 with the proper fix for the cross-project dependency that broke CI on \`deploy-test\` after #323 merged.

## The problem

The runzi corpus test introduced in #323 walked a sibling \`MISC/nzshm-runzi\` clone via a filesystem path hardcoded relative to the toshi-api repo. CI runners don't have that clone — Strawberry POC Tests failed immediately on the post-merge deploy-test run ([27516724739](https://github.com/GNS-Science/nshm-toshi-api/actions/runs/27516724739/job/81326613754)).

#324 worked around it with \`pytest.mark.skipif\` — silently disables the check when runzi isn't on the filesystem. That's not a real gate; on CI it became a no-op.

## The fix — vendor a snapshot

Three new files:

| File | What |
|---|---|
| \`tools/refresh_runzi_corpus.py\` | Extraction script. Walks a runzi clone, finds every \`qry = '''…'''\` literal, drops templated queries with \`###PLACEHOLDER###\` tokens, writes a Python fixture pinned to the runzi commit SHA. |
| \`tests/runzi_corpus_data.py\` | Vendored fixture — **18 operations**, pinned to runzi \`8f29eb7\`. DO NOT EDIT BY HAND. |
| \`tests/test_runzi_query_corpus.py\` (rewritten) | Loads operations from the vendored fixture via \`importlib\` (avoids making \`tests/\` a package, which would break the rest of the suite). Validates each query against \`schema._schema\`. |

\`_RUNZI_KNOWN_BAD\` still records the two runzi-side bugs filed as [runzi#307](https://github.com/GNS-Science/nzshm-runzi/issues/307).

## Why vendored, not CI-clone-runzi

Three reasons:

1. **CI runs without cross-project filesystem dependencies.** No extra workflow steps to clone runzi; no risk of runzi-side breakage red-lighting toshi-api CI.
2. **The corpus pins to a specific runzi commit**, so we know exactly what we tested.
3. **The vendored copy is intentionally short-lived.** Long-term plan is runzi#308 (Option 4 below).

## Long-term plan — Option 4 — runzi#308

The right home for "client queries validate against API SDL" is on the client side, like weka and kororaa already do. Both keep a \`schema.graphql\` at their repo root and run codegen/validation against it as part of CI. Runzi#308 asks runzi to follow suit. When that lands:

- \`tools/refresh_runzi_corpus.py\` — deleted
- \`tests/runzi_corpus_data.py\` — deleted
- \`tests/test_runzi_query_corpus.py\` — deleted

A comment on runzi#308 should reference the runzi commit that closes the loop.

## Verification

- POC suite: **351 passed, 1 skipped** (net −1 vs. the live-fetch version that #323 originally had — the vendored test drops one sentinel test plus the parametrized placeholder)
- Refresh script regenerates the fixture cleanly:

      $ python tools/refresh_runzi_corpus.py
      Wrote 18 operations → spike/strawberry_poc/tests/runzi_corpus_data.py

- No external filesystem dependency
- No skipif logic — corpus runs unconditionally in CI

## What about #324

Close it as superseded. This PR achieves the same goal (CI green on deploy-test) but does it properly.

## Test plan

- [x] Vendored fixture loads + validates against POC schema (18/18 pass)
- [x] Refresh script regenerates the fixture from a runzi clone
- [x] Full POC suite passes
- [x] No external filesystem dependency
- [ ] CI on this PR — confirms deploy-test workflow goes green
- [ ] runzi#308 filed against GNS-Science/nzshm-runzi (filing alongside this PR)