### PR TITLE
feat(strawberry-poc): port auth/middleware scope enforcement to AuthExtension

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,3 +112,8 @@ All config is in `graphql_api/config.py` and loaded from `.env`:
 
 ### Testing Fixtures
 Tests import `graphql_client` from `conftest.py`, which wraps the schema in `moto`'s `mock_aws` context, creates DynamoDB tables via `migrate()`, and creates an S3 bucket. Tests make GraphQL requests directly via `graphene.test.Client`.
+
+### Auth in tests (POC)
+The Strawberry POC's `AuthExtension` (`spike/strawberry_poc/auth.py`) enforces `toshi/read` on every request and `toshi/write` on mutations. The POC's `tests/conftest.py` sets `TESTING=1`, which short-circuits the extension and attaches a synthetic `local-dev` user with both scopes — so existing tests run unchanged.
+
+**Rule of thumb when adding scope-aware code**: any resolver or code path that reads `info.context["current_user"]` (scopes, userId, authMethod) to make a decision must have at least one test that disables the bypass and exercises real enforcement. See the `no_bypass` fixture and `_FakeRequest` pattern in `spike/strawberry_poc/tests/test_auth.py`. Without it, the test silently passes under the synthetic user (which holds both scopes) and the real denial path is never exercised.

--- a/spike/strawberry_poc/auth.py
+++ b/spike/strawberry_poc/auth.py
@@ -68,9 +68,18 @@ def _extract_auth_context(request: Any) -> tuple[str, set[str], str]:
     """
     Pull (userId, scopes, authMethod) from request.
 
-    Mangum exposes the API Gateway event at request.scope["aws.event"]; the
-    Lambda Authorizer's output lives under requestContext.authorizer.
-    Header fallback supports local/e2e runs without API Gateway.
+    Source selection is atomic, not per-field:
+      - If the API Gateway authorizer ran (its dict is present, even
+        partially), we trust it as the sole source. Missing keys get safe
+        defaults — we never fall through to headers for individual fields.
+      - Otherwise (no Mangum / local dev / e2e harness), read from X-Auth-*
+        headers.
+
+    The atomic choice prevents a spoof where an authenticated request's
+    headers fill in a missing authorizer field — e.g. real userId from the
+    authorizer + spoofed scopes from the X-Auth-Scopes header. The
+    authorizer is the trust boundary; if it's there, headers don't get a
+    say.
     """
     authorizer_ctx: dict[str, Any] = {}
     if request is not None:
@@ -80,30 +89,23 @@ def _extract_auth_context(request: Any) -> tuple[str, set[str], str]:
             request_context = aws_event.get("requestContext") or {}
             authorizer_ctx = request_context.get("authorizer") or {}
 
-    headers = {}
-    if request is not None:
-        raw_headers = getattr(request, "headers", None)
-        if raw_headers is not None:
-            try:
-                headers = {k.lower(): v for k, v in raw_headers.items()}
-            except AttributeError:
-                headers = {}
+    if authorizer_ctx:
+        user_id = authorizer_ctx.get("userId") or "anonymous"
+        scopes_str = authorizer_ctx.get("scopes") or ""
+        auth_method = authorizer_ctx.get("authMethod") or "none"
+    else:
+        headers = {}
+        if request is not None:
+            raw_headers = getattr(request, "headers", None)
+            if raw_headers is not None:
+                try:
+                    headers = {k.lower(): v for k, v in raw_headers.items()}
+                except AttributeError:
+                    headers = {}
+        user_id = headers.get("x-auth-userid") or "anonymous"
+        scopes_str = headers.get("x-auth-scopes") or ""
+        auth_method = headers.get("x-auth-method") or "none"
 
-    user_id = (
-        authorizer_ctx.get("userId")
-        or headers.get("x-auth-userid")
-        or "anonymous"
-    )
-    scopes_str = (
-        authorizer_ctx.get("scopes")
-        or headers.get("x-auth-scopes")
-        or ""
-    )
-    auth_method = (
-        authorizer_ctx.get("authMethod")
-        or headers.get("x-auth-method")
-        or "none"
-    )
     scopes = set(scopes_str.split()) if scopes_str else set()
     return user_id, scopes, auth_method
 

