### PR TITLE
add s3 permissions required for administering batch environment and Q w/ terraform

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -486,6 +486,9 @@ resources:
                 - batch:DeleteComputeEnvironment
                 - batch:RegisterJobDefinition
                 - batch:DeregisterJobDefinition
+                - batch:CreateJobQueue
+                - batch:UpdateJobQueue
+                - batch:DeleteJobQueue
               Resource: '*'
             - Sid: ECRAdmin
               Effect: Allow
@@ -498,6 +501,18 @@ resources:
                 - ecr:BatchDeleteImage
               Resource:
                 - arn:aws:ecr:*:*:repository/nshm-runzi-*
+            # Terraform state for terraform/batch/ in nzshm-runzi (S3 backend +
+            # native S3 locking, which writes/deletes a "<key>.tflock" object).
+            - Sid: TerraformStateS3
+              Effect: Allow
+              Action:
+                - s3:GetObject
+                - s3:PutObject
+                - s3:DeleteObject
+                - s3:ListBucket
+              Resource:
+                - arn:aws:s3:::nzshm22-runzi-tfstate
+                - arn:aws:s3:::nzshm22-runzi-tfstate/*
 
     # ── IAM roles (assumed via Identity Pool after Cognito login) ──────────────
     # local tier — base permissions only (ECR pull, S3 read/write).


### PR DESCRIPTION
Current work on runzi is porting batch job queue and compute environment from hand build console to terraform IaC.

1. S3 access for the Terraform state bucket. The S3 backend with use_lockfile = true needs GetObject/PutObject for the state file itself, plus PutObject/DeleteObject on the lock object (Terraform's native S3 locking writes a conditional <key>.tflock object to acquire the lock, then deletes it to release). ListBucket covers init's bucket-existence check.

  2. Job-queue actions — BatchAdmin currently only has CreateComputeEnvironment/UpdateComputeEnvironment/DeleteComputeEnvironment and RegisterJobDefinition/DeregisterJobDefinition. There's no CreateJobQueue/UpdateJobQueue/DeleteJobQueue — but terraform/batch/main.tf manages aws_batch_job_queue.fargate, so apply will fail on the queue without these.
  (DescribeJobQueues/DescribeComputeEnvironments are already covered — they're in the batch tier, which admin inherits.