### PR TITLE
docs: vulnerability register + initial Dependabot triage

### DIFF
--- a/docs/security/VULNERABILITY_REGISTER.md
+++ b/docs/security/VULNERABILITY_REGISTER.md
@@ -1,0 +1,68 @@
+# Vulnerability Register
+
+**Scope:** `nshm-toshi-api` deployed Lambda + supporting tooling.
+**Authoritative tool:** GitHub Dependabot ([alerts dashboard](https://github.com/GNS-Science/nshm-toshi-api/security/dependabot)).
+**This doc:** policy, runtime-exposure model, active exceptions, review log. **Not** a per-CVE log — Dependabot is.
+
+## Policy
+
+1. **Triage cadence.** Dependabot alerts are triaged within 5 business days of opening.
+2. **Every dismissal carries a comment.** GitHub's `dismissed_comment` is the audit trail. Reasons used:
+   - `not_used` — the vulnerable package is a transitive of a dev-only tool; not present in the Lambda runtime.
+   - `tolerable_risk` — the vulnerable code path exists in the Lambda runtime but is not reachable from untrusted input; OR a patch exists and is queued for the next quarterly deps cycle.
+   - `no_bandwidth` — fix is wanted but not scheduled. Avoid this — prefer `tolerable_risk` with a queued-for-next-cycle note.
+   - `inaccurate` / `fix_started` — self-explanatory; use as needed.
+3. **Re-open if reachability changes.** Anyone adding code that:
+   - Accepts `application/x-www-form-urlencoded` bodies → re-open #188 (starlette).
+   - Adds an outbound HTTP call to a third-party (non-AWS) endpoint → re-open undici alerts.
+   - Adds user-controlled XML parsing → re-open fast-xml-parser alerts.
+4. **Quarterly review.** Last Friday of each quarter, the owner re-checks dismissed-but-not-fixed alerts. Anything still relevant gets either patched or re-justified.
+
+## Runtime exposure model
+
+The deployed Lambda runs:
+
+- **Python runtime deps** declared under `[project] dependencies` in `pyproject.toml` (FastAPI, Strawberry, boto3, etc.).
+- **Auth Lambda Authorizer** under `auth/authorizer/` (PyJWT, cryptography).
+- **No multipart, no form-urlencoded body handling** — GraphQL is JSON-only over POST.
+- **Outbound HTTP only to AWS** (DynamoDB, S3, Cognito, Elasticsearch) — no third-party API integration in the request path.
+
+Everything else is dev-only and **not Lambda-reachable**:
+
+- `serverless-*` plugins (s3-local, dynamodb, offline, warmup) — local-dev tooling for `yarn sls offline`.
+- `safety`, `pip-audit`, `moto`, `cachecontrol`, `nltk`, `msgpack` (transitive) — CI / audit tooling.
+- `testcontainers`, `httpx` (test client), `pytest` — test infrastructure.
+
+Rule of thumb: if a vulnerable package appears in `pyproject.toml` under `[project] dependencies` (not `[dependency-groups] dev`) and is reachable from a request handler, it's a real exposure. Otherwise it's a candidate for `not_used` / `tolerable_risk`.
+
+## Active exceptions
+
+Specific cross-cutting context that GitHub's per-alert UI can't capture:
+
+### `fast-xml-parser` — 7 alerts dismissed `tolerable_risk`
+Transitive via two consumers: (a) AWS SDK pins `5.2.5` — receives only trusted AWS API responses, so attacker can't supply the malicious XML; (b) `s3rver` (local-dev only via `serverless-s3-local`) — pinned to `3.21.1` via scoped resolution in `package.json`. **See [PR #350](https://github.com/GNS-Science/nshm-toshi-api/pull/350)** for the resolution-pinning rationale. Won't bump the AWS SDK pin in isolation; will move when next `@aws-sdk/*` minor lands.
+
+### `undici` — 3 alerts dismissed `tolerable_risk`
+Transitive via AWS SDK for outbound HTTP. Patched in `6.27.0`. **Queued for next quarterly deps cycle** (will land via a routine `yarn` minor-bump PR). If we ever add a third-party outbound integration, re-open immediately.
+
+### `starlette` — 1 alert dismissed `tolerable_risk`
+FastAPI dependency. The vulnerability is in `request.form()` size-limit handling for `application/x-www-form-urlencoded` bodies — we accept JSON only via GraphQL, so the vulnerable code path is unreachable. Patched in `1.3.1`. **Queued for next quarterly deps cycle.**
+
+### `nltk` / `msgpack` — 2 alerts dismissed `not_used`
+Transitive via dev-only tooling (`safety` audit tool, and `cachecontrol` under it). Not in the Lambda runtime; not in CI's request path. Will pick up patches naturally on `uv lock` regen.
+
+### `dicer` — 1 alert dismissed `not_used`
+Transitive via `serverless-offline → busboy → dicer` for multipart parsing in local dev. Not in the Lambda runtime. No upstream patch (the package is unmaintained); will go away when `serverless-offline` switches its parser.
+
+## Review log
+
+| Date | Reviewer | Open alerts before | Action taken |
+|---|---|---|---|
+| 2026-06-22 | chrisbc | 14 | Initial triage; all 14 dismissed (3 × `not_used`, 11 × `tolerable_risk`). Register established. |
+| _next: 2026-09-26_ | | | Q3 review — re-check dismissals; confirm queued patches landed |
+
+## Related
+
+- [Dependabot alerts (live)](https://github.com/GNS-Science/nshm-toshi-api/security/dependabot)
+- [PR #350 — yarn resolutions scoping (fast-xml-parser context)](https://github.com/GNS-Science/nshm-toshi-api/pull/350)
+- `docs/MIGRATION_RUNBOOK.md` § 4.7 — yarn `resolutions` traps (related operational guidance for sibling APIs)


### PR DESCRIPTION
## Summary

Establishes `docs/security/VULNERABILITY_REGISTER.md` capturing the policy + runtime-exposure model + active exceptions for security alerts. Pairs with a full triage of the 14 Dependabot alerts that were open as of today.

## Triage outcome

**14 open → 0 open.** Every dismissal carries a `dismissed_comment` audit trail visible in the Dependabot UI.

| Reason | Count | Packages |
|---|---|---|
| `not_used` | 3 | dicer, nltk, msgpack (dev-only transitives) |
| `tolerable_risk` | 11 | fast-xml-parser ×7, undici ×3, starlette ×1 |

All dismissals are reversible. Patched versions are queued for the next quarterly deps cycle for undici/starlette/msgpack; fast-xml-parser is gated on the next `@aws-sdk/*` minor bump.

## What the register is (and isn't)

- **Is:** policy + the runtime-exposure model (what's in Lambda vs dev-only) + cross-cutting context that GitHub's per-alert UI can't hold (e.g. "PR #350 explains why fast-xml-parser is pinned the way it is") + a quarterly review log.
- **Isn't:** a per-CVE log. Dependabot remains authoritative — duplicating it here would just drift.

## Why this matters for the migration runbook

The four sibling APIs (`kororaa`, `nshm-hazard`, `nshm-model`, `solvis`) ship with the same `yarn` resolutions / s3rver / AWS SDK stack and will trip the same fast-xml-parser-shaped alerts. The register's runtime-exposure model is a reusable template they can copy.

## Test plan

- [x] Reviewer cross-checks the runtime-exposure model against `pyproject.toml` direct deps
- [ ] Confirms dismissed alerts now show audit comments in the Dependabot UI
- [ ] Adds calendar reminder for 2026-09-26 quarterly review