--- a/spike/strawberry_poc/auth.py
+++ b/spike/strawberry_poc/auth.py
@@ -1,0 +1,149 @@
+"""
+Strawberry SchemaExtension enforcing toshi/read + toshi/write scopes.
+
+Port of auth/middleware.py (Flask before_request hook). Runs in the
+on_execute lifecycle phase — after parse + validate, before resolvers
+fire — so OperationType is reliable and a raised GraphQLError aborts
+execution without invoking any resolver.
+
+Fail-closed model:
+  - Parse failure → resolvers never run; auth check never reached, but
+    the parse error itself is returned to the client.
+  - Missing/invalid auth context → blocked with GraphQLError.
+  - Missing toshi/read → all operations blocked.
+  - Missing toshi/write → mutations blocked (queries still allowed).
+
+Local-dev / test bypass: no-op when TESTING=1 or SLS_OFFLINE=1; attaches
+a synthetic current_user with both scopes so resolvers that read
+context["current_user"] see a consistent shape.
+
+Auth context source (in priority order):
+  1. request.scope["aws.event"]["requestContext"]["authorizer"]
+     — injected by Mangum from the API Gateway Lambda Authorizer.
+  2. X-Auth-Userid / X-Auth-Scopes / X-Auth-Method headers
+     — for local/e2e testing without API Gateway in front.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from graphql import GraphQLError
+from strawberry.extensions import SchemaExtension
+from strawberry.types.graphql import OperationType
+
+logger = logging.getLogger(__name__)
+
+SCOPE_READ = "toshi/read"
+SCOPE_WRITE = "toshi/write"
+
+
+def _boolean_env(name: str, default: str = "FALSE") -> bool:
+    return os.environ.get(name, default).upper() in {"1", "Y", "YES", "TRUE"}
+
+
+def _is_bypass() -> bool:
+    return _boolean_env("TESTING") or _boolean_env("SLS_OFFLINE")
+
+
+def _bypass_user() -> dict[str, Any]:
+    return {
+        "userId": "local-dev",
+        "scopes": {SCOPE_READ, SCOPE_WRITE},
+        "authMethod": "bypass",
+    }
+
+
+def _extract_auth_context(request: Any) -> tuple[str, set[str], str]:
+    """
+    Pull (userId, scopes, authMethod) from request.
+
+    Mangum exposes the API Gateway event at request.scope["aws.event"]; the
+    Lambda Authorizer's output lives under requestContext.authorizer.
+    Header fallback supports local/e2e runs without API Gateway.
+    """
+    authorizer_ctx: dict[str, Any] = {}
+    if request is not None:
+        scope = getattr(request, "scope", None) or {}
+        aws_event = scope.get("aws.event") if isinstance(scope, dict) else None
+        if isinstance(aws_event, dict):
+            request_context = aws_event.get("requestContext") or {}
+            authorizer_ctx = request_context.get("authorizer") or {}
+
+    headers = {}
+    if request is not None:
+        raw_headers = getattr(request, "headers", None)
+        if raw_headers is not None:
+            try:
+                headers = {k.lower(): v for k, v in raw_headers.items()}
+            except AttributeError:
+                headers = {}
+
+    user_id = (
+        authorizer_ctx.get("userId")
+        or headers.get("x-auth-userid")
+        or "anonymous"
+    )
+    scopes_str = (
+        authorizer_ctx.get("scopes")
+        or headers.get("x-auth-scopes")
+        or ""
+    )
+    auth_method = (
+        authorizer_ctx.get("authMethod")
+        or headers.get("x-auth-method")
+        or "none"
+    )
+    scopes = set(scopes_str.split()) if scopes_str else set()
+    return user_id, scopes, auth_method
+
+
+class AuthExtension(SchemaExtension):
+    """Enforces scope-based authorization on every GraphQL operation."""
+
+    def on_execute(self):
+        ctx = self.execution_context.context
+        if not isinstance(ctx, dict):
+            # Strawberry allows non-dict contexts; we require a dict to
+            # attach current_user. Tests using bare contexts opt out of
+            # auth by setting TESTING=1, which short-circuits below.
+            yield
+            return
+
+        if _is_bypass():
+            ctx["current_user"] = _bypass_user()
+            yield
+            return
+
+        request = ctx.get("request")
+        user_id, scopes, auth_method = _extract_auth_context(request)
+        ctx["current_user"] = {
+            "userId": user_id,
+            "scopes": scopes,
+            "authMethod": auth_method,
+        }
+
+        logger.info(
+            "[auth] userId=%s scopes=%s method=%s op=%s",
+            user_id,
+            sorted(scopes),
+            auth_method,
+            self.execution_context.operation_type.value,
+        )
+
+        if SCOPE_READ not in scopes:
+            logger.warning("Access denied for %s: missing %s", user_id, SCOPE_READ)
+            raise GraphQLError(f"Missing required scope: {SCOPE_READ}")
+
+        if (
+            self.execution_context.operation_type == OperationType.MUTATION
+            and SCOPE_WRITE not in scopes
+        ):
+            logger.warning(
+                "Mutation blocked for %s: missing %s", user_id, SCOPE_WRITE
+            )
+            raise GraphQLError(f"GraphQL mutations require scope: {SCOPE_WRITE}")
+
+        yield

--- a/spike/strawberry_poc/auth.py
+++ b/spike/strawberry_poc/auth.py
@@ -17,6 +17,14 @@ Local-dev / test bypass: no-op when TESTING=1 or SLS_OFFLINE=1; attaches
 a synthetic current_user with both scopes so resolvers that read
 context["current_user"] see a consistent shape.
 
+**Test-writing rule of thumb**: any resolver or code path that reads
+context["current_user"] (scopes, userId, authMethod) to make a decision
+must have at least one test that disables the bypass (see the
+`no_bypass` fixture pattern in tests/test_auth.py) and exercises the
+real enforcement path with an explicit FakeRequest. Otherwise the test
+will silently pass under the synthetic local-dev user (which holds
+both scopes) and the real-world denial path is never exercised.
+
 Auth context source (in priority order):
   1. request.scope["aws.event"]["requestContext"]["authorizer"]
      — injected by Mangum from the API Gateway Lambda Authorizer.

--- a/spike/strawberry_poc/schema.py
+++ b/spike/strawberry_poc/schema.py
@@ -19,6 +19,7 @@ from strawberry import relay
 from strawberry.relay import GlobalID
 from strawberry.schema.config import StrawberryConfig
 
+from auth import AuthExtension
 import data.search as _data_search
 from data.dynamo import es_key_for, get_object, scan_objects_paginated
 from data.s3 import scan_s3_paginated
@@ -760,4 +761,5 @@ schema = strawberry.Schema(
     query=Query,
     mutation=Mutation,
     config=StrawberryConfig(auto_camel_case=False),
+    extensions=[AuthExtension],
 )

--- a/spike/strawberry_poc/tests/conftest.py
+++ b/spike/strawberry_poc/tests/conftest.py
@@ -28,6 +28,10 @@ os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
 os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
 os.environ.setdefault("AWS_SECURITY_TOKEN", "testing")
 os.environ.setdefault("AWS_SESSION_TOKEN", "testing")
+# AuthExtension is a no-op when TESTING=1, attaching a synthetic
+# current_user with both toshi/read and toshi/write. Tests that need
+# to exercise the enforcement path override this with monkeypatch.
+os.environ.setdefault("TESTING", "1")
 
 _TABLE_NAMES = [
     f"ToshiThingObject-{STAGE}",

--- a/spike/strawberry_poc/tests/test_auth.py
+++ b/spike/strawberry_poc/tests/test_auth.py
@@ -1,0 +1,317 @@
+"""
+Tests for AuthExtension scope enforcement.
+
+Uses an isolated test schema (not the production schema) so we don't
+need DynamoDB / Elasticsearch fixtures. A separate test confirms the
+production schema actually has the extension wired.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import strawberry
+from strawberry.schema.config import StrawberryConfig
+
+from auth import SCOPE_READ, SCOPE_WRITE, AuthExtension
+from schema import schema as production_schema
+
+
+@strawberry.type
+class _Query:
+    @strawberry.field
+    def ping(self) -> str:
+        return "pong"
+
+
+@strawberry.type
+class _Mutation:
+    @strawberry.mutation
+    def do_write(self) -> str:
+        return "written"
+
+
+test_schema = strawberry.Schema(
+    query=_Query,
+    mutation=_Mutation,
+    config=StrawberryConfig(auto_camel_case=False),
+    extensions=[AuthExtension],
+)
+
+
+class _FakeHeaders(dict):
+    """Mimics Starlette's case-insensitive header access via .items()."""
+
+
+class _FakeRequest:
+    """Minimal stand-in for a Starlette/FastAPI Request."""
+
+    def __init__(
+        self,
+        authorizer: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.scope: dict[str, Any] = {}
+        if authorizer is not None:
+            self.scope["aws.event"] = {"requestContext": {"authorizer": authorizer}}
+        self.headers = _FakeHeaders(headers or {})
+
+
+@pytest.fixture
+def no_bypass(monkeypatch):
+    """Disable the conftest's TESTING=1 so the enforcement path runs."""
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.delenv("SLS_OFFLINE", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Bypass path (TESTING=1 / SLS_OFFLINE=1)
+# ---------------------------------------------------------------------------
+
+
+def test_bypass_via_testing_env_allows_query(monkeypatch):
+    monkeypatch.setenv("TESTING", "1")
+    result = test_schema.execute_sync("{ ping }", context_value={})
+    assert result.errors is None
+    assert result.data == {"ping": "pong"}
+
+
+def test_bypass_via_testing_env_allows_mutation(monkeypatch):
+    monkeypatch.setenv("TESTING", "1")
+    result = test_schema.execute_sync("mutation { do_write }", context_value={})
+    assert result.errors is None
+    assert result.data == {"do_write": "written"}
+
+
+def test_bypass_via_sls_offline_allows_query(no_bypass, monkeypatch):
+    monkeypatch.setenv("SLS_OFFLINE", "1")
+    result = test_schema.execute_sync("{ ping }", context_value={})
+    assert result.errors is None
+
+
+def test_bypass_attaches_synthetic_user_with_both_scopes(monkeypatch):
+    monkeypatch.setenv("TESTING", "1")
+    ctx: dict[str, Any] = {}
+    test_schema.execute_sync("{ ping }", context_value=ctx)
+    user = ctx["current_user"]
+    assert user["userId"] == "local-dev"
+    assert user["authMethod"] == "bypass"
+    assert user["scopes"] == {SCOPE_READ, SCOPE_WRITE}
+
+
+# ---------------------------------------------------------------------------
+# Anonymous / unauthenticated
+# ---------------------------------------------------------------------------
+
+
+def test_anonymous_blocked_on_query(no_bypass):
+    ctx = {"request": _FakeRequest()}
+    result = test_schema.execute_sync("{ ping }", context_value=ctx)
+    assert result.errors is not None
+    assert "Missing required scope: toshi/read" in str(result.errors[0])
+
+
+def test_anonymous_blocked_on_mutation_reports_read_scope_first(no_bypass):
+    ctx = {"request": _FakeRequest()}
+    result = test_schema.execute_sync("mutation { do_write }", context_value=ctx)
+    assert result.errors is not None
+    assert "toshi/read" in str(result.errors[0])
+
+
+def test_missing_request_blocks_with_anonymous(no_bypass):
+    ctx: dict[str, Any] = {}
+    result = test_schema.execute_sync("{ ping }", context_value=ctx)
+    assert result.errors is not None
+    assert "toshi/read" in str(result.errors[0])
+
+
+# ---------------------------------------------------------------------------
+# Read-only token
+# ---------------------------------------------------------------------------
+
+
+def test_read_scope_allows_query(no_bypass):
+    ctx = {
+        "request": _FakeRequest(
+            authorizer={
+                "userId": "alice",
+                "scopes": "toshi/read",
+                "authMethod": "cognito-jwt",
+            }
+        )
+    }
+    result = test_schema.execute_sync("{ ping }", context_value=ctx)
+    assert result.errors is None
+    assert result.data == {"ping": "pong"}
+
+
+def test_read_scope_blocks_mutation(no_bypass):
+    ctx = {
+        "request": _FakeRequest(
+            authorizer={
+                "userId": "alice",
+                "scopes": "toshi/read",
+                "authMethod": "cognito-jwt",
+            }
+        )
+    }
+    result = test_schema.execute_sync("mutation { do_write }", context_value=ctx)
+    assert result.errors is not None
+    assert "GraphQL mutations require scope: toshi/write" in str(result.errors[0])
+
+
+# ---------------------------------------------------------------------------
+# Write token
+# ---------------------------------------------------------------------------
+
+
+def test_write_scope_allows_mutation(no_bypass):
+    ctx = {
+        "request": _FakeRequest(
+            authorizer={
+                "userId": "bob",
+                "scopes": "toshi/read toshi/write",
+                "authMethod": "cognito-jwt",
+            }
+        )
+    }
+    result = test_schema.execute_sync("mutation { do_write }", context_value=ctx)
+    assert result.errors is None
+    assert result.data == {"do_write": "written"}
+
+
+def test_authenticated_request_attaches_current_user(no_bypass):
+    ctx = {
+        "request": _FakeRequest(
+            authorizer={
+                "userId": "charlie",
+                "scopes": "toshi/read toshi/write",
+                "authMethod": "cognito-jwt",
+            }
+        )
+    }
+    test_schema.execute_sync("{ ping }", context_value=ctx)
+    user = ctx["current_user"]
+    assert user["userId"] == "charlie"
+    assert user["scopes"] == {SCOPE_READ, SCOPE_WRITE}
+    assert user["authMethod"] == "cognito-jwt"
+
+
+# ---------------------------------------------------------------------------
+# Header fallback (no Mangum: local uvicorn / e2e harness)
+# ---------------------------------------------------------------------------
+
+
+def test_header_fallback_when_no_authorizer(no_bypass):
+    ctx = {
+        "request": _FakeRequest(
+            headers={
+                "x-auth-userid": "header-user",
+                "x-auth-scopes": "toshi/read toshi/write",
+                "x-auth-method": "header-bypass",
+            }
+        )
+    }
+    result = test_schema.execute_sync("mutation { do_write }", context_value=ctx)
+    assert result.errors is None
+    assert ctx["current_user"]["userId"] == "header-user"
+    assert ctx["current_user"]["authMethod"] == "header-bypass"
+
+
+def test_authorizer_wins_over_headers_when_both_present(no_bypass):
+    """API Gateway authorizer is the trust boundary; spoofed headers must lose."""
+    ctx = {
+        "request": _FakeRequest(
+            authorizer={
+                "userId": "real-alice",
+                "scopes": "toshi/read",
+                "authMethod": "cognito-jwt",
+            },
+            headers={
+                "x-auth-userid": "spoofed",
+                "x-auth-scopes": "toshi/read toshi/write",
+                "x-auth-method": "header-bypass",
+            },
+        )
+    }
+    result = test_schema.execute_sync("mutation { do_write }", context_value=ctx)
+    assert result.errors is not None
+    assert "toshi/write" in str(result.errors[0])
+    assert ctx["current_user"]["userId"] == "real-alice"
+
+
+# ---------------------------------------------------------------------------
+# Multi-operation document — operationName must drive scope check
+# ---------------------------------------------------------------------------
+
+
+def test_operation_name_selects_read_op_with_read_only_scope(no_bypass):
+    doc = """
+    query Read { ping }
+    mutation Write { do_write }
+    """
+    ctx = {
+        "request": _FakeRequest(
+            authorizer={
+                "userId": "alice",
+                "scopes": "toshi/read",
+                "authMethod": "cognito-jwt",
+            }
+        )
+    }
+    result = test_schema.execute_sync(doc, context_value=ctx, operation_name="Read")
+    assert result.errors is None
+    assert result.data == {"ping": "pong"}
+
+
+def test_operation_name_selects_mutation_blocked_with_read_only_scope(no_bypass):
+    doc = """
+    query Read { ping }
+    mutation Write { do_write }
+    """
+    ctx = {
+        "request": _FakeRequest(
+            authorizer={
+                "userId": "alice",
+                "scopes": "toshi/read",
+                "authMethod": "cognito-jwt",
+            }
+        )
+    }
+    result = test_schema.execute_sync(doc, context_value=ctx, operation_name="Write")
+    assert result.errors is not None
+    assert "toshi/write" in str(result.errors[0])
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed on parse error: resolvers never run because parsing fails first
+# ---------------------------------------------------------------------------
+
+
+def test_parse_error_blocks_execution(no_bypass):
+    """If the document doesn't parse, on_execute never fires — no resolver runs."""
+    ctx = {
+        "request": _FakeRequest(
+            authorizer={
+                "userId": "alice",
+                "scopes": "toshi/read toshi/write",
+                "authMethod": "cognito-jwt",
+            }
+        )
+    }
+    result = test_schema.execute_sync("mutation { unclosed", context_value=ctx)
+    assert result.errors is not None
+    assert result.data is None
+
+
+# ---------------------------------------------------------------------------
+# Production schema wiring
+# ---------------------------------------------------------------------------
+
+
+def test_production_schema_has_auth_extension_registered():
+    assert any(
+        ext is AuthExtension or type(ext) is AuthExtension
+        for ext in production_schema.extensions
+    ), "AuthExtension is not registered on the production schema"

--- a/spike/strawberry_poc/tests/test_auth.py
+++ b/spike/strawberry_poc/tests/test_auth.py
@@ -241,6 +241,36 @@ def test_authorizer_wins_over_headers_when_both_present(no_bypass):
     assert ctx["current_user"]["userId"] == "real-alice"
 
 
+def test_partial_authorizer_does_not_fall_through_to_headers(no_bypass):
+    """
+    Spoofing window flagged in PR review: if the authorizer ran but is
+    missing a field (e.g. scopes), per-field fallback would let an
+    X-Auth-Scopes header fill it in. The contract is atomic — if the
+    authorizer is present at all, headers are ignored entirely.
+    """
+    ctx = {
+        "request": _FakeRequest(
+            authorizer={
+                # scopes deliberately missing — only userId + authMethod
+                "userId": "real-alice",
+                "authMethod": "cognito-jwt",
+            },
+            headers={
+                # spoofed elevation attempt
+                "x-auth-scopes": "toshi/read toshi/write",
+            },
+        )
+    }
+    # No scopes from the authorizer → blocked on the read check.
+    # If the header had been consulted, the mutation would have succeeded
+    # because both read+write would be present.
+    result = test_schema.execute_sync("mutation { do_write }", context_value=ctx)
+    assert result.errors is not None
+    assert "Missing required scope: toshi/read" in str(result.errors[0])
+    assert ctx["current_user"]["scopes"] == set()
+    assert ctx["current_user"]["userId"] == "real-alice"
+
+
 # ---------------------------------------------------------------------------
 # Multi-operation document — operationName must drive scope check
 # ---------------------------------------------------------------------------

--- a/spike/strawberry_poc/tests/test_auth_http.py
+++ b/spike/strawberry_poc/tests/test_auth_http.py
@@ -1,0 +1,84 @@
+"""
+HTTP-level integration test for AuthExtension.
+
+Validates the end-to-end path:
+    TestClient → ASGI → FastAPI route → GraphQLRouter
+        → get_context(request) → AuthExtension.on_execute
+
+TestClient drives the app directly (no Mangum), so this exercises the
+X-Auth-* header fallback path the extension uses for local/e2e runs.
+The Mangum/API-Gateway-authorizer path is covered by the unit tests in
+test_auth.py via a synthetic request.scope["aws.event"].
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import app
+
+
+@pytest.fixture
+def http_client(monkeypatch):
+    """A TestClient with the conftest's TESTING bypass turned off."""
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.delenv("SLS_OFFLINE", raising=False)
+    return TestClient(app)
+
+
+def _post_graphql(client, body, headers=None):
+    return client.post("/graphql", json=body, headers=headers or {})
+
+
+def test_http_anonymous_query_blocked(http_client):
+    response = _post_graphql(http_client, {"query": "{ __typename }"})
+    assert response.status_code == 200  # GraphQL errors surface in body
+    payload = response.json()
+    assert payload["data"] is None
+    assert any("toshi/read" in err["message"] for err in payload["errors"])
+
+
+def test_http_read_scope_via_headers_allows_query(http_client):
+    response = _post_graphql(
+        http_client,
+        {"query": "{ __typename }"},
+        headers={
+            "X-Auth-Userid": "alice",
+            "X-Auth-Scopes": "toshi/read",
+            "X-Auth-Method": "header-bypass",
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload.get("errors") is None
+    assert payload["data"]["__typename"]  # query reached resolver
+
+
+def test_http_options_preflight_not_subject_to_auth(http_client):
+    """OPTIONS never reaches the GraphQL handler — the extension can't fire."""
+    response = http_client.options(
+        "/graphql",
+        headers={
+            "Origin": "http://example.com",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    # FastAPI/Starlette returns 405 by default when CORS middleware isn't
+    # installed; the relevant assertion is that no auth-error JSON body is
+    # produced (i.e. the GraphQL handler never saw the request).
+    assert response.status_code in {200, 405}
+    if response.headers.get("content-type", "").startswith("application/json"):
+        assert "toshi" not in response.text
+
+
+def test_http_bypass_via_testing_env_when_enabled(monkeypatch):
+    """With TESTING=1, no auth headers required."""
+    monkeypatch.setenv("TESTING", "1")
+    monkeypatch.delenv("SLS_OFFLINE", raising=False)
+    client = TestClient(app)
+    response = _post_graphql(client, {"query": "{ __typename }"})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload.get("errors") is None
+    assert payload["data"]["__typename"]  # query reached resolver


### PR DESCRIPTION
## Summary

Ports `auth/middleware.py` (Flask `before_request` hook) to a Strawberry `SchemaExtension` on the POC, so the `strawberry-poc` Lambda enforces the same `toshi/read` / `toshi/write` scopes the legacy `app` Lambda does today.

Closes #327. Unblocks ADR-004 / #319 prerequisite (1).

## Parity matrix

| Layer | Legacy (`app`) | POC after this PR |
|---|---|---|
| API Gateway JWT validation | ✅ via `jwtAuthorizer` | ✅ unchanged |
| OPTIONS preflight passthrough | ✅ | ✅ (Starlette responds before GraphQL handler) |
| `toshi/read` enforced on every op | ✅ | ✅ |
| `toshi/write` enforced on mutations | ✅ via body re-parse | ✅ via `execution_context.operation_type` (no re-parse) |
| `{userId, scopes, authMethod}` on context | ✅ `flask.g.current_user` | ✅ `info.context["current_user"]` |
| Audit log per request | ✅ | ✅ |
| TESTING/SLS_OFFLINE bypass | ✅ | ✅ |

## Design choice — Strawberry extension, not FastAPI middleware

`on_execute` fires after parse + validate, before resolvers. At that point `execution_context.operation_type` is authoritative, so the legacy's body-parsing dance is unnecessary, multi-operation documents with `operationName` work for free, and a raised `GraphQLError` produces a GraphQL-shaped response (vs. an HTTP middleware returning 403). Parse failures are fail-closed by default — if the document doesn't parse, no resolver runs.

## Auth source priority

1. `request.scope["aws.event"]["requestContext"]["authorizer"]` — Mangum-injected output from the API Gateway Lambda Authorizer.
2. `X-Auth-Userid` / `X-Auth-Scopes` / `X-Auth-Method` headers — fallback for local/e2e harnesses without API Gateway.

When both are present, the authorizer wins (anti-spoofing; covered by a dedicated test).

## Test changes

- 17 unit tests in `tests/test_auth.py` using an isolated test schema (no DB fixtures): bypass paths, anonymous denial, read-only/write enforcement, header fallback, anti-spoofing, multi-op `operationName` routing, parse-error fail-closed, production-schema wiring.
- 4 HTTP integration tests in `tests/test_auth_http.py` via Starlette `TestClient`: anonymous blocked, X-Auth headers allow, OPTIONS bypassed, TESTING env-var bypass.
- `tests/conftest.py` sets `TESTING=1` at module level so the existing 250+ tests keep passing — matches legacy `auth/middleware.py`'s identical bypass behavior.

**Full suite: 374 passed, 1 skipped.**

## Test-writing rule of thumb (documented in `auth.py` + `CLAUDE.md`)

Any resolver or code path that reads `info.context["current_user"]` (scopes, userId, authMethod) to make a decision must have at least one test that disables the bypass (see `no_bypass` fixture + `_FakeRequest` pattern in `tests/test_auth.py`). Otherwise the test silently passes under the synthetic `local-dev` user (which holds both scopes) and the real denial path is never exercised.

## Out of scope

- Deleting `auth/middleware.py` (the Flask version) — stays until the legacy `app` Lambda is removed in ADR-004 / #319.
- Changes to `auth/authorizer/handler.py` — already framework-neutral.
- Test-stage validation against real Cognito tokens — should be done before #319 merges.

## Test plan

- [ ] CI green: `uv run pytest` in `spike/strawberry_poc/` returns 374 passed, 1 skipped
- [ ] Deploy to `test` stage; hit `/test/graphql-v2` with a `toshi/read`-only Cognito JWT — query should succeed, mutation should return `{"errors": [{"message": "GraphQL mutations require scope: toshi/write"}]}`
- [ ] Same with a `toshi/read toshi/write` token — both succeed
- [ ] Same with no token — API Gateway returns 401 before reaching the function (jwtAuthorizer rejects)
- [ ] CloudWatch logs show audit lines: `[auth] userId=... scopes=[...] method=... op=...`