### PR TITLE
chore(lint): clean up post-ADR-004 ruff failures on deploy-test

### DIFF
--- a/auth/toshi_auth.py
+++ b/auth/toshi_auth.py
@@ -254,7 +254,7 @@ def get_aws_credentials(config, access_token, profile='toshi'):
         with open(aws_credentials_path) as f:
             config_content = f.read()
 
-    import configparser
+    import configparser  # noqa: PLC0415
 
     parser = configparser.ConfigParser()
     parser.read_string(config_content)

--- a/graphql_api/auth.py
+++ b/graphql_api/auth.py
@@ -147,13 +147,8 @@ class AuthExtension(SchemaExtension):
             logger.warning("Access denied for %s: missing %s", user_id, SCOPE_READ)
             raise GraphQLError(f"Missing required scope: {SCOPE_READ}")
 
-        if (
-            self.execution_context.operation_type == OperationType.MUTATION
-            and SCOPE_WRITE not in scopes
-        ):
-            logger.warning(
-                "Mutation blocked for %s: missing %s", user_id, SCOPE_WRITE
-            )
+        if self.execution_context.operation_type == OperationType.MUTATION and SCOPE_WRITE not in scopes:
+            logger.warning("Mutation blocked for %s: missing %s", user_id, SCOPE_WRITE)
             raise GraphQLError(f"GraphQL mutations require scope: {SCOPE_WRITE}")
 
         yield

--- a/graphql_api/models/_base/file.py
+++ b/graphql_api/models/_base/file.py
@@ -16,8 +16,13 @@ from strawberry.types import Info
 from graphql_api.data.dynamo import create_file, get_file, list_files
 from graphql_api.data.models import ToshiFileData
 from graphql_api.data.s3 import presigned_post_for_file
-
-from graphql_api.models._infra.common import BigInt, DateTime, KeyValuePair, KeyValuePairInput, client_mutation_id_input_field
+from graphql_api.models._infra.common import (
+    BigInt,
+    DateTime,
+    KeyValuePair,
+    KeyValuePairInput,
+    client_mutation_id_input_field,
+)
 from graphql_api.models._interfaces.file_interface import FileInterface
 from graphql_api.models._interfaces.predecessor import PredecessorInput
 from graphql_api.models._interfaces.predecessors_interface import PredecessorsInterface
@@ -83,9 +88,7 @@ def resolve_files(info: Info) -> Iterable[ToshiFile]:
 
 def mutate_create_file(info: Info, input: CreateFileInput) -> ToshiFile:
     meta = [{"k": i.k, "v": i.v} for i in input.meta] if input.meta else None
