### PR TITLE
ci: run tests on every PR regardless of base branch

### DIFF
--- a/.github/workflows/run-tests-on-pull-request.yaml
+++ b/.github/workflows/run-tests-on-pull-request.yaml
@@ -3,14 +3,16 @@ name: Run Tests On PullRequest
 on:
   # schedule:
   #  - cron:  '25 4 * * 0' # At 04:25 on Sunday
+  # Run on every PR regardless of base — stacked PRs targeting intermediate
+  # branches need CI too. Cost is low (~25s) and the failure mode of "my PR
+  # didn't run CI because of its base" is worse than the occasional extra run.
   pull_request:
-    branches: [ deploy-test, main ]
 
   # Allows us to call the workflow from another workflow
-  workflow_call:    
+  workflow_call:
 
   # Allows us to run the workflow manually
-  workflow_dispatch:  
+  workflow_dispatch:
 
 jobs:
   call-test-workflow:


### PR DESCRIPTION
## Summary

The `branches: [deploy-test, main]` filter on the `pull_request` trigger matches the **base** branch of the PR. Stacked PRs targeting intermediate branches were silently skipping CI:

| PR | Base | CI runs today? |
|---|---|---|
| #328 auth-parity | `deploy-test` | ✅ |
| #330 housekeeping | `deploy-test` | ✅ |
| #331 step 1 | `feat/poc-auth-middleware-parity` | ❌ |
| #332 step 2 | `refactor/adr-004-step-1-...` | ❌ |
| ...all 6 stacked PRs | (intermediate branches) | ❌ |

After this lands, all 6 stacked PRs in #331–#336 will pick up CI on their next push.

## Change

Drop the `branches:` filter from the `pull_request` trigger. Workflow now runs on every PR regardless of base.

Cost is low (~25s test run on uv); the "my PR didn't run CI because of its base" surprise is worse than the occasional extra run.

Other triggers (`workflow_call`, `workflow_dispatch`, scheduled) are unchanged. The deploy workflow (`deploy-aws-lambda.yaml`) is unaffected — it triggers on `push` to `deploy-test`/`main`, not on PR base.

## Test plan

- [ ] CI green on this PR (which proves the change works — the PR's own run is its proof)
- [ ] After merge, push a no-op commit to any stacked PR branch and confirm CI fires