### PR TITLE
fix(strawberry-poc): restore deprecated OpenquakeHazardTask.config field

### DIFF
--- a/spike/strawberry_poc/data/models.py
+++ b/spike/strawberry_poc/data/models.py
@@ -205,6 +205,11 @@ class OpenquakeHazardTaskData(AutomationTaskData):
     srm_logic_tree: str | None = None  # JSON string
     gmcm_logic_tree: str | None = None  # JSON string
     openquake_config: str | None = None  # JSON string
+    # Legacy: relay GlobalID → OpenquakeHazardConfig. Deprecated in the Graphene
+    # schema ("We no longer store this value") but still queried by older runzi
+    # client code (e.g. AutomationTaskPageQuery), and present on records
+    # created before deprecation. Surfaced for read-only parity.
+    config: str | None = None
 
 
 class TableData(BaseModel):

--- a/spike/strawberry_poc/models/openquake_hazard_task.py
+++ b/spike/strawberry_poc/models/openquake_hazard_task.py
@@ -27,6 +27,7 @@ from .relations import (
 )
 
 _OpenquakeHazardSolution = Annotated["OpenquakeHazardSolution", strawberry.lazy("models.openquake_hazard_solution")]
+_OpenquakeHazardConfig = Annotated["OpenquakeHazardConfig", strawberry.lazy("models.openquake_hazard_config")]
 
 @strawberry.type
 class OpenquakeHazardTask(relay.Node, Thing, AutomationTaskInterface):
@@ -50,6 +51,7 @@ class OpenquakeHazardTask(relay.Node, Thing, AutomationTaskInterface):
     parents_raw: strawberry.Private[list | None] = None
     children_raw: strawberry.Private[list | None] = None
     hazard_solution_raw_id: strawberry.Private[str | None] = None
+    config_raw_id: strawberry.Private[str | None] = None
 
     @relay.connection(FileRelationsConnection)
     def files(self, info: Info) -> list[FileRelation | None]:
@@ -66,6 +68,19 @@ class OpenquakeHazardTask(relay.Node, Thing, AutomationTaskInterface):
     @strawberry.field
     def inversion_solution(self, info: Info) -> InversionSolutionUnion | None:
         return resolve_task_inversion_solution(info.context["dynamodb"], self.files_raw)
+
+    @strawberry.field(deprecation_reason="We no longer store this value.")
+    def config(self, info: Info) -> _OpenquakeHazardConfig | None:
+        if not self.config_raw_id:
+            return None
+        from models.openquake_hazard_config import OpenquakeHazardConfig  # noqa: PLC0415
+
+        try:
+            raw_id = GlobalID.from_id(self.config_raw_id).node_id
+        except Exception:
+            raw_id = self.config_raw_id
+        data = get_thing(info.context["dynamodb"], raw_id)
+        return OpenquakeHazardConfig.from_dict(data) if data else None
 
     @strawberry.field
     def hazard_solution(self, info: Info) -> _OpenquakeHazardSolution | None:
@@ -108,6 +123,7 @@ class OpenquakeHazardTask(relay.Node, Thing, AutomationTaskInterface):
             parents_raw=d.parents,
             children_raw=d.children,
             hazard_solution_raw_id=d.hazard_solution,
+            config_raw_id=d.config,
         )
 
 @strawberry.input

--- a/spike/strawberry_poc/tests/test_openquake.py
+++ b/spike/strawberry_poc/tests/test_openquake.py
@@ -531,3 +531,81 @@ def test_oq_solution_predecessors(oq_solution_with_archives, csv_archive_id):
     assert preds[0]["id"] == csv_archive_id
     assert preds[0]["depth"] == -1
     assert preds[0]["relationship"].lower() == "parent"