-    predecessors = (
-        [{"id": str(p.id), "depth": p.depth} for p in input.predecessors] if input.predecessors else None
-    )
+    predecessors = [{"id": str(p.id), "depth": p.depth} for p in input.predecessors] if input.predecessors else None
     payload = {
         "file_name": input.file_name,
         "md5_digest": input.md5_digest,

--- a/graphql_api/models/_base/object_identity.py
+++ b/graphql_api/models/_base/object_identity.py
@@ -45,9 +45,7 @@ class ObjectIdentitiesPageInfo:
 class ObjectIdentitiesConnection:
     edges: list[ObjectIdentitiesEdge | None] = strawberry.field(default_factory=list)
     # Modern Relay-spec camelCase (preferred)
-    page_info: ObjectIdentitiesPageInfo = strawberry.field(
-        name="pageInfo", default_factory=ObjectIdentitiesPageInfo
-    )
+    page_info: ObjectIdentitiesPageInfo = strawberry.field(name="pageInfo", default_factory=ObjectIdentitiesPageInfo)
 
     @strawberry.field(
         name="page_info",

--- a/graphql_api/models/_base/table.py
+++ b/graphql_api/models/_base/table.py
@@ -8,7 +8,6 @@ from strawberry.types import Info
 
 from graphql_api.data.dynamo import create_table, get_table
 from graphql_api.data.models import TableData
-
 from graphql_api.models._infra.common import (
     DateTime,
     KeyValueListPair,
@@ -20,6 +19,7 @@ from graphql_api.models._infra.common import (
     _try_enum,
     client_mutation_id_input_field,
 )
+
 
 @strawberry.type
 class Table(relay.Node):
@@ -58,6 +58,7 @@ class Table(relay.Node):
             dimensions=[KeyValueListPair(k=i.k, v=i.v) for i in d.dimensions] if d.dimensions else None,
         )
 
+
 @strawberry.input
 class CreateTableInput:
     object_id: strawberry.ID
@@ -70,6 +71,7 @@ class CreateTableInput:
     table_type: TableType | None = None
     dimensions: list[KeyValueListPairInput | None] | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
+
 
 def mutate_create_table(info: Info, input: CreateTableInput) -> Table:
     meta = [{"k": i.k, "v": i.v} for i in input.meta] if input.meta else None

--- a/graphql_api/models/_infra/common.py
+++ b/graphql_api/models/_infra/common.py
@@ -1,14 +1,12 @@
 """Shared scalar types and enums used across schema types."""
 
 import enum
-from typing import NewType, TypeVar
+from typing import NewType
 
 import strawberry
 
-_E = TypeVar("_E", bound=enum.Enum)
 
-
-def _try_enum(enum_cls: type[_E], value: str | None) -> _E | None:
+def _try_enum[E: enum.Enum](enum_cls: type[E], value: str | None) -> E | None:
     """Construct an enum from a string value, returning None for unknown/missing values."""
     if value is None:
         return None
@@ -27,6 +25,7 @@ BigInt = strawberry.scalar(
     description="A signed integer with arbitrary precision (not limited to GraphQL Int 32-bit). "
     "Used for file_size where production values can exceed 2GB.",
 )
+
 
 def _parse_datetime(value):
     """Validate an inbound DateTime value, matching legacy Graphene semantics:

--- a/graphql_api/models/_infra/inversion_solution_union.py
+++ b/graphql_api/models/_infra/inversion_solution_union.py
@@ -10,11 +10,12 @@ from typing import Annotated
 import strawberry
 
 from graphql_api.data.dynamo import get_file
-
 from graphql_api.models._infra.common import FileRole
 
 _InversionSolution = Annotated["InversionSolution", strawberry.lazy("graphql_api.models.inversion_solution")]
-_ScaledInversionSolution = Annotated["ScaledInversionSolution", strawberry.lazy("graphql_api.models.scaled_inversion_solution")]
+_ScaledInversionSolution = Annotated[
+    "ScaledInversionSolution", strawberry.lazy("graphql_api.models.scaled_inversion_solution")
+]
 _AggregateInversionSolution = Annotated[
     "AggregateInversionSolution", strawberry.lazy("graphql_api.models.aggregate_inversion_solution")
 ]

--- a/graphql_api/models/_interfaces/file_interface.py
+++ b/graphql_api/models/_interfaces/file_interface.py
@@ -6,7 +6,6 @@ import strawberry
 from strawberry.types import Info
 
 from graphql_api.data.s3 import presigned_download_url
-
 from graphql_api.models._infra.common import BigInt, DateTime, JSONString, KeyValuePair
 
 

--- a/graphql_api/models/_interfaces/inversion_solution_interface.py
+++ b/graphql_api/models/_interfaces/inversion_solution_interface.py
@@ -20,7 +20,6 @@ from strawberry.relay import GlobalID
 from strawberry.types import Info
 
 from graphql_api.data.dynamo import get_table, get_thing
-
 from graphql_api.models._infra.common import BigInt, DateTime, KeyValuePair, TableType
 from graphql_api.models.relations import InversionSolutionRelations, build_file_relations_for_file
 

--- a/graphql_api/models/_interfaces/predecessor.py
+++ b/graphql_api/models/_interfaces/predecessor.py
@@ -13,14 +13,18 @@ from graphql_api.models._infra.common import AncestryLabel
 # All file-like; reuse the lazy refs pattern from relations.py.
 _File = Annotated["ToshiFile", strawberry.lazy("graphql_api.models._base.file")]
 _InversionSolution = Annotated["InversionSolution", strawberry.lazy("graphql_api.models.inversion_solution")]
-_ScaledInversionSolution = Annotated["ScaledInversionSolution", strawberry.lazy("graphql_api.models.scaled_inversion_solution")]
+_ScaledInversionSolution = Annotated[
+    "ScaledInversionSolution", strawberry.lazy("graphql_api.models.scaled_inversion_solution")
+]
 _AggregateInversionSolution = Annotated[
     "AggregateInversionSolution", strawberry.lazy("graphql_api.models.aggregate_inversion_solution")
 ]
 _TimeDependentInversionSolution = Annotated[
     "TimeDependentInversionSolution", strawberry.lazy("graphql_api.models.time_dependent_inversion_solution")
 ]
-_InversionSolutionNrml = Annotated["InversionSolutionNrml", strawberry.lazy("graphql_api.models.inversion_solution_nrml")]
+_InversionSolutionNrml = Annotated[
+    "InversionSolutionNrml", strawberry.lazy("graphql_api.models.inversion_solution_nrml")
+]
 
 PredecessorUnion = Annotated[
     _File

--- a/graphql_api/models/aggregate_inversion_solution.py
+++ b/graphql_api/models/aggregate_inversion_solution.py
@@ -11,13 +11,20 @@ from strawberry.types import Info
 from graphql_api.data.dynamo import create_file, get_file, list_files
 from graphql_api.data.models import AggregateInversionSolutionData
 from graphql_api.data.s3 import presigned_post_for_file
-
-from graphql_api.models._infra.common import AggregationFn, BigInt, DateTime, KeyValuePair, KeyValuePairInput, _try_enum, client_mutation_id_input_field
+from graphql_api.models._infra.common import (
+    AggregationFn,
+    BigInt,
+    DateTime,
+    KeyValuePair,
+    KeyValuePairInput,
+    _try_enum,
+    client_mutation_id_input_field,
+)
 from graphql_api.models._interfaces.file_interface import FileInterface
-from graphql_api.models.inversion_solution import LabelledTableRelation, _ltr_from_dict
 from graphql_api.models._interfaces.inversion_solution_interface import InversionSolutionInterface
 from graphql_api.models._interfaces.predecessor import PredecessorInput
 from graphql_api.models._interfaces.predecessors_interface import PredecessorsInterface
+from graphql_api.models.inversion_solution import _ltr_from_dict
 from graphql_api.models.rupture_set import RuptureSet
 from graphql_api.models.scaled_inversion_solution import SourceSolutionUnion, dispatch_source_solution
 

--- a/graphql_api/models/automation_task.py
+++ b/graphql_api/models/automation_task.py
@@ -18,7 +18,7 @@ from strawberry.types import Info
 
 from graphql_api.data.dynamo import create_thing, get_thing, list_things, update_thing
 from graphql_api.data.models import AutomationTaskData
-
+from graphql_api.models._base.thing import AutomationTaskInterface, Thing
 from graphql_api.models._infra.common import (
     DateTime,
     EventResult,
@@ -40,7 +40,6 @@ from graphql_api.models.relations import (
     build_task_children,
     build_task_parents,
 )
-from graphql_api.models._base.thing import AutomationTaskInterface, Thing
 
 
 def _kv_input_to_list(items) -> list[dict] | None:

--- a/graphql_api/models/general_task.py
+++ b/graphql_api/models/general_task.py
@@ -17,10 +17,9 @@ from strawberry.types import Info
 
 from graphql_api.data.dynamo import create_thing, get_thing, list_things, update_thing
 from graphql_api.data.models import GeneralTaskData
-
+from graphql_api.models._base.thing import Thing
 from graphql_api.models._infra.common import (
     DateTime,
-    client_mutation_id_input_field,
     EventResult,
     KeyValueListPair,
     KeyValueListPairInput,
@@ -29,6 +28,7 @@ from graphql_api.models._infra.common import (
     ModelType,
     TaskSubType,
     _try_enum,
+    client_mutation_id_input_field,
 )
 from graphql_api.models.relations import (
     FileRelation,
@@ -39,7 +39,7 @@ from graphql_api.models.relations import (
     build_task_children,
     build_task_parents,
 )
-from graphql_api.models._base.thing import Thing
+
 
 @strawberry.type
 class GeneralTask(relay.Node, Thing):
@@ -117,6 +117,7 @@ class GeneralTask(relay.Node, Thing):
             parents_raw=d.parents,
         )
 
+
 @strawberry.input
 class CreateGeneralTaskInput:
     title: str | None = None
@@ -131,6 +132,7 @@ class CreateGeneralTaskInput:
     argument_lists: list[KeyValueListPairInput | None] | None = None
     meta: list[KeyValuePairInput | None] | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
+
 
 @strawberry.input
 class UpdateGeneralTaskInput:
@@ -148,9 +150,11 @@ class UpdateGeneralTaskInput:
     meta: list[KeyValuePairInput | None] | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
 
+
 def resolve_general_tasks(info: Info) -> Iterable[GeneralTask]:
     items = list_things(info.context["dynamodb"], "GeneralTask")
     return [GeneralTask.from_dict(item) for item in items]
+
 
 def mutate_create_general_task(info: Info, input: CreateGeneralTaskInput) -> GeneralTask:
     def _kvl(items):
@@ -171,6 +175,7 @@ def mutate_create_general_task(info: Info, input: CreateGeneralTaskInput) -> Gen
     }
     data = create_thing(info.context["dynamodb"], "GeneralTask", payload)
     return GeneralTask.from_dict(data)
+
 
 def mutate_update_general_task(info: Info, input: UpdateGeneralTaskInput) -> GeneralTask | None:
     # Decode relay global ID → raw object_id

--- a/graphql_api/models/inversion_solution.py
+++ b/graphql_api/models/inversion_solution.py
@@ -19,17 +19,17 @@ from strawberry.types import Info
 from graphql_api.data.dynamo import _file_table, create_file, get_file, list_files
 from graphql_api.data.models import InversionSolutionData
 from graphql_api.data.s3 import presigned_post_for_file
-
+from graphql_api.models._base.table import Table  # noqa: F401 — re-exported; also needed for mfd_table return type
 from graphql_api.models._infra.common import (
     BigInt,
     DateTime,
-    client_mutation_id_input_field,
     KeyValueListPair,
     KeyValueListPairInput,
     KeyValuePair,
     KeyValuePairInput,
     TableType,
     _try_enum,
+    client_mutation_id_input_field,
 )
 from graphql_api.models._interfaces.file_interface import FileInterface
 from graphql_api.models._interfaces.inversion_solution_interface import (  # noqa: F401 — re-export AutomationTaskUnion for other modules
@@ -37,10 +37,11 @@ from graphql_api.models._interfaces.inversion_solution_interface import (  # noq
     InversionSolutionInterface,
     _dispatch_automation_task,
 )
-from graphql_api.models._interfaces.predecessor import Predecessor, PredecessorInput  # noqa: F401 — re-exported for other models
+from graphql_api.models._interfaces.predecessor import (  # noqa: F401 — re-exported for other models
+    Predecessor,
+    PredecessorInput,
+)
 from graphql_api.models._interfaces.predecessors_interface import PredecessorsInterface
-from graphql_api.models._base.table import Table  # noqa: F401 — re-exported; also needed for mfd_table return type
-
 
 # ── LabelledTableRelation (embedded — not a relay.Node) ───────────────────────
 

--- a/graphql_api/models/inversion_solution_nrml.py
+++ b/graphql_api/models/inversion_solution_nrml.py
@@ -11,8 +11,13 @@ from strawberry.types import Info
 from graphql_api.data.dynamo import create_file, get_file, list_files
 from graphql_api.data.models import InversionSolutionNrmlData
 from graphql_api.data.s3 import presigned_post_for_file
-
-from graphql_api.models._infra.common import BigInt, DateTime, KeyValuePair, KeyValuePairInput, client_mutation_id_input_field
+from graphql_api.models._infra.common import (
+    BigInt,
+    DateTime,
+    KeyValuePair,
+    KeyValuePairInput,
+    client_mutation_id_input_field,
+)
 from graphql_api.models._interfaces.file_interface import FileInterface
 from graphql_api.models._interfaces.predecessor import PredecessorInput
 from graphql_api.models._interfaces.predecessors_interface import PredecessorsInterface

--- a/graphql_api/models/openquake_hazard_config.py
+++ b/graphql_api/models/openquake_hazard_config.py
@@ -10,15 +10,17 @@ from strawberry.types import Info
 
 from graphql_api.data.dynamo import create_thing, get_file, get_thing, list_things
 from graphql_api.data.models import OpenquakeHazardConfigData
-from graphql_api.models._infra.common import DateTime, client_mutation_id_input_field
 from graphql_api.models._base.file import ToshiFile
-from graphql_api.models.inversion_solution_nrml import InversionSolutionNrml
 from graphql_api.models._base.thing import Thing
+from graphql_api.models._infra.common import DateTime, client_mutation_id_input_field
+from graphql_api.models.inversion_solution_nrml import InversionSolutionNrml
 
 # ── OpenquakeNrmlUnion ────────────────────────────────────────────────────────
 
 _ToshiFile = Annotated["ToshiFile", strawberry.lazy("graphql_api.models._base.file")]
-_InversionSolutionNrml = Annotated["InversionSolutionNrml", strawberry.lazy("graphql_api.models.inversion_solution_nrml")]
+_InversionSolutionNrml = Annotated[
+    "InversionSolutionNrml", strawberry.lazy("graphql_api.models.inversion_solution_nrml")
+]
 
 OpenquakeNrmlUnion = Annotated[
     _ToshiFile | _InversionSolutionNrml,

--- a/graphql_api/models/openquake_hazard_solution.py
+++ b/graphql_api/models/openquake_hazard_solution.py
@@ -11,16 +11,21 @@ from strawberry.types import Info
 from graphql_api.data.dynamo import create_thing, get_file, get_thing, list_things
 from graphql_api.data.models import OpenquakeHazardSolutionData
 from graphql_api.models._base.file import ToshiFile
-from graphql_api.models.openquake_hazard_task import OpenquakeHazardTask
-
-from graphql_api.models._infra.common import DateTime, KeyValuePair, KeyValuePairInput, OpenquakeTaskType, client_mutation_id_input_field
-
 from graphql_api.models._base.thing import Thing
+from graphql_api.models._infra.common import (
+    DateTime,
+    KeyValuePair,
+    KeyValuePairInput,
+    OpenquakeTaskType,
+    client_mutation_id_input_field,
+)
 from graphql_api.models._interfaces.predecessor import PredecessorInput
 from graphql_api.models._interfaces.predecessors_interface import PredecessorsInterface
+from graphql_api.models.openquake_hazard_task import OpenquakeHazardTask
 
 _OpenquakeHazardTask = Annotated["OpenquakeHazardTask", strawberry.lazy("graphql_api.models.openquake_hazard_task")]
 _ToshiFile = Annotated["ToshiFile", strawberry.lazy("graphql_api.models._base.file")]
+
 
 @strawberry.type
 class OpenquakeHazardSolution(relay.Node, PredecessorsInterface, Thing):
@@ -94,6 +99,7 @@ class OpenquakeHazardSolution(relay.Node, PredecessorsInterface, Thing):
             predecessors_raw=[p.model_dump() for p in d.predecessors] if d.predecessors else None,
         )
 
+
 @strawberry.input
 class CreateOpenquakeHazardSolutionInput:
     produced_by: strawberry.ID
@@ -107,9 +113,11 @@ class CreateOpenquakeHazardSolutionInput:
     predecessors: list[PredecessorInput | None] | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
 
+
 def resolve_openquake_hazard_solutions(info: Info) -> Iterable[OpenquakeHazardSolution]:
     items = list_things(info.context["dynamodb"], "OpenquakeHazardSolution")
     return [OpenquakeHazardSolution.from_dict(item) for item in items]
+
 
 def mutate_create_openquake_hazard_solution(
     info: Info, input: CreateOpenquakeHazardSolutionInput

--- a/graphql_api/models/openquake_hazard_task.py
+++ b/graphql_api/models/openquake_hazard_task.py
@@ -10,11 +10,19 @@ from strawberry.types import Info
 
 from graphql_api.data.dynamo import create_thing, get_thing, list_things, update_thing
 from graphql_api.data.models import OpenquakeHazardTaskData
-
-from graphql_api.models._infra.common import DateTime, EventResult, EventState, JSONString, KeyValuePair, KeyValuePairInput, ModelType, TaskSubType, _try_enum, client_mutation_id_input_field
-
 from graphql_api.models._base.thing import AutomationTaskInterface, Thing
-
+from graphql_api.models._infra.common import (
+    DateTime,
+    EventResult,
+    EventState,
+    JSONString,
+    KeyValuePair,
+    KeyValuePairInput,
+    ModelType,
+    TaskSubType,
+    _try_enum,
+    client_mutation_id_input_field,
+)
 from graphql_api.models._infra.inversion_solution_union import InversionSolutionUnion, resolve_task_inversion_solution
 from graphql_api.models.relations import (
     FileRelation,
@@ -26,8 +34,13 @@ from graphql_api.models.relations import (
     build_task_parents,
 )
 
-_OpenquakeHazardSolution = Annotated["OpenquakeHazardSolution", strawberry.lazy("graphql_api.models.openquake_hazard_solution")]
-_OpenquakeHazardConfig = Annotated["OpenquakeHazardConfig", strawberry.lazy("graphql_api.models.openquake_hazard_config")]
+_OpenquakeHazardSolution = Annotated[
+    "OpenquakeHazardSolution", strawberry.lazy("graphql_api.models.openquake_hazard_solution")
+]
+_OpenquakeHazardConfig = Annotated[
+    "OpenquakeHazardConfig", strawberry.lazy("graphql_api.models.openquake_hazard_config")
+]
+
 
 @strawberry.type
 class OpenquakeHazardTask(relay.Node, Thing, AutomationTaskInterface):
@@ -126,6 +139,7 @@ class OpenquakeHazardTask(relay.Node, Thing, AutomationTaskInterface):
             config_raw_id=d.config,
         )
 
+
 @strawberry.input
 class CreateOpenquakeHazardTaskInput:
     state: EventState
@@ -144,6 +158,7 @@ class CreateOpenquakeHazardTaskInput:
     hazard_solution: strawberry.ID | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
 
+
 @strawberry.input
 class UpdateOpenquakeHazardTaskInput:
     task_id: strawberry.ID
@@ -158,9 +173,11 @@ class UpdateOpenquakeHazardTaskInput:
     executor: str | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
 
+
 def resolve_openquake_hazard_tasks(info: Info) -> Iterable[OpenquakeHazardTask]:
     items = list_things(info.context["dynamodb"], "OpenquakeHazardTask")
     return [OpenquakeHazardTask.from_dict(item) for item in items]
+
 
 def mutate_create_openquake_hazard_task(info: Info, input: CreateOpenquakeHazardTaskInput) -> OpenquakeHazardTask:
     payload = {
@@ -181,6 +198,7 @@ def mutate_create_openquake_hazard_task(info: Info, input: CreateOpenquakeHazard
     }
     data = create_thing(info.context["dynamodb"], "OpenquakeHazardTask", payload)
     return OpenquakeHazardTask.from_dict(data)
+
 
 def mutate_update_openquake_hazard_task(
     info: Info, input: UpdateOpenquakeHazardTaskInput

--- a/graphql_api/models/relations.py
+++ b/graphql_api/models/relations.py
@@ -15,15 +15,12 @@ causing circular imports at schema build time.
 from typing import Annotated
 
 import strawberry
-from strawberry import relay
 from strawberry.relay import GlobalID
 from strawberry.types import Info
 
 from graphql_api.data.dynamo import create_file_relation, create_task_relation, get_file, get_thing
-
-from graphql_api.models._infra.common import FileRole
+from graphql_api.models._infra.common import FileRole, client_mutation_id_input_field
 from graphql_api.models._infra.page_info import CompatListConnection
-from graphql_api.models._infra.common import client_mutation_id_input_field, FileRole
 
 # ── Lazy forward references (break circular deps) ─────────────────────────────
 
@@ -31,21 +28,29 @@ _ToshiFile = Annotated["ToshiFile", strawberry.lazy("graphql_api.models._base.fi
 _SmsFile = Annotated["SmsFile", strawberry.lazy("graphql_api.models.sms_file")]
 _RuptureSet = Annotated["RuptureSet", strawberry.lazy("graphql_api.models.rupture_set")]
 _InversionSolution = Annotated["InversionSolution", strawberry.lazy("graphql_api.models.inversion_solution")]
-_ScaledInversionSolution = Annotated["ScaledInversionSolution", strawberry.lazy("graphql_api.models.scaled_inversion_solution")]
+_ScaledInversionSolution = Annotated[
+    "ScaledInversionSolution", strawberry.lazy("graphql_api.models.scaled_inversion_solution")
+]
 _AggregateInversionSolution = Annotated[
     "AggregateInversionSolution", strawberry.lazy("graphql_api.models.aggregate_inversion_solution")
 ]
 _TimeDependentInversionSolution = Annotated[
     "TimeDependentInversionSolution", strawberry.lazy("graphql_api.models.time_dependent_inversion_solution")
 ]
-_InversionSolutionNrml = Annotated["InversionSolutionNrml", strawberry.lazy("graphql_api.models.inversion_solution_nrml")]
+_InversionSolutionNrml = Annotated[
+    "InversionSolutionNrml", strawberry.lazy("graphql_api.models.inversion_solution_nrml")
+]
 _GeneralTask = Annotated["GeneralTask", strawberry.lazy("graphql_api.models.general_task")]
 _RuptureGenerationTask = Annotated["RuptureGenerationTask", strawberry.lazy("graphql_api.models.automation_task")]
 _AutomationTask = Annotated["AutomationTask", strawberry.lazy("graphql_api.models.automation_task")]
 _StrongMotionStation = Annotated["StrongMotionStation", strawberry.lazy("graphql_api.models.strong_motion_station")]
 _OpenquakeHazardTask = Annotated["OpenquakeHazardTask", strawberry.lazy("graphql_api.models.openquake_hazard_task")]
-_OpenquakeHazardSolution = Annotated["OpenquakeHazardSolution", strawberry.lazy("graphql_api.models.openquake_hazard_solution")]
-_OpenquakeHazardConfig = Annotated["OpenquakeHazardConfig", strawberry.lazy("graphql_api.models.openquake_hazard_config")]
+_OpenquakeHazardSolution = Annotated[
+    "OpenquakeHazardSolution", strawberry.lazy("graphql_api.models.openquake_hazard_solution")
+]
+_OpenquakeHazardConfig = Annotated[
+    "OpenquakeHazardConfig", strawberry.lazy("graphql_api.models.openquake_hazard_config")
+]
 
 # Union types — referenced as return types of @strawberry.field methods
 FileUnion = Annotated[
@@ -225,9 +230,8 @@ class TaskRelationsConnection(CompatListConnection[TaskTaskRelation]):
 # ── Dispatch helpers ──────────────────────────────────────────────────────────
 
 
-from graphql_api.models._infra._dispatch import dispatch_file as _dispatch_file
-from graphql_api.models._infra._dispatch import dispatch_thing as _dispatch_thing
-
+from graphql_api.models._infra._dispatch import dispatch_file as _dispatch_file  # noqa: E402
+from graphql_api.models._infra._dispatch import dispatch_thing as _dispatch_thing  # noqa: E402
 
 # ── Input types for mutations ─────────────────────────────────────────────────
 

--- a/graphql_api/models/rupture_set.py
+++ b/graphql_api/models/rupture_set.py
@@ -17,10 +17,15 @@ from strawberry.types import Info
 from graphql_api.data.dynamo import create_file, get_file, get_thing, list_files
 from graphql_api.data.models import RuptureSetData
 from graphql_api.data.s3 import presigned_post_for_file
-
-from graphql_api.models.automation_task import RuptureGenerationTask  # noqa: F401 — re-exported for schema.py
-from graphql_api.models._infra.common import BigInt, DateTime, KeyValuePair, KeyValuePairInput, client_mutation_id_input_field
+from graphql_api.models._infra.common import (
+    BigInt,
+    DateTime,
+    KeyValuePair,
+    KeyValuePairInput,
+    client_mutation_id_input_field,
+)
 from graphql_api.models._interfaces.file_interface import FileInterface
+from graphql_api.models.automation_task import RuptureGenerationTask  # noqa: F401 — re-exported for schema.py
 
 # ── RuptureSet ────────────────────────────────────────────────────────────────
 

--- a/graphql_api/models/scaled_inversion_solution.py
+++ b/graphql_api/models/scaled_inversion_solution.py
@@ -11,19 +11,26 @@ from strawberry.types import Info
 from graphql_api.data.dynamo import create_file, get_file, list_files
 from graphql_api.data.models import ScaledInversionSolutionData
 from graphql_api.data.s3 import presigned_post_for_file
-
-from graphql_api.models._infra.common import BigInt, DateTime, KeyValuePair, KeyValuePairInput, client_mutation_id_input_field
+from graphql_api.models._infra.common import (
+    BigInt,
+    DateTime,
+    KeyValuePair,
+    KeyValuePairInput,
+    client_mutation_id_input_field,
+)
 from graphql_api.models._interfaces.file_interface import FileInterface
-from graphql_api.models.inversion_solution import InversionSolution, LabelledTableRelation, _ltr_from_dict
 from graphql_api.models._interfaces.inversion_solution_interface import InversionSolutionInterface
 from graphql_api.models._interfaces.predecessor import PredecessorInput
 from graphql_api.models._interfaces.predecessors_interface import PredecessorsInterface
+from graphql_api.models.inversion_solution import InversionSolution, _ltr_from_dict
 from graphql_api.models.time_dependent_inversion_solution import TimeDependentInversionSolution
 
 # ── SourceSolutionUnion (lazy — defined once here, imported elsewhere) ────────
 
 _InversionSolution = Annotated["InversionSolution", strawberry.lazy("graphql_api.models.inversion_solution")]
-_ScaledInversionSolution = Annotated["ScaledInversionSolution", strawberry.lazy("graphql_api.models.scaled_inversion_solution")]
+_ScaledInversionSolution = Annotated[
+    "ScaledInversionSolution", strawberry.lazy("graphql_api.models.scaled_inversion_solution")
+]
 _AggregateInversionSolution = Annotated[
     "AggregateInversionSolution", strawberry.lazy("graphql_api.models.aggregate_inversion_solution")
 ]

--- a/graphql_api/models/sms_file.py
+++ b/graphql_api/models/sms_file.py
@@ -11,8 +11,14 @@ from strawberry.types import Info
 
 from graphql_api.data.dynamo import create_file, get_file, list_files
 from graphql_api.data.models import SmsFileData
-
-from graphql_api.models._infra.common import BigInt, DateTime, KeyValuePair, SmsFileType, _try_enum, client_mutation_id_input_field
+from graphql_api.models._infra.common import (
+    BigInt,
+    DateTime,
+    KeyValuePair,
+    SmsFileType,
+    _try_enum,
+    client_mutation_id_input_field,
+)
 from graphql_api.models._interfaces.file_interface import FileInterface
 from graphql_api.models.relations import FileRelation, FileRelationsConnection, build_file_relations_for_file
 

--- a/graphql_api/models/strong_motion_station.py
+++ b/graphql_api/models/strong_motion_station.py
@@ -11,11 +11,15 @@ from strawberry.types import Info
 
 from graphql_api.data.dynamo import create_thing, get_thing, list_things
 from graphql_api.data.models import StrongMotionStationData
-
-from graphql_api.models._infra.common import DateTime, SmsSiteClass, SmsSiteClassBasis, _try_enum, client_mutation_id_input_field
-from graphql_api.models.relations import FileRelation, FileRelationsConnection, build_file_relations_for_thing
-
 from graphql_api.models._base.thing import Thing
+from graphql_api.models._infra.common import (
+    DateTime,
+    SmsSiteClass,
+    SmsSiteClassBasis,
+    _try_enum,
+    client_mutation_id_input_field,
+)
+
 
 @strawberry.type
 class StrongMotionStation(relay.Node, Thing):
@@ -61,6 +65,7 @@ class StrongMotionStation(relay.Node, Thing):
             files_raw=d.files,
         )
 
+
 @strawberry.input
 class CreateStrongMotionStationInput:
     site_code: str | None = None
@@ -77,9 +82,11 @@ class CreateStrongMotionStationInput:
     updated: str | None = None
     client_mutation_id: str | None = client_mutation_id_input_field()
 
+
 def resolve_strong_motion_stations(info: Info) -> Iterable[StrongMotionStation]:
     items = list_things(info.context["dynamodb"], "StrongMotionStation")
     return [StrongMotionStation.from_dict(item) for item in items]
+
 
 def mutate_create_strong_motion_station(info: Info, input: CreateStrongMotionStationInput) -> StrongMotionStation:
     payload = {

--- a/graphql_api/models/time_dependent_inversion_solution.py
+++ b/graphql_api/models/time_dependent_inversion_solution.py
@@ -11,13 +11,18 @@ from strawberry.types import Info
 from graphql_api.data.dynamo import create_file, get_file, list_files
 from graphql_api.data.models import TimeDependentInversionSolutionData
 from graphql_api.data.s3 import presigned_post_for_file
-
-from graphql_api.models._infra.common import BigInt, DateTime, KeyValuePair, KeyValuePairInput, client_mutation_id_input_field
+from graphql_api.models._infra.common import (
+    BigInt,
+    DateTime,
+    KeyValuePair,
+    KeyValuePairInput,
+    client_mutation_id_input_field,
+)
 from graphql_api.models._interfaces.file_interface import FileInterface
-from graphql_api.models.inversion_solution import InversionSolution, LabelledTableRelation, _ltr_from_dict
 from graphql_api.models._interfaces.inversion_solution_interface import InversionSolutionInterface
 from graphql_api.models._interfaces.predecessor import PredecessorInput
 from graphql_api.models._interfaces.predecessors_interface import PredecessorsInterface
+from graphql_api.models.inversion_solution import InversionSolution, _ltr_from_dict
 
 _InversionSolution = Annotated["InversionSolution", strawberry.lazy("graphql_api.models.inversion_solution")]
 

--- a/graphql_api/schema.py
+++ b/graphql_api/schema.py
@@ -19,11 +19,27 @@ from strawberry import relay
 from strawberry.relay import GlobalID
 from strawberry.schema.config import StrawberryConfig
 
-from graphql_api.auth import AuthExtension
 import graphql_api.data.search as _data_search
+from graphql_api.auth import AuthExtension
 from graphql_api.data.dynamo import es_key_for, get_object, scan_objects_paginated
 from graphql_api.data.s3 import scan_s3_paginated
 from graphql_api.data.search import search as es_search
+from graphql_api.models._base.file import CreateFileInput, ToshiFile, mutate_create_file, resolve_files
+from graphql_api.models._base.object_identity import (
+    ObjectIdentitiesConnection,
+    decode_cursor,
+    make_object_identities_connection,
+)
+from graphql_api.models._base.table import CreateTableInput, Table, mutate_create_table
+from graphql_api.models._infra.common import (
+    BigInt,
+    DateTime,
+    FileRole,
+    KeyValuePairInput,
+    client_mutation_id_payload_field,
+)
+from graphql_api.models._infra.page_info import CompatListConnection
+from graphql_api.models._interfaces.predecessor import PredecessorInput
 from graphql_api.models.aggregate_inversion_solution import (
     AggregateInversionSolution,
     CreateAggregateInversionSolutionInput,
@@ -42,15 +58,6 @@ from graphql_api.models.automation_task import (
     resolve_automation_tasks,
     resolve_rupture_generation_tasks,
 )
-from graphql_api.models._infra.common import (
-    BigInt,
-    DateTime,
-    FileRole,
-    KeyValuePairInput,
-    client_mutation_id_payload_field,
-)
-from graphql_api.models._base.file import CreateFileInput, ToshiFile, mutate_create_file, resolve_files
-from graphql_api.models._interfaces.predecessor import PredecessorInput
 from graphql_api.models.general_task import (
     CreateGeneralTaskInput,
     GeneralTask,
@@ -73,11 +80,6 @@ from graphql_api.models.inversion_solution_nrml import (
     mutate_create_inversion_solution_nrml,
     resolve_inversion_solution_nrmls,
 )
-from graphql_api.models._base.object_identity import (
-    ObjectIdentitiesConnection,
-    decode_cursor,
-    make_object_identities_connection,
-)
 from graphql_api.models.openquake_hazard_config import (
     CreateOpenquakeHazardConfigInput,
     OpenquakeHazardConfig,
@@ -98,7 +100,6 @@ from graphql_api.models.openquake_hazard_task import (
     mutate_update_openquake_hazard_task,
     resolve_openquake_hazard_tasks,
 )
-from graphql_api.models._infra.page_info import CompatListConnection
 from graphql_api.models.relations import (
     CreateFileRelationInput,
     CreateTaskRelationInput,
@@ -126,7 +127,6 @@ from graphql_api.models.strong_motion_station import (
     mutate_create_strong_motion_station,
     resolve_strong_motion_stations,
 )
-from graphql_api.models._base.table import CreateTableInput, Table, mutate_create_table
 from graphql_api.models.time_dependent_inversion_solution import (
     CreateTimeDependentInversionSolutionInput,
     TimeDependentInversionSolution,
@@ -333,9 +333,7 @@ class CreateOpenquakeHazardTaskPayload:
     ok: bool | None = None
     # Field name matches legacy SDL — `openquake_hazard_task`, not the
     # POC-original `task_result` (chris's audit Problem 2 #1).
-    openquake_hazard_task: OpenquakeHazardTask | None = strawberry.field(
-        default=None, name="openquake_hazard_task"
-    )
+    openquake_hazard_task: OpenquakeHazardTask | None = strawberry.field(default=None, name="openquake_hazard_task")
     client_mutation_id: str | None = client_mutation_id_payload_field()
 
 
@@ -344,9 +342,7 @@ class UpdateOpenquakeHazardTaskPayload:
     ok: bool | None = None
     # Legacy uses `openquake_hazard_task` not `task_result` on the OQ task
     # payloads (chris's Problem 2 #1).
-    openquake_hazard_task: OpenquakeHazardTask | None = strawberry.field(
-        default=None, name="openquake_hazard_task"
-    )
+    openquake_hazard_task: OpenquakeHazardTask | None = strawberry.field(default=None, name="openquake_hazard_task")
     client_mutation_id: str | None = client_mutation_id_payload_field()
 
 

--- a/graphql_api/tests/test_auth.py
+++ b/graphql_api/tests/test_auth.py
@@ -341,7 +341,6 @@ def test_parse_error_blocks_execution(no_bypass):
 
 
 def test_production_schema_has_auth_extension_registered():
-    assert any(
-        ext is AuthExtension or type(ext) is AuthExtension
-        for ext in production_schema.extensions
-    ), "AuthExtension is not registered on the production schema"
+    assert any(ext is AuthExtension or type(ext) is AuthExtension for ext in production_schema.extensions), (
+        "AuthExtension is not registered on the production schema"
+    )

--- a/graphql_api/tests/test_automation_task.py
+++ b/graphql_api/tests/test_automation_task.py
@@ -113,9 +113,7 @@ def test_update_state_and_result(gql_context, created_task):
     assert updated["state"] == "DONE"
     assert updated["result"] == "SUCCESS"
 
-    node_result = schema.execute_sync(
-        NODE_QUERY, variable_values={"id": created_task["id"]}, context_value=gql_context
-    )
+    node_result = schema.execute_sync(NODE_QUERY, variable_values={"id": created_task["id"]}, context_value=gql_context)
     assert node_result.errors is None, node_result.errors
     assert node_result.data["node"]["state"] == "DONE"
     assert node_result.data["node"]["result"] == "SUCCESS"

--- a/graphql_api/tests/test_automation_task_schema_legacy.py
+++ b/graphql_api/tests/test_automation_task_schema_legacy.py
@@ -9,11 +9,9 @@ Covers cases the existing POC test_automation_task.py doesn't:
 
 import datetime as dt
 
-import pytest
 from dateutil.tz import tzutc
 
 from graphql_api.schema import schema
-
 
 CREATE_AT = """
 mutation ($created: DateTime!) {
@@ -62,9 +60,7 @@ mutation ($created: DateTime!) {
 def test_naive_datetime_rejected(gql_context):
     """Bare datetime (no tz) should fail at the DateTime scalar layer."""
     naive = dt.datetime.now()  # no tz
-    res = schema.execute_sync(
-        CREATE_AT, variable_values={"created": naive.isoformat()}, context_value=gql_context
-    )
+    res = schema.execute_sync(CREATE_AT, variable_values={"created": naive.isoformat()}, context_value=gql_context)
     assert res.errors is not None, "expected naive datetime to be rejected"
     # The legacy error said "must have a timezone". Strawberry's may differ; we
     # accept any error referencing timezone or aware/naive distinction.

--- a/graphql_api/tests/test_bugfix_167_fileunion_aggregate.py
+++ b/graphql_api/tests/test_bugfix_167_fileunion_aggregate.py
@@ -16,7 +16,6 @@ from dateutil.tz import tzutc
 
 from graphql_api.schema import schema
 
-
 CREATE_AT_AGGREGATE = """
 mutation ($created: DateTime!) {
   create_automation_task(input: {
@@ -162,9 +161,7 @@ def scenario(gql_context):
 
 def test_files_resolves_aggregate_inversion_solution(scenario, gql_context):
     """The FileUnion must dispatch to AggregateInversionSolution typename."""
-    res = schema.execute_sync(
-        QUERY_AT_FILES, variable_values={"id": scenario["at_id"]}, context_value=gql_context
-    )
+    res = schema.execute_sync(QUERY_AT_FILES, variable_values={"id": scenario["at_id"]}, context_value=gql_context)
     assert res.errors is None, res.errors
     node = res.data["node"]
     assert node["files"]["total_count"] == 1

--- a/graphql_api/tests/test_client_mutation_id_compat.py
+++ b/graphql_api/tests/test_client_mutation_id_compat.py
@@ -7,7 +7,6 @@ echoed back unchanged in the payload. Modern Relay 2 / Apollo clients can
 omit it entirely.
 """
 
-
 from graphql_api.schema import schema
 
 CREATE_WITH_CMI_MUTATION = """
@@ -117,9 +116,7 @@ def test_sdl_has_client_mutation_id_on_every_mutation_input():
 
     inputs = re.findall(r"input ((?:Create|Update|Append)\w+Input) \{[^}]+\}", sdl, re.DOTALL)
     assert len(inputs) > 15, f"expected many inputs, found {len(inputs)}"
-    blocks = re.findall(
-        r"input (?:Create|Update|Append)\w+Input \{[^}]+\}", sdl, re.DOTALL
-    )
+    blocks = re.findall(r"input (?:Create|Update|Append)\w+Input \{[^}]+\}", sdl, re.DOTALL)
     for block in blocks:
         assert "clientMutationId: String" in block, f"missing clientMutationId in:\n{block}"
 
@@ -131,9 +128,7 @@ def test_sdl_has_client_mutation_id_on_every_mutation_payload():
 
     payloads = re.findall(r"type ((?:Create|Update|Append)\w+Payload) \{[^}]+\}", sdl, re.DOTALL)
     assert len(payloads) > 10, f"expected many payloads, found {len(payloads)}"
-    blocks = re.findall(
-        r"type (?:Create|Update|Append)\w+Payload \{[^}]+\}", sdl, re.DOTALL
-    )
+    blocks = re.findall(r"type (?:Create|Update|Append)\w+Payload \{[^}]+\}", sdl, re.DOTALL)
     for block in blocks:
         assert "clientMutationId: String" in block, f"missing clientMutationId in:\n{block}"
 

--- a/graphql_api/tests/test_create_file_validation.py
+++ b/graphql_api/tests/test_create_file_validation.py
@@ -31,11 +31,11 @@ def test_create_file_with_int_file_size(gql_context):
     result = schema.execute_sync(
         CREATE_FILE_MUTATION,
         variable_values={
-                "file_name": "small.zip",
-                "md5_digest": "00",
-                "file_size": 1024,
-                "created": "2024-05-01T00:00:00Z",
-            },
+            "file_name": "small.zip",
+            "md5_digest": "00",
+            "file_size": 1024,
+            "created": "2024-05-01T00:00:00Z",
+        },
         context_value=gql_context,
     )
     assert result.errors is None, result.errors
@@ -47,11 +47,11 @@ def test_create_file_with_max_int32_file_size(gql_context):
     result = schema.execute_sync(
         CREATE_FILE_MUTATION,
         variable_values={
-                "file_name": "near_max.zip",
-                "md5_digest": "01a",
-                "file_size": MAX_INT32,
-                "created": "2024-05-01T00:00:00Z",
-            },
+            "file_name": "near_max.zip",
+            "md5_digest": "01a",
+            "file_size": MAX_INT32,
+            "created": "2024-05-01T00:00:00Z",
+        },
         context_value=gql_context,
     )
     assert result.errors is None, result.errors
@@ -64,11 +64,11 @@ def test_create_file_with_large_file_size_bigint(gql_context):
     result = schema.execute_sync(
         CREATE_FILE_MUTATION,
         variable_values={
-                "file_name": "big.zip",
-                "md5_digest": "01",
-                "file_size": big,
-                "created": "2024-05-01T00:00:00Z",
-            },
+            "file_name": "big.zip",
+            "md5_digest": "01",
+            "file_size": big,
+            "created": "2024-05-01T00:00:00Z",
+        },
         context_value=gql_context,
     )
     assert result.errors is None, result.errors
@@ -80,11 +80,11 @@ def test_create_file_rejects_string_file_size(gql_context):
     result = schema.execute_sync(
         CREATE_FILE_MUTATION,
         variable_values={
-                "file_name": "bad.zip",
-                "md5_digest": "02",
-                "file_size": "not-a-number",
-                "created": "2024-05-01T00:00:00Z",
-            },
+            "file_name": "bad.zip",
+            "md5_digest": "02",
+            "file_size": "not-a-number",
+            "created": "2024-05-01T00:00:00Z",
+        },
         context_value=gql_context,
     )
     assert result.errors is not None

--- a/graphql_api/tests/test_file_predecessors_legacy.py
+++ b/graphql_api/tests/test_file_predecessors_legacy.py
@@ -11,13 +11,9 @@ The legacy test shows that File-with-predecessors is a real shape —
 clients chaining files via predecessor edges need it to work.
 """
 
-import datetime as dt
-
 import pytest
-from dateutil.tz import tzutc
 
 from graphql_api.schema import schema
-
 
 CREATE_FILE_NO_PRED = """
 mutation ($file_name: String!, $md5: String!, $size: BigInt!) {

--- a/graphql_api/tests/test_file_relation.py
+++ b/graphql_api/tests/test_file_relation.py
@@ -1,6 +1,5 @@
 """Tests for file relations — linking ToshiFiles to tasks."""
 
-
 import pytest
 
 from graphql_api.schema import schema
@@ -81,11 +80,11 @@ def file_id(gql_context):
     result = schema.execute_sync(
         CREATE_FILE_MUTATION,
         variable_values={
-                "file_name": "output_data.zip",
-                "md5_digest": "99aabbcc",
-                "file_size": 2048,
-                "created": "2024-08-01T00:00:00Z",
-            },
+            "file_name": "output_data.zip",
+            "md5_digest": "99aabbcc",
+            "file_size": 2048,
+            "created": "2024-08-01T00:00:00Z",
+        },
         context_value=gql_context,
     )
     assert result.errors is None, result.errors

--- a/graphql_api/tests/test_file_relation_bugfix_126.py
+++ b/graphql_api/tests/test_file_relation_bugfix_126.py
@@ -15,7 +15,6 @@ from dateutil.tz import tzutc
 
 from graphql_api.schema import schema
 
-
 CREATE_AT = """
 mutation ($created: DateTime!) {
   create_automation_task(input: {

--- a/graphql_api/tests/test_file_relation_compression.py
+++ b/graphql_api/tests/test_file_relation_compression.py
@@ -21,7 +21,6 @@ from nzshm_common.util import compress_string, decompress_string
 from graphql_api.data import dynamo
 from graphql_api.schema import schema
 
-
 CREATE_AT_MUTATION = """
 mutation CreateTask($input: CreateAutomationTaskInput!) {
     create_automation_task(input: $input) {
@@ -96,11 +95,11 @@ def test_relations_stored_as_list_under_threshold(gql_context, lower_threshold):
     file_result = schema.execute_sync(
         CREATE_FILE_MUTATION,
         variable_values={
-                "file_name": "compression_under.zip",
-                "md5_digest": "00aa",
-                "file_size": 1024,
-                "created": "2024-07-01T00:00:00Z",
-            },
+            "file_name": "compression_under.zip",
+            "md5_digest": "00aa",
+            "file_size": 1024,
+            "created": "2024-07-01T00:00:00Z",
+        },
         context_value=gql_context,
     )
     assert file_result.errors is None, file_result.errors
@@ -108,7 +107,7 @@ def test_relations_stored_as_list_under_threshold(gql_context, lower_threshold):
     file_raw_id = base64.b64decode(file_gid).decode().split(":")[1]
 
     # Add 5 relations — well below the lowered threshold of 25.
-    for i in range(5):
+    for _i in range(5):
         at = schema.execute_sync(
             CREATE_AT_MUTATION,
             variable_values={
@@ -141,11 +140,11 @@ def test_relations_compressed_above_threshold(gql_context, lower_threshold):
     file_result = schema.execute_sync(
         CREATE_FILE_MUTATION,
         variable_values={
-                "file_name": "compression_over.zip",
-                "md5_digest": "01bb",
-                "file_size": 1024,
-                "created": "2024-07-02T00:00:00Z",
-            },
+            "file_name": "compression_over.zip",
+            "md5_digest": "01bb",
+            "file_size": 1024,
+            "created": "2024-07-02T00:00:00Z",
+        },
         context_value=gql_context,
     )
     assert file_result.errors is None, file_result.errors
@@ -153,7 +152,7 @@ def test_relations_compressed_above_threshold(gql_context, lower_threshold):
     file_raw_id = base64.b64decode(file_gid).decode().split(":")[1]
 
     # Add lower_threshold + 1 = 26 relations to cross the threshold.
-    for i in range(lower_threshold + 1):
+    for _i in range(lower_threshold + 1):
         at = schema.execute_sync(
             CREATE_AT_MUTATION,
             variable_values={
@@ -190,18 +189,18 @@ def test_relations_round_trip_through_graphql(gql_context, lower_threshold):
     file_result = schema.execute_sync(
         CREATE_FILE_MUTATION,
         variable_values={
-                "file_name": "compression_roundtrip.zip",
-                "md5_digest": "02cc",
-                "file_size": 1024,
-                "created": "2024-07-03T00:00:00Z",
-            },
+            "file_name": "compression_roundtrip.zip",
+            "md5_digest": "02cc",
+            "file_size": 1024,
+            "created": "2024-07-03T00:00:00Z",
+        },
         context_value=gql_context,
     )
     assert file_result.errors is None, file_result.errors
     file_gid = file_result.data["create_file"]["file_result"]["id"]
 
     thing_gids = []
-    for i in range(lower_threshold + 5):  # 30 relations, well above threshold
+    for _i in range(lower_threshold + 5):  # 30 relations, well above threshold
         at = schema.execute_sync(
             CREATE_AT_MUTATION,
             variable_values={
@@ -225,9 +224,7 @@ def test_relations_round_trip_through_graphql(gql_context, lower_threshold):
         assert rel.errors is None, rel.errors
 
     # Query the file — node lookup should decompress transparently.
-    result = schema.execute_sync(
-        FILE_WITH_RELATIONS_QUERY, variable_values={"id": file_gid}, context_value=gql_context
-    )
+    result = schema.execute_sync(FILE_WITH_RELATIONS_QUERY, variable_values={"id": file_gid}, context_value=gql_context)
     assert result.errors is None, result.errors
     node = result.data["node"]
     assert node["file_name"] == "compression_roundtrip.zip"
@@ -243,11 +240,11 @@ def test_pre_compressed_legacy_data_reads_correctly(gql_context):
     file_result = schema.execute_sync(
         CREATE_FILE_MUTATION,
         variable_values={
-                "file_name": "legacy_compressed.zip",
-                "md5_digest": "03dd",
-                "file_size": 1024,
-                "created": "2024-07-04T00:00:00Z",
-            },
+            "file_name": "legacy_compressed.zip",
+            "md5_digest": "03dd",
+            "file_size": 1024,
+            "created": "2024-07-04T00:00:00Z",
+        },
         context_value=gql_context,
     )
     assert file_result.errors is None, file_result.errors

--- a/graphql_api/tests/test_general_task.py
+++ b/graphql_api/tests/test_general_task.py
@@ -221,9 +221,7 @@ def test_subtask_result_field(created_task):
 
 def test_children_total_count_zero(gql_context, created_task):
     """children.total_count is 0 when no child tasks have been linked."""
-    result = schema.execute_sync(
-        NODE_QUERY, variable_values={"id": created_task["id"]}, context_value=gql_context
-    )
+    result = schema.execute_sync(NODE_QUERY, variable_values={"id": created_task["id"]}, context_value=gql_context)
     assert result.errors is None, result.errors
     assert result.data["node"]["children"]["total_count"] == 0
 
@@ -252,9 +250,7 @@ def test_children_total_count_after_relation(gql_context, created_task):
     )
     assert rel_result.errors is None, rel_result.errors
 
-    result = schema.execute_sync(
-        NODE_QUERY, variable_values={"id": created_task["id"]}, context_value=gql_context
-    )
+    result = schema.execute_sync(NODE_QUERY, variable_values={"id": created_task["id"]}, context_value=gql_context)
     assert result.errors is None, result.errors
     assert result.data["node"]["children"]["total_count"] == 1
 

--- a/graphql_api/tests/test_general_task_schema_legacy.py
+++ b/graphql_api/tests/test_general_task_schema_legacy.py
@@ -15,7 +15,6 @@ from dateutil.tz import tzutc
 
 from graphql_api.schema import schema
 
-
 CREATE_GT = """
 mutation ($created: DateTime!, $argument_lists: [KeyValueListPairInput], $meta: [KeyValuePairInput]) {
   create_general_task(input: {
@@ -100,8 +99,7 @@ def test_argument_lists_inner_null_round_trip(created):
 
 
 def test_swept_arguments_excludes_single_null_list(created):
-    """A key with `v: [null]` (one element) is NOT swept — only keys with len(v) > 1.
-    """
+    """A key with `v: [null]` (one element) is NOT swept — only keys with len(v) > 1."""
     assert created["swept_arguments"] == ["bogus_metric"]
 
 
@@ -113,9 +111,7 @@ def test_meta_round_trip(created):
 
 def test_node_lookup_preserves_argument_lists(created, gql_context):
     """Same shape via node(id:) lookup — separate code path."""
-    res = schema.execute_sync(
-        NODE_QUERY_GT, variable_values={"id": created["id"]}, context_value=gql_context
-    )
+    res = schema.execute_sync(NODE_QUERY_GT, variable_values={"id": created["id"]}, context_value=gql_context)
     assert res.errors is None, res.errors
     node = res.data["node"]
     al = {item["k"]: item["v"] for item in node["argument_lists"]}

--- a/graphql_api/tests/test_inversion_solution_bug_93.py
+++ b/graphql_api/tests/test_inversion_solution_bug_93.py
@@ -16,7 +16,6 @@ from dateutil.tz import tzutc
 
 from graphql_api.schema import schema
 
-
 CREATE_AT = """
 mutation ($created: DateTime!) {
   create_automation_task(input: {
@@ -130,9 +129,7 @@ def scenario(gql_context):
 
 def test_inversion_solution_skips_non_is_write_files(scenario, gql_context):
     """Bug #93 regression: with multiple WRITE files, only the IS is selected."""
-    res = schema.execute_sync(
-        QUERY_AT_INVERSION, variable_values={"id": scenario["at_id"]}, context_value=gql_context
-    )
+    res = schema.execute_sync(QUERY_AT_INVERSION, variable_values={"id": scenario["at_id"]}, context_value=gql_context)
     assert res.errors is None, res.errors
     sol = res.data["node"]["inversion_solution"]
     assert sol is not None
@@ -143,9 +140,7 @@ def test_inversion_solution_skips_non_is_write_files(scenario, gql_context):
 
 def test_inversion_solution_not_the_non_is_write_file(scenario, gql_context):
     """Explicit assertion the resolver did NOT return the plain WRITE File."""
-    res = schema.execute_sync(
-        QUERY_AT_INVERSION, variable_values={"id": scenario["at_id"]}, context_value=gql_context
-    )
+    res = schema.execute_sync(QUERY_AT_INVERSION, variable_values={"id": scenario["at_id"]}, context_value=gql_context)
     assert res.errors is None, res.errors
     sol = res.data["node"]["inversion_solution"]
     assert sol["id"] != scenario["write_other_id"]

--- a/graphql_api/tests/test_inversion_solution_interface.py
+++ b/graphql_api/tests/test_inversion_solution_interface.py
@@ -164,9 +164,7 @@ def is_with_mfd_table(gql_context, rgt_id, mfd_table_id):
                 "md5_digest": "aabbccdd",
                 "file_size": 1024,
                 "created": "2024-06-01T00:00:00Z",
-                "tables": [
-                    {"table_id": mfd_table_id, "table_type": "MFD_CURVES_V2", "label": "mfd"}
-                ],
+                "tables": [{"table_id": mfd_table_id, "table_type": "MFD_CURVES_V2", "label": "mfd"}],
             }
         },
         context_value=gql_context,

--- a/graphql_api/tests/test_inversion_solution_nrml.py
+++ b/graphql_api/tests/test_inversion_solution_nrml.py
@@ -174,9 +174,7 @@ def _create_nrml(gql_context, source_id: str, file_name: str, predecessors=None)
     }
     if predecessors is not None:
         payload["predecessors"] = predecessors
-    result = schema.execute_sync(
-        CREATE_NRML_MUTATION, variable_values={"input": payload}, context_value=gql_context
-    )
+    result = schema.execute_sync(CREATE_NRML_MUTATION, variable_values={"input": payload}, context_value=gql_context)
     assert result.errors is None, result.errors
     return result.data["create_inversion_solution_nrml"]["inversion_solution_nrml"]
 
@@ -230,9 +228,7 @@ def test_nrml_with_predecessors(gql_context, is_id):
 
 def test_nrml_node_lookup(gql_context, is_id):
     nrml = _create_nrml(gql_context, is_id, "node_lookup.xml")
-    result = schema.execute_sync(
-        NODE_QUERY, variable_values={"id": nrml["id"]}, context_value=gql_context
-    )
+    result = schema.execute_sync(NODE_QUERY, variable_values={"id": nrml["id"]}, context_value=gql_context)
     assert result.errors is None, result.errors
     node = result.data["node"]
     assert node["__typename"] == "InversionSolutionNrml"

--- a/graphql_api/tests/test_inversion_solution_predecessors_legacy.py
+++ b/graphql_api/tests/test_inversion_solution_predecessors_legacy.py
@@ -14,7 +14,6 @@ from dateutil.tz import tzutc
 
 from graphql_api.schema import schema
 
-
 CREATE_RGT = """
 mutation ($created: DateTime!) {
   create_rupture_generation_task(input: {
@@ -151,9 +150,7 @@ def test_predecessor_node_meta_round_trips(scenario):
 
 def test_predecessors_interface_node_lookup(scenario, gql_context):
     """Same shape via `... on PredecessorsInterface` fragment on node(id:)."""
-    res = schema.execute_sync(
-        NODE_QUERY, variable_values={"id": scenario["inv_id"]}, context_value=gql_context
-    )
+    res = schema.execute_sync(NODE_QUERY, variable_values={"id": scenario["inv_id"]}, context_value=gql_context)
     assert res.errors is None, res.errors
     preds = res.data["node"]["predecessors"]
     assert len(preds) == 1

--- a/graphql_api/tests/test_inversion_solution_schema_legacy.py
+++ b/graphql_api/tests/test_inversion_solution_schema_legacy.py
@@ -17,7 +17,6 @@ from dateutil.tz import tzutc
 
 from graphql_api.schema import schema
 
-
 CREATE_TABLE = """
 mutation ($name: String, $object_id: ID!, $rows: [[String]], $column_headers: [String], $column_types: [RowItemType]) {
   create_table(input: {

--- a/graphql_api/tests/test_legacy_class_names_present.py
+++ b/graphql_api/tests/test_legacy_class_names_present.py
@@ -13,26 +13,29 @@ type in POC's SDL.
 
 from graphql_api.schema import schema
 
-
 # Verbatim from legacy CLASS_MAPPINGS — these are the types clients
 # may reference. Sorted + deduped so an addition shows as a real diff.
-LEGACY_CLASS_NAMES = sorted(set([
-    "AggregateInversionSolution",
-    "File",
-    "GeneralTask",
-    "InversionSolution",
-    "InversionSolutionNrml",
-    "OpenquakeHazardConfig",
-    "OpenquakeHazardSolution",
-    "OpenquakeHazardTask",
-    "RuptureGenerationTask",
-    "RuptureSet",
-    "ScaledInversionSolution",
-    "SmsFile",
-    "StrongMotionStation",
-    "Table",
-    "TimeDependentInversionSolution",
-]))
+LEGACY_CLASS_NAMES = sorted(
+    set(
+        [
+            "AggregateInversionSolution",
+            "File",
+            "GeneralTask",
+            "InversionSolution",
+            "InversionSolutionNrml",
+            "OpenquakeHazardConfig",
+            "OpenquakeHazardSolution",
+            "OpenquakeHazardTask",
+            "RuptureGenerationTask",
+            "RuptureSet",
+            "ScaledInversionSolution",
+            "SmsFile",
+            "StrongMotionStation",
+            "Table",
+            "TimeDependentInversionSolution",
+        ]
+    )
+)
 
 
 def test_every_legacy_class_name_resolves_in_poc_sdl():

--- a/graphql_api/tests/test_nodes_query.py
+++ b/graphql_api/tests/test_nodes_query.py
@@ -205,9 +205,7 @@ def chain(gql_context):
 def test_nodes_basic_returns_typename_and_id(gql_context, chain):
     """nodes(id_in: [mixed]) returns matching __typename and id for each."""
     ids = [chain["sis_id"], chain["is_id"], chain["at_id"]]
-    result = schema.execute_sync(
-        NODES_BASIC_QUERY, variable_values={"ids": ids}, context_value=gql_context
-    )
+    result = schema.execute_sync(NODES_BASIC_QUERY, variable_values={"ids": ids}, context_value=gql_context)
     assert result.errors is None, result.errors
     edges = result.data["nodes"]["result"]["edges"]
     nodes = [e["node"] for e in edges]

--- a/graphql_api/tests/test_object_identities_legacy.py
+++ b/graphql_api/tests/test_object_identities_legacy.py
@@ -16,7 +16,6 @@ from dateutil.tz import tzutc
 
 from graphql_api.schema import schema
 
-
 CREATE_GT = """
 mutation ($created: DateTime!, $title: String!) {
   create_general_task(input: {
@@ -128,9 +127,7 @@ def test_object_identities_after_cursor_returns_next_page(seeded_ids, gql_contex
     assert second.errors is None, second.errors
     second_ids = {e["node"]["object_id"] for e in second.data["object_identities"]["edges"]}
     # No overlap between batches
-    assert first_ids.isdisjoint(second_ids), (
-        f"page-1 and page-2 ids overlap: {first_ids & second_ids}"
-    )
+    assert first_ids.isdisjoint(second_ids), f"page-1 and page-2 ids overlap: {first_ids & second_ids}"
 
 
 def test_object_identities_unknown_type_returns_empty(seeded_ids, gql_context):

--- a/graphql_api/tests/test_openquake.py
+++ b/graphql_api/tests/test_openquake.py
@@ -489,9 +489,7 @@ def task_args_id(gql_context):
 
 
 @pytest.fixture(scope="module")
-def oq_solution_with_archives(
-    gql_context, created_oq_task, csv_archive_id, hdf5_archive_id, task_args_id
-):
+def oq_solution_with_archives(gql_context, created_oq_task, csv_archive_id, hdf5_archive_id, task_args_id):
     result = schema.execute_sync(
         CREATE_OQ_SOLUTION_FULL_MUTATION,
         variable_values={

--- a/graphql_api/tests/test_openquake_hazard_solution_legacy.py
+++ b/graphql_api/tests/test_openquake_hazard_solution_legacy.py
@@ -14,7 +14,6 @@ from dateutil.tz import tzutc
 
 from graphql_api.schema import schema
 
-
 CREATE_FILE = """
 mutation ($file_name: String!, $md5: String!, $size: BigInt!) {
   create_file(file_name: $file_name, md5_digest: $md5, file_size: $size) {

--- a/graphql_api/tests/test_page_info_compat.py
+++ b/graphql_api/tests/test_page_info_compat.py
@@ -12,7 +12,6 @@ import pytest
 
 from graphql_api.schema import schema
 
-
 CREATE_TASK_MUTATION = """
 mutation CreateTask($input: CreateGeneralTaskInput!) {
     create_general_task(input: $input) { general_task { id } }

--- a/graphql_api/tests/test_runzi_query_corpus.py
+++ b/graphql_api/tests/test_runzi_query_corpus.py
@@ -39,7 +39,6 @@ from graphql import parse, validate
 
 from graphql_api.schema import schema
 
-
 # `tests/` is not a Python package (adding an __init__.py here breaks the
 # rest of the suite, which relies on sys.path-based imports). Load the
 # fixture by file path instead.
@@ -92,10 +91,7 @@ def test_runzi_query_validates_against_poc(origin, query):
     document = parse(query)
     errors = validate(schema._schema, document)
     # Strip out errors that match runzi-own bugs (see _RUNZI_KNOWN_BAD).
-    real_errors = [
-        e for e in errors
-        if not any(known in e.message for known in _RUNZI_KNOWN_BAD)
-    ]
+    real_errors = [e for e in errors if not any(known in e.message for known in _RUNZI_KNOWN_BAD)]
     assert not real_errors, (
         f"{origin}\n"
         + "\n".join(f"  - {e.message}" for e in real_errors)

--- a/graphql_api/tests/test_rupture_generation_task.py
+++ b/graphql_api/tests/test_rupture_generation_task.py
@@ -105,9 +105,7 @@ def test_create_with_metrics(gql_context):
     """Mirrors legacy test_create_with_metrics — create RGT carrying a metrics list."""
     result = schema.execute_sync(
         CREATE_RGT,
-        variable_values={
-            "input": _make_input(metrics=[{"k": "rupture_count", "v": "206776"}])
-        },
+        variable_values={"input": _make_input(metrics=[{"k": "rupture_count", "v": "206776"}])},
         context_value=gql_context,
     )
     assert result.errors is None, result.errors

--- a/graphql_api/tests/test_rupture_set_mutation_checks.py
+++ b/graphql_api/tests/test_rupture_set_mutation_checks.py
@@ -13,7 +13,6 @@ from dateutil.tz import tzutc
 
 from graphql_api.schema import schema
 
-
 CREATE_RS_BARE = """
 mutation ($created: DateTime!) {
   create_rupture_set(input: {

--- a/graphql_api/tests/test_s3_fallback.py
+++ b/graphql_api/tests/test_s3_fallback.py
@@ -227,9 +227,7 @@ def test_scan_skips_entries_without_clazz_name(mocked_aws):
     from graphql_api.data import s3 as s3_mod
 
     _put_s3_object(mocked_aws["s3"], "ThingData/300/object.json", {"state": "done"})
-    _put_s3_object(
-        mocked_aws["s3"], "ThingData/400/object.json", {"clazz_name": "AutomationTask"}
-    )
+    _put_s3_object(mocked_aws["s3"], "ThingData/400/object.json", {"clazz_name": "AutomationTask"})
 
     items, _, _ = s3_mod.scan_s3_paginated("Thing", limit=10)
     object_ids = {it["object_id"] for it in items}
@@ -240,9 +238,7 @@ def test_scan_file_data_applies_first_dynamo_id_watermark(mocked_aws):
     """File-prefixed IDs >= FIRST_DYNAMO_ID are filtered out (avoid double-yield vs DDB scan)."""
     from graphql_api.data import s3 as s3_mod
 
-    _put_s3_object(
-        mocked_aws["s3"], "FileData/99/object.json", {"clazz_name": "RuptureSet", "file_name": "old.zip"}
-    )
+    _put_s3_object(mocked_aws["s3"], "FileData/99/object.json", {"clazz_name": "RuptureSet", "file_name": "old.zip"})
     _put_s3_object(
         mocked_aws["s3"],
         "FileData/100001/object.json",
@@ -258,9 +254,7 @@ def test_scan_thing_data_does_not_apply_watermark(mocked_aws):
     """The watermark filter is FileData-specific (matches legacy base_data.py:178)."""
     from graphql_api.data import s3 as s3_mod
 
-    _put_s3_object(
-        mocked_aws["s3"], "ThingData/100001/object.json", {"clazz_name": "GeneralTask", "title": "x"}
-    )
+    _put_s3_object(mocked_aws["s3"], "ThingData/100001/object.json", {"clazz_name": "GeneralTask", "title": "x"})
     items, _, _ = s3_mod.scan_s3_paginated("Thing", limit=10)
     assert len(items) == 1
     assert items[0]["object_id"] == "100001"

--- a/graphql_api/tests/test_schema_parity.py
+++ b/graphql_api/tests/test_schema_parity.py
@@ -22,7 +22,6 @@ from graphql_api.tools.schema_parity import (  # noqa: E402
     main,
 )
 
-
 # ── Unit tests: extractor ─────────────────────────────────────────────────────
 
 
@@ -121,13 +120,13 @@ def test_diff_detects_argument_drift_on_field():
     legacy = "type Query { node(id: ID!, deep: Boolean): String }"
     poc = "type Query { node(id: ID!): String }"
     d = diff_schemas(legacy, poc)
-    assert d["type_diffs"]["Query"]["field_arg_mismatches"]["node"]["args_only_in_legacy"] == [
-        "deep"
-    ]
+    assert d["type_diffs"]["Query"]["field_arg_mismatches"]["node"]["args_only_in_legacy"] == ["deep"]
 
 
 def test_diff_detects_interface_implementation_drift():
-    legacy = "interface Node { id: ID! } interface FI { fn: String } type Foo implements Node & FI { id: ID! fn: String }"
+    legacy = (
+        "interface Node { id: ID! } interface FI { fn: String } type Foo implements Node & FI { id: ID! fn: String }"
+    )
     poc = "interface Node { id: ID! } type Foo implements Node { id: ID! fn: String }"
     d = diff_schemas(legacy, poc)
     assert d["type_diffs"]["Foo"]["interfaces_only_in_legacy"] == ["FI"]
@@ -137,9 +136,7 @@ def test_diff_input_field_type_mismatch():
     legacy = "input CreateInput { file_size: BigInt }"
     poc = "input CreateInput { file_size: Int }"
     d = diff_schemas(legacy, poc)
-    assert d["type_diffs"]["CreateInput"]["field_type_mismatches"] == {
-        "file_size": ("BigInt", "Int")
-    }
+    assert d["type_diffs"]["CreateInput"]["field_type_mismatches"] == {"file_size": ("BigInt", "Int")}
 
 
 def test_identical_schemas_produce_empty_diff():
@@ -231,9 +228,7 @@ def test_catches_file_size_int_vs_bigint_mismatch():
     legacy = "type ToshiFile { id: ID! file_size: BigInt }"
     poc = "type ToshiFile { id: ID! file_size: Int }"
     d = diff_schemas(legacy, poc)
-    assert d["type_diffs"]["ToshiFile"]["field_type_mismatches"] == {
-        "file_size": ("BigInt", "Int")
-    }
+    assert d["type_diffs"]["ToshiFile"]["field_type_mismatches"] == {"file_size": ("BigInt", "Int")}
 
 
 def test_catches_missing_total_count_on_connection(legacy_minimal):

--- a/graphql_api/tests/test_sdl_emission_invariants.py
+++ b/graphql_api/tests/test_sdl_emission_invariants.py
@@ -81,9 +81,7 @@ def test_create_file_relation_uses_positional_args(sdl):
     assert m, "create_file_relation disappeared from SDL"
     sig = m.group(0)
     assert "file_id: ID!" in sig, f"create_file_relation lost positional file_id: {sig}"
-    assert "input: CreateFileRelationInput" not in sig, (
-        f"create_file_relation regressed: {sig}"
-    )
+    assert "input: CreateFileRelationInput" not in sig, f"create_file_relation regressed: {sig}"
 
 
 def test_create_task_relation_uses_positional_args(sdl):
@@ -93,9 +91,7 @@ def test_create_task_relation_uses_positional_args(sdl):
     sig = m.group(0)
     assert "child_id: ID!" in sig, f"create_task_relation lost positional child_id: {sig}"
     assert "parent_id: ID!" in sig, f"create_task_relation lost positional parent_id: {sig}"
-    assert "input: CreateTaskRelationInput" not in sig, (
-        f"create_task_relation regressed: {sig}"
-    )
+    assert "input: CreateTaskRelationInput" not in sig, f"create_task_relation regressed: {sig}"
 
 
 # ── Invariant 3: Connection type names match legacy ──────────────────────────
@@ -110,9 +106,7 @@ def test_connection_type_names_match_legacy(sdl):
     assert "type FileRelationsConnection " not in sdl, (
         "FileRelationsConnection (plural) regressed into SDL — clients break"
     )
-    assert "type TaskRelationsConnection " not in sdl, (
-        "TaskRelationsConnection (single Task) regressed into SDL"
-    )
+    assert "type TaskRelationsConnection " not in sdl, "TaskRelationsConnection (single Task) regressed into SDL"
 
 
 # ── Invariant 4: OQ task payloads use `openquake_hazard_task` not `task_result` ──
@@ -150,6 +144,4 @@ def test_create_inversion_solution_input_has_mfd_table_id(sdl):
     m = re.search(r"input CreateInversionSolutionInput \{[^}]+\}", sdl, re.DOTALL)
     assert m, "CreateInversionSolutionInput missing"
     body = m.group(0)
-    assert "mfd_table_id:" in body, (
-        f"CreateInversionSolutionInput missing mfd_table_id: {body}"
-    )
+    assert "mfd_table_id:" in body, f"CreateInversionSolutionInput missing mfd_table_id: {body}"

--- a/graphql_api/tests/test_source_solution_bugfix_214.py
+++ b/graphql_api/tests/test_source_solution_bugfix_214.py
@@ -15,7 +15,6 @@ from dateutil.tz import tzutc
 
 from graphql_api.schema import schema
 
-
 CREATE_AT = """
 mutation ($created: DateTime!) {
   create_automation_task(input: {
@@ -151,9 +150,7 @@ def test_scaled_source_solution_dispatches_to_time_dependent_on_create(chain):
 
 def test_scaled_source_solution_dispatches_to_time_dependent_via_node_lookup(chain, gql_context):
     """Same assertion via a node lookup — separate code path (resolve_node)."""
-    res = schema.execute_sync(
-        QUERY_SCALED_NODE, variable_values={"id": chain["scaled_id"]}, context_value=gql_context
-    )
+    res = schema.execute_sync(QUERY_SCALED_NODE, variable_values={"id": chain["scaled_id"]}, context_value=gql_context)
     assert res.errors is None, res.errors
     ss = res.data["node"]["source_solution"]
     assert ss["__typename"] == "TimeDependentInversionSolution"

--- a/graphql_api/tests/test_swept_arguments_edges.py
+++ b/graphql_api/tests/test_swept_arguments_edges.py
@@ -18,11 +18,9 @@ a vague "the swept_args got weird" report.
 
 import datetime as dt
 
-import pytest
 from dateutil.tz import tzutc
 
 from graphql_api.schema import schema
-
 
 CREATE_GT = """
 mutation ($created: DateTime!, $argument_lists: [KeyValueListPairInput]) {

--- a/graphql_api/tests/test_table.py
+++ b/graphql_api/tests/test_table.py
@@ -212,9 +212,7 @@ def test_table_node_lookup_returns_name(gql_context, task_id):
     assert create_result.errors is None, create_result.errors
     table_id = create_result.data["create_table"]["table"]["id"]
 
-    result = schema.execute_sync(
-        NODE_NAME_QUERY, variable_values={"id": table_id}, context_value=gql_context
-    )
+    result = schema.execute_sync(NODE_NAME_QUERY, variable_values={"id": table_id}, context_value=gql_context)
     assert result.errors is None, result.errors
     assert result.data["node"]["name"] == "Hazard Sites Grid"
 

--- a/graphql_api/tests/test_table_schema_legacy.py
+++ b/graphql_api/tests/test_table_schema_legacy.py
@@ -11,7 +11,6 @@ import pytest
 
 from graphql_api.schema import schema
 
-
 CREATE_TABLE = """
 mutation (
   $object_id: ID!,
@@ -103,9 +102,7 @@ def test_node_lookup_returns_rows(created, gql_context):
     """node(id:) returns the full rows back. The Table.rows[list[list[str|None]|None]|None]
     read path has no other test coverage in POC.
     """
-    res = schema.execute_sync(
-        NODE_QUERY, variable_values={"id": created["id"]}, context_value=gql_context
-    )
+    res = schema.execute_sync(NODE_QUERY, variable_values={"id": created["id"]}, context_value=gql_context)
     assert res.errors is None, res.errors
     node = res.data["node"]
     assert node["rows"] == [["1", "1.01"], ["2", "2.2"]]
@@ -113,9 +110,7 @@ def test_node_lookup_returns_rows(created, gql_context):
 
 def test_node_lookup_returns_dimensions(created, gql_context):
     """dimensions list-of-KeyValueListPair survives the node lookup."""
-    res = schema.execute_sync(
-        NODE_QUERY, variable_values={"id": created["id"]}, context_value=gql_context
-    )
+    res = schema.execute_sync(NODE_QUERY, variable_values={"id": created["id"]}, context_value=gql_context)
     assert res.errors is None, res.errors
     dims = {d["k"]: d["v"] for d in res.data["node"]["dimensions"]}
     assert dims["grid_spacings"] == ["0.1"]
@@ -125,9 +120,7 @@ def test_node_lookup_returns_dimensions(created, gql_context):
 
 def test_node_lookup_returns_meta(created, gql_context):
     """meta list-of-KeyValuePair survives the node lookup."""
-    res = schema.execute_sync(
-        NODE_QUERY, variable_values={"id": created["id"]}, context_value=gql_context
-    )
+    res = schema.execute_sync(NODE_QUERY, variable_values={"id": created["id"]}, context_value=gql_context)
     assert res.errors is None, res.errors
     meta = {m["k"]: m["v"] for m in res.data["node"]["meta"]}
     assert meta["round"] == "0"
@@ -136,8 +129,6 @@ def test_node_lookup_returns_meta(created, gql_context):
 
 def test_node_lookup_returns_table_type(created, gql_context):
     """Enum round-trips via node lookup."""
-    res = schema.execute_sync(
-        NODE_QUERY, variable_values={"id": created["id"]}, context_value=gql_context
-    )
+    res = schema.execute_sync(NODE_QUERY, variable_values={"id": created["id"]}, context_value=gql_context)
     assert res.errors is None, res.errors
     assert res.data["node"]["table_type"] == "HAZARD_GRIDDED"

--- a/graphql_api/tests/test_thing_interface.py
+++ b/graphql_api/tests/test_thing_interface.py
@@ -10,7 +10,6 @@ import pytest
 
 from graphql_api.schema import schema
 
-
 CREATE_GT_MUTATION = """
 mutation($input: CreateGeneralTaskInput!) {
     create_general_task(input: $input) { general_task { id } }
@@ -120,11 +119,7 @@ def test_thing_attached_to_all_concrete_types():
     sdl = schema.as_str()
     import re
 
-    matches = {
-        tn: impl
-        for tn, impl in re.findall(r"type (\w+) implements ([\w &]+)", sdl)
-        if "Thing" in impl
-    }
+    matches = {tn: impl for tn, impl in re.findall(r"type (\w+) implements ([\w &]+)", sdl) if "Thing" in impl}
     # The 7 types ADR-002 specifies
     expected = {
         "GeneralTask",

--- a/graphql_api/tests/test_thing_relation_bugfix_95.py
+++ b/graphql_api/tests/test_thing_relation_bugfix_95.py
@@ -17,7 +17,6 @@ from dateutil.tz import tzutc
 
 from graphql_api.schema import schema
 
-
 CREATE_GT = """
 mutation new_gt ($created: DateTime!) {
   create_general_task(input:{
@@ -115,9 +114,7 @@ query get_task ($id: ID!) {
 def seeded(gql_context):
     created = dt.datetime.now(tzutc()).isoformat()
 
-    gt_res = schema.execute_sync(
-        CREATE_GT, variable_values={"created": created}, context_value=gql_context
-    )
+    gt_res = schema.execute_sync(CREATE_GT, variable_values={"created": created}, context_value=gql_context)
     assert gt_res.errors is None, gt_res.errors
     gt_id = gt_res.data["create_general_task"]["general_task"]["id"]
 
@@ -152,9 +149,7 @@ def test_at_parents_connection_resolves_general_task(seeded, gql_context):
     """The #322-renamed Connection field `parents { edges { node { parent } } }`
     on AutomationTask resolves back to the seeded GeneralTask.
     """
-    res = schema.execute_sync(
-        QUERY_AT_PARENT, variable_values={"id": seeded["at_id"]}, context_value=gql_context
-    )
+    res = schema.execute_sync(QUERY_AT_PARENT, variable_values={"id": seeded["at_id"]}, context_value=gql_context)
     assert res.errors is None, res.errors
     node = res.data["node"]
     assert node["__typename"] == "AutomationTask"
@@ -170,9 +165,7 @@ def test_at_arguments_input_list_nullability(seeded, gql_context):
     """The arguments list field accepts the legacy [KeyValuePairInput] shape.
     Verifies #322's `list[KeyValuePairInput | None]` SDL emission.
     """
-    res = schema.execute_sync(
-        QUERY_AT_PARENT, variable_values={"id": seeded["at_id"]}, context_value=gql_context
-    )
+    res = schema.execute_sync(QUERY_AT_PARENT, variable_values={"id": seeded["at_id"]}, context_value=gql_context)
     assert res.errors is None, res.errors
     # Argument list itself isn't reselected in this query; assert via a fresh node lookup.
     Q = """

--- a/graphql_api/tests/test_time_dependent_inversion_solution.py
+++ b/graphql_api/tests/test_time_dependent_inversion_solution.py
@@ -83,11 +83,11 @@ def _seed_automation_task(gql_context) -> str:
         gql_context["dynamodb"],
         "AutomationTask",
         {
-                "state": "done",
-                "result": "success",
-                "task_type": "time_dependent_solution",
-                "created": "2024-01-01T00:00:00Z",
-            },
+            "state": "done",
+            "result": "success",
+            "task_type": "time_dependent_solution",
+            "created": "2024-01-01T00:00:00Z",
+        },
     )
     return base64.b64encode(f"AutomationTask:{data['object_id']}".encode()).decode()
 

--- a/graphql_api/tests/test_weka_codegen_queries.py
+++ b/graphql_api/tests/test_weka_codegen_queries.py
@@ -17,7 +17,6 @@ from dateutil.tz import tzutc
 
 from graphql_api.schema import schema
 
-
 CREATE_GT = """
 mutation ($created: DateTime!, $title: String!) {
   create_general_task(input: {

--- a/graphql_api/tools/refresh_runzi_corpus.py
+++ b/graphql_api/tools/refresh_runzi_corpus.py
@@ -41,7 +41,6 @@ import sys
 import textwrap
 from pathlib import Path
 
-
 # Triple-quoted block whose first non-whitespace token is `query`,
 # `mutation`, or `fragment`. Permissive on whitespace and the operation
 # name so we catch runzi's typical `qry = '''mutation foo (…) {…}'''`.
@@ -118,9 +117,9 @@ OPERATIONS = [
     for label, query in operations:
         # Use ` ''' `-safe triple-quoted strings; runzi queries never contain
         # `"""` so emit with double-quote triplets.
-        parts.append(f"    (\n")
+        parts.append("    (\n")
         parts.append(f"        {label!r},\n")
-        parts.append(f'        """\\\n')
+        parts.append('        """\\\n')
         # Indent the query body by 8 spaces so the docstring is readable but
         # the query text itself is left-aligned for parse correctness.
         parts.append(textwrap.indent(query, ""))

--- a/graphql_api/tools/schema_parity.py
+++ b/graphql_api/tools/schema_parity.py
@@ -73,11 +73,7 @@ def _fields_to_dict(field_defs) -> dict[str, dict]:
 
 def _input_fields_to_dict(field_defs) -> dict[str, str]:
     """{field_name: rendered_type} for input object fields."""
-    return {
-        f.name.value: _type_to_str(f.type)
-        for f in field_defs
-        if isinstance(f, InputValueDefinitionNode)
-    }
+    return {f.name.value: _type_to_str(f.type) for f in field_defs if isinstance(f, InputValueDefinitionNode)}
 
 
 def extract_types(sdl: str) -> dict[str, dict]:
@@ -142,9 +138,7 @@ def _diff_object_or_interface(legacy: dict, poc: dict) -> dict:
                 "args_only_in_legacy": sorted(set(l_args) - set(p_args)),
                 "args_only_in_poc": sorted(set(p_args) - set(l_args)),
                 "arg_type_mismatches": {
-                    a: (l_args[a], p_args[a])
-                    for a in set(l_args) & set(p_args)
-                    if l_args[a] != p_args[a]
+                    a: (l_args[a], p_args[a]) for a in set(l_args) & set(p_args) if l_args[a] != p_args[a]
                 },
             }
 
@@ -186,9 +180,7 @@ def _diff_input(legacy: dict, poc: dict) -> dict:
         out["fields_only_in_poc"] = only_p
 
     type_mismatches = {
-        name: (l_fields[name], p_fields[name])
-        for name in l_names & p_names
-        if l_fields[name] != p_fields[name]
+        name: (l_fields[name], p_fields[name]) for name in l_names & p_names if l_fields[name] != p_fields[name]
     }
     if type_mismatches:
         out["field_type_mismatches"] = type_mismatches
@@ -228,20 +220,20 @@ def diff_schemas(legacy_sdl: str, poc_sdl: str) -> dict:
 
     type_diffs: dict[str, dict] = {}
     for name in sorted(in_both):
-        l = legacy[name]
+        leg = legacy[name]
         p = poc[name]
-        if l["kind"] != p["kind"]:
-            type_diffs[name] = {"kind_mismatch": (l["kind"], p["kind"])}
+        if leg["kind"] != p["kind"]:
+            type_diffs[name] = {"kind_mismatch": (leg["kind"], p["kind"])}
             continue
-        kind = l["kind"]
+        kind = leg["kind"]
         if kind in ("object", "interface"):
-            d = _diff_object_or_interface(l, p)
+            d = _diff_object_or_interface(leg, p)
         elif kind == "input":
-            d = _diff_input(l, p)
+            d = _diff_input(leg, p)
         elif kind == "enum":
-            d = _diff_enum(l, p)
+            d = _diff_enum(leg, p)
         elif kind == "union":
-            d = _diff_union(l, p)
+            d = _diff_union(leg, p)
         else:
             d = {}
         if d:
@@ -320,9 +312,7 @@ def format_report(diff: dict) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(
-        description="Diff a legacy GraphQL SDL against a Strawberry POC SDL"
-    )
+    parser = argparse.ArgumentParser(description="Diff a legacy GraphQL SDL against a Strawberry POC SDL")
     parser.add_argument("legacy", help="Path to legacy SDL file")
     parser.add_argument("poc", help="Path to POC SDL file")
     parser.add_argument(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,8 @@ select = ["E", "F", "I", "B", "UP", "G004", "PLC0415"]
 "graphql_api/models/*.py" = ["F821"]
 # test helpers / fixtures use local imports for clarity and testcontainer lazy-start patterns
 "graphql_api/tests/**" = ["E501", "PLC0415"]
+# auth/ test harness uses local imports the same way
+"auth/tests/**" = ["PLC0415"]
 
 [tool.ruff.format]
 quote-style = "preserve"


### PR DESCRIPTION
## Why this PR exists

After the ADR-004 stack landed, the deploy-test pipeline started failing in tox's `format` and `lint` envs. Two structural reasons:

1. The reorg + Step 4 tooling consolidation made the POC's stricter ruff config (`PLC0415` in `select`, etc.) authoritative for the whole tree, including `auth/`.
2. The import-path expansion (`from .X` → `from graphql_api.models.X`) pushed many lines past the 120-char limit and shuffled import ordering.

This PR is the post-landing cleanup. Pure mechanical fixes — no behavior change.

## Changes

- **`ruff check --fix`** cleared 58 auto-fixable issues: 44 unsorted imports (I001), 11 unused imports (F401), 2 f-string-without-placeholder (F541), 1 redefined-while-unused (F811)
- **`ruff format`** reformatted 46 files, which wraps the long absolute import paths and eliminates all 21 E501s
- **`graphql_api/models/_infra/common.py`** — `_try_enum` uses PEP 695 generic syntax (`[E: Enum]`) instead of `typing.TypeVar` (UP047)
- **`graphql_api/models/relations.py`** — `# noqa: E402` on the two late `_dispatch` imports (intentional placement to break import cycle)
- **`graphql_api/tests/test_file_relation_compression.py`** — 3 unused loop vars `i` → `_i` (B007)
- **`graphql_api/tools/schema_parity.py`** — `l = legacy[name]` → `leg` (E741 ambiguous-name)
- **`auth/toshi_auth.py:257`** — `# noqa: PLC0415` on the inline `import configparser`
- **`pyproject.toml`** — added `"auth/tests/**" = ["PLC0415"]` per-file-ignore (matches the existing pattern for `graphql_api/tests/**`)

## Verification

- [x] `uv run ruff check graphql_api auth` — All checks passed!
- [x] `uv run ruff format --check graphql_api auth` — 111 files already formatted
- [x] `uv run pytest` — 375 passed, 1 skipped