### PR TITLE
fix: restore deprecated config + modified_config fields for OpenquakeHazard parity

### DIFF
--- a/graphql_api/data/models.py
+++ b/graphql_api/data/models.py
@@ -194,6 +194,11 @@ class OpenquakeHazardSolutionData(BaseModel):
     metrics: list[KVPairModel] | None = None
     meta: list[KVPairModel] | None = None
     predecessors: list[PredecessorEntry] | None = None
+    # Legacy parity: deprecated fields still queried by older clients (e.g.
+    # toshi-ui OpenquakeHazardSolutionDetailTabQuery). Present on records
+    # created before deprecation. Surfaced read-only for compatibility.
+    config: str | None = None  # relay GlobalID → OpenquakeHazardConfig
+    modified_config: str | None = None  # relay GlobalID → File
     files: list[dict] | None = None
     parents: list[dict] | None = None
     children: list[dict] | None = None

--- a/graphql_api/models/openquake_hazard_solution.py
+++ b/graphql_api/models/openquake_hazard_solution.py
@@ -24,6 +24,9 @@ from graphql_api.models._interfaces.predecessors_interface import PredecessorsIn
 from graphql_api.models.openquake_hazard_task import OpenquakeHazardTask
 
 _OpenquakeHazardTask = Annotated["OpenquakeHazardTask", strawberry.lazy("graphql_api.models.openquake_hazard_task")]
+_OpenquakeHazardConfig = Annotated[
+    "OpenquakeHazardConfig", strawberry.lazy("graphql_api.models.openquake_hazard_config")
+]
 _ToshiFile = Annotated["ToshiFile", strawberry.lazy("graphql_api.models._base.file")]
 
 
@@ -39,6 +42,8 @@ class OpenquakeHazardSolution(relay.Node, PredecessorsInterface, Thing):
     csv_archive_raw_id: strawberry.Private[str | None] = None
     hdf5_archive_raw_id: strawberry.Private[str | None] = None
     task_args_raw_id: strawberry.Private[str | None] = None
+    config_raw_id: strawberry.Private[str | None] = None
+    modified_config_raw_id: strawberry.Private[str | None] = None
     predecessors_raw: strawberry.Private[list | None] = None
 
     def _resolve_file(self, info: Info, raw_id: str | None):
@@ -74,6 +79,23 @@ class OpenquakeHazardSolution(relay.Node, PredecessorsInterface, Thing):
     def task_args(self, info: Info) -> _ToshiFile | None:
         return self._resolve_file(info, self.task_args_raw_id)
 
+    @strawberry.field(deprecation_reason="We no longer store this value.")
+    def config(self, info: Info) -> _OpenquakeHazardConfig | None:
+        if not self.config_raw_id:
+            return None
+        from graphql_api.models.openquake_hazard_config import OpenquakeHazardConfig  # noqa: PLC0415
+
+        try:
+            raw_id = GlobalID.from_id(self.config_raw_id).node_id
+        except Exception:
+            raw_id = self.config_raw_id
+        data = get_thing(info.context["dynamodb"], raw_id)
+        return OpenquakeHazardConfig.from_dict(data) if data else None
+
+    @strawberry.field(deprecation_reason="We no longer use this field.")
+    def modified_config(self, info: Info) -> _ToshiFile | None:
+        return self._resolve_file(info, self.modified_config_raw_id)
+
     @classmethod
     def resolve_node(cls, node_id: str, *, info: Info, **kwargs) -> Optional["OpenquakeHazardSolution"]:
         data = get_thing(info.context["dynamodb"], node_id)
@@ -96,6 +118,8 @@ class OpenquakeHazardSolution(relay.Node, PredecessorsInterface, Thing):
             csv_archive_raw_id=d.csv_archive,
             hdf5_archive_raw_id=d.hdf5_archive,
             task_args_raw_id=d.task_args,
+            config_raw_id=d.config,
+            modified_config_raw_id=d.modified_config,
             predecessors_raw=[p.model_dump() for p in d.predecessors] if d.predecessors else None,
         )
 

--- a/graphql_api/models/openquake_hazard_task.py
+++ b/graphql_api/models/openquake_hazard_task.py
@@ -156,6 +156,13 @@ class CreateOpenquakeHazardTaskInput:
     gmcm_logic_tree: JSONString | None = None
     openquake_config: JSONString | None = None
     hazard_solution: strawberry.ID | None = None
+    # Legacy parity: deprecated input field, kept so old clients writing
+    # tasks with a config GlobalID still round-trip. Persisted on the
+    # record.
+    config: strawberry.ID | None = strawberry.field(
+        default=None,
+        deprecation_reason="We no longer store this config",
+    )
     client_mutation_id: str | None = client_mutation_id_input_field()
 
 
