### PR TITLE
feat: drop /graphql-v2 path, serve at /graphql

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -190,16 +190,16 @@ functions:
       LEGACY_API_KEY: ${env:NZSHM22_TOSHI_API_KEY, env:LEGACY_API_KEY, ''}
 
   graphql:
-    description: GraphQL API (Strawberry/FastAPI) at /graphql-v2
+    description: GraphQL API (Strawberry/FastAPI) at /graphql
     handler: graphql_api.app.handler
     memorySize: 1024
     timeout: 30
     events:
       - http:
-          path: graphql-v2
+          path: graphql
           method: OPTIONS
       - http:
-          path: graphql-v2
+          path: graphql
           method: GET
           authorizer:
             name: jwtAuthorizer
@@ -207,7 +207,7 @@ functions:
             identitySource: ''
             type: request
       - http:
-          path: graphql-v2
+          path: graphql
           method: POST
           authorizer:
             name: jwtAuthorizer
@@ -217,7 +217,7 @@ functions:
     environment:
       DB_READ_ONLY: "1"
       DEPLOYMENT_STAGE: ${self:custom.stage}
-      GRAPHQL_PATH: /graphql-v2
+      GRAPHQL_PATH: /graphql
       # REGION + S3_BUCKET_NAME inherit from provider.environment but we set
       # S3_BUCKET_NAME explicitly so the dependency for _from_s3 / S3 fallback
       # paths in graphql_api/data/{dynamo,s3}.py is visible at function scope.


### PR DESCRIPTION
## Why

\`/graphql-v2\` was the temporary URL used during the ADR-004 cutover, when the new Strawberry stack had to coexist with the legacy Flask/Graphene stack at \`/graphql\`. With the legacy stack removed, there's no coexistence concern — the new stack can serve at the conventional \`/graphql\` path, matching what prod has always used.

## Change

\`serverless.yml\` (single file):

- 3 http events on the \`graphql\` function: \`path: graphql-v2\` → \`path: graphql\` (OPTIONS / GET / POST)
- \`GRAPHQL_PATH\` env var: \`/graphql-v2\` → \`/graphql\`
- Function description string updated

## Cutover plan

1. **Merge to deploy-test** → only the test-stage Lambda is affected initially
2. **Test-stage clients reconfigure** from \`/test/graphql-v2\` → \`/test/graphql\` — runzi config, scientist tooling, anything chrisdicaprio repointed during the cutover
3. **Validate on test** for as long as needed
4. **deploy-test → main** → prod gets the same config. Prod URL has always been \`/graphql\`, so prod clients (weka, runzi prod config, simple-toshi-ui) see no change

## Why no ADR

The design decision is implicit: undo the temporary \`_v2\` suffix that was only ever placeholder during the parallel-deploy phase. Prod URL never changes; test stage clients revert one config. No dual-route window, no deprecation deadline.

## Rollback

Revert this PR → \`/graphql-v2\` is back. Test-stage clients re-revert. Prod unaffected either way (this hasn't reached main yet).

## Out of scope

- Historical references to \`/graphql-v2\` in ADR-001/002/004 and \`smoke-test-learnings.md\` left in place as period record.

## Test plan

- [ ] CI green
- [ ] Deploy to test stage; \`POST /test/graphql\` with a valid auth token returns a GraphQL response
- [ ] \`POST /test/graphql-v2\` returns 403/404 from API Gateway (route no longer exists)
- [ ] Coordinate runzi config flip with chrisdicaprio before deploying