### PR TITLE
release: promote OpenquakeHazard deprecated-field fixes to prod

### DIFF
--- a/graphql_api/data/models.py
+++ b/graphql_api/data/models.py
@@ -194,6 +194,11 @@ class OpenquakeHazardSolutionData(BaseModel):
     metrics: list[KVPairModel] | None = None
     meta: list[KVPairModel] | None = None
     predecessors: list[PredecessorEntry] | None = None
+    # Legacy parity: deprecated fields still queried by older clients (e.g.
+    # toshi-ui OpenquakeHazardSolutionDetailTabQuery). Present on records
+    # created before deprecation. Surfaced read-only for compatibility.
+    config: str | None = None  # relay GlobalID → OpenquakeHazardConfig
+    modified_config: str | None = None  # relay GlobalID → File
     files: list[dict] | None = None
     parents: list[dict] | None = None
     children: list[dict] | None = None

--- a/graphql_api/models/openquake_hazard_solution.py
+++ b/graphql_api/models/openquake_hazard_solution.py
@@ -24,6 +24,9 @@ from graphql_api.models._interfaces.predecessors_interface import PredecessorsIn
 from graphql_api.models.openquake_hazard_task import OpenquakeHazardTask
 
 _OpenquakeHazardTask = Annotated["OpenquakeHazardTask", strawberry.lazy("graphql_api.models.openquake_hazard_task")]
+_OpenquakeHazardConfig = Annotated[
+    "OpenquakeHazardConfig", strawberry.lazy("graphql_api.models.openquake_hazard_config")
+]
 _ToshiFile = Annotated["ToshiFile", strawberry.lazy("graphql_api.models._base.file")]
 
 
@@ -39,6 +42,8 @@ class OpenquakeHazardSolution(relay.Node, PredecessorsInterface, Thing):
     csv_archive_raw_id: strawberry.Private[str | None] = None
     hdf5_archive_raw_id: strawberry.Private[str | None] = None
     task_args_raw_id: strawberry.Private[str | None] = None
+    config_raw_id: strawberry.Private[str | None] = None
+    modified_config_raw_id: strawberry.Private[str | None] = None
     predecessors_raw: strawberry.Private[list | None] = None
 
     def _resolve_file(self, info: Info, raw_id: str | None):
@@ -74,6 +79,23 @@ class OpenquakeHazardSolution(relay.Node, PredecessorsInterface, Thing):
     def task_args(self, info: Info) -> _ToshiFile | None:
         return self._resolve_file(info, self.task_args_raw_id)
 
+    @strawberry.field(deprecation_reason="We no longer store this value.")
+    def config(self, info: Info) -> _OpenquakeHazardConfig | None:
+        if not self.config_raw_id:
+            return None
+        from graphql_api.models.openquake_hazard_config import OpenquakeHazardConfig  # noqa: PLC0415
+
+        try:
+            raw_id = GlobalID.from_id(self.config_raw_id).node_id
+        except Exception:
+            raw_id = self.config_raw_id
+        data = get_thing(info.context["dynamodb"], raw_id)
+        return OpenquakeHazardConfig.from_dict(data) if data else None
+
+    @strawberry.field(deprecation_reason="We no longer use this field.")
+    def modified_config(self, info: Info) -> _ToshiFile | None:
+        return self._resolve_file(info, self.modified_config_raw_id)
+
     @classmethod
     def resolve_node(cls, node_id: str, *, info: Info, **kwargs) -> Optional["OpenquakeHazardSolution"]:
         data = get_thing(info.context["dynamodb"], node_id)
@@ -96,6 +118,8 @@ class OpenquakeHazardSolution(relay.Node, PredecessorsInterface, Thing):
             csv_archive_raw_id=d.csv_archive,
             hdf5_archive_raw_id=d.hdf5_archive,
             task_args_raw_id=d.task_args,
+            config_raw_id=d.config,
+            modified_config_raw_id=d.modified_config,
             predecessors_raw=[p.model_dump() for p in d.predecessors] if d.predecessors else None,
         )
 