@@ -195,6 +202,7 @@ def mutate_create_openquake_hazard_task(info: Info, input: CreateOpenquakeHazard
         "gmcm_logic_tree": input.gmcm_logic_tree,
         "openquake_config": input.openquake_config,
         "hazard_solution": str(input.hazard_solution) if input.hazard_solution else None,
+        "config": str(input.config) if input.config else None,
     }
     data = create_thing(info.context["dynamodb"], "OpenquakeHazardTask", payload)
     return OpenquakeHazardTask.from_dict(data)

--- a/graphql_api/tests/test_openquake.py
+++ b/graphql_api/tests/test_openquake.py
@@ -223,6 +223,35 @@ def test_oq_solution_node_lookup(gql_context, created_oq_solution, created_oq_ta
     assert node["produced_by"]["id"] == created_oq_task["id"]
 
 
+def test_oq_solution_legacy_deprecated_fields_resolve(gql_context, created_oq_solution):
+    """Parity gap caught in prod: legacy `config` + `modified_config` fields
+    on OpenquakeHazardSolution must be queryable even though they're deprecated.
+    Older clients (e.g. toshi-ui OpenquakeHazardSolutionDetailTabQuery) hit
+    these as part of a larger selection; missing them returns a validation
+    error that nulls the whole node payload."""
+    result = schema.execute_sync(
+        """
+        query($id: ID!) {
+            node(id: $id) {
+                ... on OpenquakeHazardSolution {
+                    id
+                    config { id }
+                    modified_config { id file_name }
+                }
+            }
+        }
+        """,
+        variable_values={"id": created_oq_solution["id"]},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["id"] == created_oq_solution["id"]
+    # Fixture record has neither field set — they resolve to null without error.
+    assert node["config"] is None
+    assert node["modified_config"] is None
+
+
 # ── update_openquake_hazard_task tests ────────────────────────────────────────
 
 


### PR DESCRIPTION
## What's broken

The following client query against prod returns all fields null with identical "Cannot query field 'config' on type 'OpenquakeHazardSolution'" errors at every path:

```graphql
query OpenquakeHazardSolutionDetailTabQuery($id: ID!) {
  node(id: $id) {
    ... on OpenquakeHazardSolution {
      id created produced_by { ... } task_args { ... }
      config { ... }                  # ← missing field
      csv_archive { ... } hdf5_archive { ... }
    }
  }
}
```

(The "all nulls + every path errored" shape is GraphQL's behaviour when one field in a selection fails validation: the whole node payload is nulled.)

## Root cause + full audit

Legacy parity gap. Grepping the pre-ADR-004 tree for `deprecation_reason` found four deprecated fields total in the legacy Graphene schema (only two files ever had any):

| # | Where | Field | Before this PR |
|---|---|---|---|
| 1 | `OpenquakeHazardSolution` (output) | `config: OpenquakeHazardConfig` | ❌ missing |
| 2 | `OpenquakeHazardSolution` (output) | `modified_config: File` | ❌ missing |
| 3 | `OpenquakeHazardTask` (output) | `config: OpenquakeHazardConfig` | ✅ already there |
| 4 | `CreateOpenquakeHazardTaskInput` (input) | `config: ID` | ❌ missing |

This PR fixes 1, 2 and 4.

## Fix

Three commits across two layers:

- **`graphql_api/data/models.py`** `OpenquakeHazardSolutionData`: + `config: str | None`, + `modified_config: str | None`
- **`graphql_api/models/openquake_hazard_solution.py`**: + private raw_ids, + two `@strawberry.field(deprecation_reason=...)` resolvers, + `from_dict` populates them
- **`graphql_api/models/openquake_hazard_task.py`**: + `config: strawberry.ID` on `CreateOpenquakeHazardTaskInput` with `strawberry.field(deprecation_reason=...)` so the SDL emits the `@deprecated` marker properly, + `mutate_create_openquake_hazard_task` persists the value

SDL now emits:

```graphql
type OpenquakeHazardSolution {
  ...
  config: OpenquakeHazardConfig @deprecated(reason: "We no longer store this value.")
  modified_config: File @deprecated(reason: "We no longer use this field.")
}

input CreateOpenquakeHazardTaskInput {
  ...
  config: ID = null @deprecated(reason: "We no longer store this config")
}
```

## Tests

Added `test_oq_solution_legacy_deprecated_fields_resolve` in `test_openquake.py` — covers the legacy selection shape against a record with neither field set (resolves to null without error). 27/27 in `test_openquake.py` pass.

## Note for reviewers

Targets `deploy-test` first — normal flow. After landing here and validating on the test stage, it propagates to prod via the next deploy-test → main promote.

`main` has hotfix #343 (DB_READ_ONLY) that `deploy-test` hasn't forward-ported yet; that's a separate follow-up I'll open once this lands.

## Test plan

- [ ] CI green
- [ ] Deploy to test stage
- [ ] Replay the failing query against `/test/graphql` — returns `data` populated (no "Cannot query field 'config'" errors)
- [ ] Promote to main via deploy-test → main → prod gets the fix