### PR TITLE
chore: bump graphql Lambda memory 1024 → 4096 MB

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -192,7 +192,7 @@ functions:
   graphql:
     description: GraphQL API (Strawberry/FastAPI) at /graphql
     handler: graphql_api.app.handler
-    memorySize: 1024
+    memorySize: 4096
     timeout: 30
     events:
       - http:


### PR DESCRIPTION
## Why

Legacy \`app\` Lambda ran at **8192 MB**; the new \`graphql\` function shipped at **1024 MB** (set during the POC when it only served read-only queries). Going prod with a 1024 MB ceiling is too steep a drop — large queries or heavy resolvers risk OOM before we have real-world memory metrics on the new stack.

**4096 MB** halves the legacy ceiling while leaving plenty of headroom. Once CloudWatch shows actual usage on prod traffic, we can tune down.

## Change

\`serverless.yml\`: \`memorySize: 1024\` → \`memorySize: 4096\` on the \`graphql\` function only.

## Sequence

Lands on \`deploy-test\` → applies to test stage deploy → propagates to prod via #341 (the deploy-test→main promote).

This unblocks #341's "memory footprint change" risk note.