### PR TITLE
sync: forward-port DB_READ_ONLY fix (#343) from main to deploy-test

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -121,9 +121,6 @@ custom:
         Exclude:
           - resourcee.Resources.ElasticSearchInstance
           - provider.iamrolestatements.1
-          # Test stage: the graphql function is the read-write primary.
-          # Drop its DB_READ_ONLY guard so writes succeed.
-          - functions.graphql.environment.DB_READ_ONLY
 
 provider:
   name: aws
@@ -215,7 +212,6 @@ functions:
             identitySource: ''
             type: request
     environment:
-      DB_READ_ONLY: "1"
       DEPLOYMENT_STAGE: ${self:custom.stage}
       GRAPHQL_PATH: /graphql
       # REGION + S3_BUCKET_NAME inherit from provider.environment but we set


### PR DESCRIPTION
## Why

Hotfix #343 landed directly on `main` while prod mutations were broken, creating a branch-divergence: `main` had the fix but `deploy-test` didn't. This PR closes that gap by cherry-picking the same commit onto `deploy-test`.

## Change

Single cherry-pick of `d6200ff`:

> hotfix: drop DB_READ_ONLY default that blocks prod mutations

Removes `DB_READ_ONLY: "1"` from the `graphql` function's env block in `serverless.yml` and the now-redundant `serverlessIfElse` exclude that only undid it on test.

## Functional impact

**On the test stage: zero.** The `serverlessIfElse` rule was already dropping the `DB_READ_ONLY` flag for `stage == "test"`, so test was already writing. This PR removes both halves of the no-op pattern.

This is **branch hygiene**, not a behavior change. The point is to make `deploy-test` and `main` describe the same deploy, so:

- the next deploy-test → main promote starts from a clean diff (no surprise "what's that DB_READ_ONLY thing doing here?")
- anyone deploying from `deploy-test` to a fresh stack gets the same env shape as a `main` deploy

## When to merge

After PR #345 (deploy-test → main promote) lands. Sequence:

1. **#345 merges first** → main gets the openquake fixes
2. **This PR merges second** → deploy-test catches up on DB_READ_ONLY

At that point both branches describe the same desired deploy, and the divergence is closed.

## Test plan

- [ ] CI green
- [ ] Test stage deploy succeeds (no functional difference — the fix was already inactive on test via the `serverlessIfElse` carve-out)