--- a/graphql_api/models/openquake_hazard_task.py
+++ b/graphql_api/models/openquake_hazard_task.py
@@ -156,6 +156,13 @@ class CreateOpenquakeHazardTaskInput:
     gmcm_logic_tree: JSONString | None = None
     openquake_config: JSONString | None = None
     hazard_solution: strawberry.ID | None = None
+    # Legacy parity: deprecated input field, kept so old clients writing
+    # tasks with a config GlobalID still round-trip. Persisted on the
+    # record.
+    config: strawberry.ID | None = strawberry.field(
+        default=None,
+        deprecation_reason="We no longer store this config",
+    )
     client_mutation_id: str | None = client_mutation_id_input_field()
 
 
@@ -195,6 +202,7 @@ def mutate_create_openquake_hazard_task(info: Info, input: CreateOpenquakeHazard
         "gmcm_logic_tree": input.gmcm_logic_tree,
         "openquake_config": input.openquake_config,
         "hazard_solution": str(input.hazard_solution) if input.hazard_solution else None,
+        "config": str(input.config) if input.config else None,
     }
     data = create_thing(info.context["dynamodb"], "OpenquakeHazardTask", payload)
     return OpenquakeHazardTask.from_dict(data)

--- a/graphql_api/tests/test_openquake.py
+++ b/graphql_api/tests/test_openquake.py
@@ -223,6 +223,35 @@ def test_oq_solution_node_lookup(gql_context, created_oq_solution, created_oq_ta
     assert node["produced_by"]["id"] == created_oq_task["id"]
 
 
+def test_oq_solution_legacy_deprecated_fields_resolve(gql_context, created_oq_solution):
+    """Parity gap caught in prod: legacy `config` + `modified_config` fields
+    on OpenquakeHazardSolution must be queryable even though they're deprecated.
+    Older clients (e.g. toshi-ui OpenquakeHazardSolutionDetailTabQuery) hit
+    these as part of a larger selection; missing them returns a validation
+    error that nulls the whole node payload."""
+    result = schema.execute_sync(
+        """
+        query($id: ID!) {
+            node(id: $id) {
+                ... on OpenquakeHazardSolution {
+                    id
+                    config { id }
+                    modified_config { id file_name }
+                }
+            }
+        }
+        """,
+        variable_values={"id": created_oq_solution["id"]},
+        context_value=gql_context,
+    )
+    assert result.errors is None, result.errors
+    node = result.data["node"]
+    assert node["id"] == created_oq_solution["id"]
+    # Fixture record has neither field set — they resolve to null without error.
+    assert node["config"] is None
+    assert node["modified_config"] is None
+
+
 # ── update_openquake_hazard_task tests ────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Promotes hotfix #344 from `deploy-test` to `main` after test-stage validation passed.

Adds three deprecated fields that were missed in the ADR-004 Strawberry port:

| Where | Field | Type |
|---|---|---|
| `OpenquakeHazardSolution` output | `config` | `OpenquakeHazardConfig` |
| `OpenquakeHazardSolution` output | `modified_config` | `File` |
| `CreateOpenquakeHazardTaskInput` input | `config` | `ID` |

All three carry the legacy `@deprecated` reasons in the SDL.

## Why

Prod clients (e.g. toshi-ui's `OpenquakeHazardSolutionDetailTabQuery`) were hitting validation errors and getting the whole node payload nulled. See #344 for the full client query + error response and the audit method (grepped the pre-ADR-004 tree for every `deprecation_reason` marker; these were the only gaps).

## Validation

- 27/27 in `test_openquake.py` pass, including the new `test_oq_solution_legacy_deprecated_fields_resolve` regression test
- Test stage replay of the failing query returns the populated payload (no "Cannot query field 'config'" errors)

## Branch sync follow-up

`main` is currently 1 PR ahead of `deploy-test` for hotfix #343 (DB_READ_ONLY default removal). That sync will be a separate PR after this lands so `deploy-test` and `main` are fully in step again.

## Test plan

- [ ] CI green
- [ ] Deploy completes successfully on prod
- [ ] Replay the failing toshi-ui query against `/prod/graphql` → returns `data` populated
- [ ] CloudWatch on `nzshm22-toshi-api-prod-graphql` shows the resolve path without error