### PR TITLE
hotfix: drop DB_READ_ONLY default blocking prod mutations

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -121,9 +121,6 @@ custom:
         Exclude:
           - resourcee.Resources.ElasticSearchInstance
           - provider.iamrolestatements.1
-          # Test stage: the graphql function is the read-write primary.
-          # Drop its DB_READ_ONLY guard so writes succeed.
-          - functions.graphql.environment.DB_READ_ONLY
 
 provider:
   name: aws
@@ -215,7 +212,6 @@ functions:
             identitySource: ''
             type: request
     environment:
-      DB_READ_ONLY: "1"
       DEPLOYMENT_STAGE: ${self:custom.stage}
       GRAPHQL_PATH: /graphql
       # REGION + S3_BUCKET_NAME inherit from provider.environment but we set


### PR DESCRIPTION
## What's broken

Prod is rejecting every write:

\`\`\`
TransportQueryError: Aborting write: DB_READ_ONLY is set
\`\`\`

## Root cause

The \`graphql\` function in \`serverless.yml\` shipped with \`DB_READ_ONLY: \"1\"\` as a default in its environment block, and \`serverlessIfElse\` only dropped that flag on the **test** stage. Prod inherited the default → every mutation blocked at the data layer.

This was correct during the ADR-004 cutover when the POC ran as a shadow / read-only mirror alongside the legacy \`app\`. With ADR-004 fully landed and the new stack as the prod primary, the default needs to flip.

## Fix

Two changes in \`serverless.yml\`:

1. Removed \`DB_READ_ONLY: \"1\"\` from the \`graphql\` function's \`environment\` block → writes enabled by default for all stages.
2. Removed the now-dead \`functions.graphql.environment.DB_READ_ONLY\` exclude from \`serverlessIfElse\` → was conditionally undoing a setting that no longer exists.

If a read-only deploy is ever wanted again (per-stage canary, etc.), set \`DB_READ_ONLY=1\` via env override at deploy time instead of baking it into the default config.

## Why direct to main

Prod is broken now. Branch and \`deploy-test\` are otherwise in sync, so there's nothing on \`deploy-test\` that needs to gate this. After merge, deploy fires automatically.

## Follow-up

Forward-port to \`deploy-test\` in a follow-up PR so the branches don't drift. (Single-line fix; trivial cherry-pick.)

## Test plan

- [ ] CI green
- [ ] Deploy completes successfully
- [ ] Retry the failing \`create_file\` mutation against prod \`/graphql\` with x-api-key → returns a payload, not the \`DB_READ_ONLY\` error
- [ ] CloudWatch on \`nzshm22-toshi-api-prod-graphql\` shows the write succeeded