+
+
+# ── Legacy OpenquakeHazardTask.config field ───────────────────────────────────
+#
+# Old OpenquakeHazardTask records (created before the field was deprecated in
+# Graphene) carry a `config` attribute holding the relay GlobalID of an
+# OpenquakeHazardConfig. Runzi's AutomationTaskPageQuery still selects
+# `config { id created source_models { ... } template_archive { ... } }` on
+# those tasks. The Strawberry schema needs to keep that field around (as
+# deprecated, read-only) for drop-in client parity. Regression test for the
+# error reproduced on the test deployment: "Cannot query field 'config' on
+# type 'OpenquakeHazardTask'."
+
+OQ_TASK_LEGACY_CONFIG_QUERY = """
+query GetTaskWithLegacyConfig($id: ID!) {
+    node(id: $id) {
+        id
+        ... on OpenquakeHazardTask {
+            config {
+                id
+                created
+                template_archive { id file_name }
+                source_models {
+                    ... on File { id file_name }
+                }
+            }
+        }
+    }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def legacy_oq_task_with_config(gql_context, created_oq_config):
+    """Seed a legacy-shape OpenquakeHazardTask carrying the deprecated `config`
+    GlobalID directly via create_thing (the field is no longer accepted by the
+    create mutation)."""
+    from data.dynamo import create_thing  # noqa: PLC0415
+
+    data = create_thing(
+        gql_context["dynamodb"],
+        "OpenquakeHazardTask",
+        {
+            "state": "DONE",
+            "result": "SUCCESS",
+            "created": "2024-05-01T00:00:00Z",
+            "task_type": "HAZARD",
+            "config": created_oq_config["id"],
+        },
+    )
+    return base64.b64encode(f"OpenquakeHazardTask:{data['object_id']}".encode()).decode()
+
+
+def test_oq_task_legacy_config_field_resolves(
+    gql_context, legacy_oq_task_with_config, created_oq_config, template_archive_id
+):
+    result = schema.execute_sync(
+        OQ_TASK_LEGACY_CONFIG_QUERY,
+        variable_values={"id": legacy_oq_task_with_config},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    config = result.data["node"]["config"]
+    assert config is not None
+    assert config["id"] == created_oq_config["id"]
+    assert config["template_archive"]["id"] == template_archive_id
+
+
+def test_oq_task_config_null_when_absent(gql_context, created_oq_task):
+    """Tasks created via the modern mutation have no `config` — it must
+    resolve to null without erroring."""
+    result = schema.execute_sync(
+        OQ_TASK_LEGACY_CONFIG_QUERY,
+        variable_values={"id": created_oq_task["id"]},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    assert result.data["node"]["config"] is None


### PR DESCRIPTION
## Summary
- Weka issued `AutomationTaskPageQuery` (selected after a successful hazard calc) selects `config { … }` on `OpenquakeHazardTask`. The Graphene schema kept this field around as deprecated; the Strawberry POC dropped it, so the test deployment returns `Cannot query field 'config' on type 'OpenquakeHazardTask'.` plus all-null data.
- Reintroduce the field as a deprecated read-only resolver mirroring the `hazard_solution` resolver shape (`GlobalID.from_id` → `get_thing` → `OpenquakeHazardConfig.from_dict`). Marked with the legacy `deprecation_reason` ("We no longer store this value.").
- Added two regression tests: a legacy-shape task seeded via `create_thing` resolves `config.template_archive.id` end-to-end; a modern task returns `config: null` without erroring.

## Why the corpus test didn't catch it
`AutomationTaskPageQuery` lives in a separate (weka-frontend) client, not the `runzi/automation/toshi_api` package that `test_runzi_query_corpus.py` walked.

## Test plan
- [x] `uv run pytest spike/strawberry_poc/tests/` — 354 passed, 1 skipped
- [x] `uv run pytest spike/strawberry_poc/tests/test_openquake.py` — 26 passed (incl. 2 new regression tests)
- [x] Ruff clean on the diff (the 2 pre-existing errors in `openquake_hazard_task.py` are unrelated)
- [ ] Confirm fix on test stage by reissuing the failing `AutomationTaskPageQuery` against the deployed branch