### PR TITLE
refactor(adr-004) 3/6: rename serverless function strawberry-poc → graphql

### DIFF
--- a/graphql_api/app.py
+++ b/graphql_api/app.py
@@ -1,15 +1,12 @@
 """
 FastAPI + Mangum entry point.
 
-Replaces Flask + serverless-wsgi. The Lambda handler is `app.handler`.
-
 Local dev:
-    uvicorn app:app --reload
+    uvicorn graphql_api.app:app --reload
     # GraphQL playground at http://localhost:8000/graphql
 
 Lambda deploy:
-    handler: spike/strawberry_poc/app.handler
-    (adjust serverless.yml function definition)
+    handler: graphql_api.app.handler
 """
 
 import os

--- a/serverless.yml
+++ b/serverless.yml
@@ -12,8 +12,7 @@ plugins:
 package:
   individually: false
   include:
-    - spike/strawberry_poc/**
-    - strawberry_poc_handler.py
+    - graphql_api/**
   exclude:
     - .env
     - .env.*
@@ -38,6 +37,13 @@ package:
     - node_modules/**
     - prof/**
     - spike/**
+    - graphql_api/tests/**
+    - graphql_api/tools/**
+    - graphql_api/README.md
+    - graphql_api/COVERAGE_GAPS.md
+    - graphql_api/pyproject.toml
+    - graphql_api/setup.cfg
+    - graphql_api/uv.lock
     - auth/test_*
     - auth/tests/**
     - auth/cdk/**
@@ -116,9 +122,9 @@ custom:
         Exclude:
           - resourcee.Resources.ElasticSearchInstance
           - provider.iamrolestatements.1
-          # Mini Phase 4 (test only): the POC is the read-write primary.
+          # Test stage: the graphql function is the read-write primary.
           # Drop its DB_READ_ONLY guard so writes succeed.
-          - functions.strawberry-poc.environment.DB_READ_ONLY
+          - functions.graphql.environment.DB_READ_ONLY
 
 provider:
   name: aws
@@ -184,9 +190,9 @@ functions:
             - !Ref ToshiAutomationClient
       LEGACY_API_KEY: ${env:NZSHM22_TOSHI_API_KEY, env:LEGACY_API_KEY, ''}
 
-  strawberry-poc:
-    description: Strawberry/FastAPI POC at /graphql-v2 (read-only)
-    handler: strawberry_poc_handler.handler
+  graphql:
+    description: GraphQL API (Strawberry/FastAPI) at /graphql-v2
+    handler: graphql_api.app.handler
     memorySize: 1024
     timeout: 30
     events:
@@ -215,10 +221,9 @@ functions:
       GRAPHQL_PATH: /graphql-v2
       # REGION + S3_BUCKET_NAME inherit from provider.environment but we set
       # S3_BUCKET_NAME explicitly so the dependency for _from_s3 / S3 fallback
-      # paths in data/dynamo.py + data/s3.py is visible at function scope.
+      # paths in graphql_api/data/{dynamo,s3}.py is visible at function scope.
       S3_BUCKET_NAME: ${self:custom.s3_bucket}
       # Watermark for legacy_object_identities — IDs below this are S3-only.
-      # Tracks custom.first_dynamo_id so the POC and legacy stay in lockstep.
       FIRST_DYNAMO_ID: ${self:custom.first_dynamo_id}
       # S3 IAM (s3:*) is inherited from provider.iamRoleStatements — covers
       # the s3:GetObject + s3:ListBucket needed by the read fallback paths.


### PR DESCRIPTION
**ADR-004 stack — step 3 of 6.** Base: PR 2/6 (#332).

## Scope

Serverless function rename + handler path update. URL path `/graphql-v2` unchanged (Phase 5 will promote to `/graphql`).

## serverless.yml changes

- function `strawberry-poc` → `graphql`
- handler `strawberry_poc_handler.handler` → `graphql_api.app.handler`
- `package.include`: `spike/strawberry_poc/**` + `strawberry_poc_handler.py` → `graphql_api/**`
- `package.exclude`: added `graphql_api/{tests,tools}/**` and metadata files (README, COVERAGE_GAPS, pyproject, setup.cfg, uv.lock) to keep the Lambda bundle lean
- `serverlessIfElse`: `functions.strawberry-poc.*` → `functions.graphql.*`
- stale path comment in env block updated to `graphql_api/data/*`

## graphql_api/app.py

Docstring updated to reflect new import paths (`uvicorn graphql_api.app:app`; `handler: graphql_api.app.handler`).

## Deploy implication

CloudFormation will **delete** the old function `nzshm22-toshi-api-{stage}-strawberry-poc` and **create** a new one `nzshm22-toshi-api-{stage}-graphql` in the same deploy. API Gateway routes get rewired atomically so `/graphql-v2` stays continuously available, but CloudWatch log groups / metrics / alarms attached to the old function name do not transfer.

## Stack

← 2/6 [`refactor/adr-004-step-2-move-poc`](https://github.com/GNS-Science/nshm-toshi-api/pull/332)
→ 4/6 [`refactor/adr-004-step-4-tooling`](https://github.com/GNS-Science/nshm-toshi-api/compare/refactor/adr-004-step-3-rename-fn...refactor/adr-004-step-4-tooling)

Refs ADR-004 / #319. Supersedes the omnibus #329.