### PR TITLE
Retain + de-reference runzi IAM resources for Terraform hand-off (deploy no. 1)

### DIFF
--- a/docs/adrs/ADR-003-cognito-permission-model.md
+++ b/docs/adrs/ADR-003-cognito-permission-model.md
@@ -166,6 +166,20 @@ is deliberate — see the reference doc's "Deferred / future" section)**
 - **A future split** of the compute-permission domain (Identity Pool +
   `runzi-*` roles + batch job role + compute resources) into a dedicated
   runzi-infra stack/repo.
+  - **Status: partially actioned.** The 3 `ToshiRunzi*ManagedPolicy` resources
+    and 3 `ToshiRunzi*Role` resources are migrating to `nzshm-runzi`'s
+    `terraform/access/` — see that repo's
+    [`docs/architecture/adr/0005-runzi-iam-tiers-terraform-migration.md`](https://github.com/GNS-Science/nzshm-runzi/blob/main/docs/architecture/adr/0005-runzi-iam-tiers-terraform-migration.md).
+    Unlike the split this ADR originally envisioned, the **Identity Pool and
+    its role attachment stay here** (and are slated for an eventual move to
+    a separate `nzshm-security` repo together, not split across two moves) —
+    they're shared identity/credential machinery, not runzi's own permission
+    surface. The role attachment's `RoleARN`/`Roles.authenticated` references
+    were changed from `!GetAtt` to `Fn::Sub` ARN strings so it no longer
+    depends on the departing role resources; see the comment above
+    `ToshiIdentityPoolRoleAttachment` in `serverless.yml`. Tracked via a
+    GitHub issue in this repo (the hand-off checklist: Retain → de-template
+    per stage, `test` then `prod`).
 
 **Verification**
 - `uv run pytest auth/tests/` passes (50), including new tests for the

--- a/serverless.yml
+++ b/serverless.yml
@@ -413,8 +413,15 @@ resources:
     # tier they need). If they are in several, the HIGHEST tier wins — see the
     # ToshiIdentityPoolRoleAttachment rules below, which are ordered
     # most-privileged-first (admin → batch → local) so the first match is correct.
+    # DeletionPolicy/UpdateReplacePolicy: Retain — being migrated to nzshm-runzi's
+    # terraform/access/ (see that repo's docs/architecture/adr/0005-...). Retain so removing
+    # this resource from this template (the final step of that migration) does not delete the
+    # live IAM resource out from under Terraform. Remove Retain only as part of that migration's
+    # de-template step, once Terraform has imported it.
     ToshiRunziBaseManagedPolicy:
       Type: AWS::IAM::ManagedPolicy
+      DeletionPolicy: Retain
+      UpdateReplacePolicy: Retain
       Properties:
         ManagedPolicyName: toshi-runzi-base-${self:custom.stage}
         Description: Base runzi permissions (ECR pull, S3 read/write, M2M secret read) shared by all runzi tiers
@@ -449,8 +456,11 @@ resources:
                 Fn::Sub: arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:toshi-m2m-*
 
     # batch increment — submit/manage AWS Batch jobs (layered on top of base).
+    # DeletionPolicy/UpdateReplacePolicy: Retain — see note on ToshiRunziBaseManagedPolicy above.
     ToshiRunziBatchManagedPolicy:
       Type: AWS::IAM::ManagedPolicy
+      DeletionPolicy: Retain
+      UpdateReplacePolicy: Retain
       Properties:
         ManagedPolicyName: toshi-runzi-batch-${self:custom.stage}
         Description: Incremental runzi-batch permissions (AWS Batch submit/describe); attached on top of the base policy
@@ -470,8 +480,11 @@ resources:
               Resource: '*'
 
     # admin increment — Batch/ECR administration (layered on top of base + batch).
+    # DeletionPolicy/UpdateReplacePolicy: Retain — see note on ToshiRunziBaseManagedPolicy above.
     ToshiRunziAdminManagedPolicy:
       Type: AWS::IAM::ManagedPolicy
+      DeletionPolicy: Retain
+      UpdateReplacePolicy: Retain
       Properties:
         ManagedPolicyName: toshi-runzi-admin-${self:custom.stage}
         Description: Incremental runzi-admin permissions (Batch + ECR administration); attached on top of the base + batch policies
@@ -501,8 +514,11 @@ resources:
 
     # ── IAM roles (assumed via Identity Pool after Cognito login) ──────────────
     # local tier — base permissions only (ECR pull, S3 read/write).
+    # DeletionPolicy/UpdateReplacePolicy: Retain — see note on ToshiRunziBaseManagedPolicy above.
     ToshiRunziLocalRole:
       Type: AWS::IAM::Role
+      DeletionPolicy: Retain
+      UpdateReplacePolicy: Retain
       Properties:
         RoleName: toshi-runzi-local-${self:custom.stage}
         Description: Runzi workstation access (ECR pull, S3 read/write)
@@ -523,8 +539,11 @@ resources:
           - !Ref ToshiRunziBaseManagedPolicy
 
     # batch tier — base + submit/manage AWS Batch jobs.
+    # DeletionPolicy/UpdateReplacePolicy: Retain — see note on ToshiRunziBaseManagedPolicy above.
     ToshiRunziBatchRole:
       Type: AWS::IAM::Role
+      DeletionPolicy: Retain
+      UpdateReplacePolicy: Retain
       Properties:
         RoleName: toshi-runzi-batch-${self:custom.stage}
         Description: Runzi batch job access (base + Batch submit)
@@ -546,8 +565,11 @@ resources:
           - !Ref ToshiRunziBatchManagedPolicy
 
     # admin tier — base + Batch submit + Batch/ECR administration.
+    # DeletionPolicy/UpdateReplacePolicy: Retain — see note on ToshiRunziBaseManagedPolicy above.
     ToshiRunziAdminRole:
       Type: AWS::IAM::Role
+      DeletionPolicy: Retain
+      UpdateReplacePolicy: Retain
       Properties:
         RoleName: toshi-runzi-admin-${self:custom.stage}
         Description: Runzi admin access (base + Batch submit + Batch/ECR admin)
@@ -570,12 +592,19 @@ resources:
           - !Ref ToshiRunziAdminManagedPolicy
 
     # ── Identity Pool role attachment (rules-based by Cognito group) ───────────
+    # Role references below are Fn::Sub ARN STRINGS, not !GetAtt, deliberately: the
+    # ToshiRunzi{Local,Batch,Admin}Role resources are being migrated to nzshm-runzi's
+    # terraform/access/ (see docs/architecture/adr/0005-... in that repo) and will be removed
+    # from this template once Terraform has imported them. Fn::Sub keeps this attachment
+    # working (the live ARN value is identical to what !GetAtt produced) without depending on
+    # resources that are leaving this stack. Do not revert to !GetAtt.
     ToshiIdentityPoolRoleAttachment:
       Type: AWS::Cognito::IdentityPoolRoleAttachment
       Properties:
         IdentityPoolId: !Ref ToshiIdentityPool
         Roles:
-          authenticated: !GetAtt ToshiRunziLocalRole.Arn
+          authenticated:
+            Fn::Sub: arn:aws:iam::${AWS::AccountId}:role/toshi-runzi-local-${self:custom.stage}
         RoleMappings:
           ToshiProvider:
             IdentityProvider:
@@ -595,15 +624,18 @@ resources:
                 - Claim: cognito:groups
                   MatchType: Contains
                   Value: runzi-admin
-                  RoleARN: !GetAtt ToshiRunziAdminRole.Arn
+                  RoleARN:
+                    Fn::Sub: arn:aws:iam::${AWS::AccountId}:role/toshi-runzi-admin-${self:custom.stage}
                 - Claim: cognito:groups
                   MatchType: Contains
                   Value: runzi-batch
-                  RoleARN: !GetAtt ToshiRunziBatchRole.Arn
+                  RoleARN:
+                    Fn::Sub: arn:aws:iam::${AWS::AccountId}:role/toshi-runzi-batch-${self:custom.stage}
                 - Claim: cognito:groups
                   MatchType: Contains
                   Value: runzi-local
-                  RoleARN: !GetAtt ToshiRunziLocalRole.Arn
+                  RoleARN:
+                    Fn::Sub: arn:aws:iam::${AWS::AccountId}:role/toshi-runzi-local-${self:custom.stage}
 
     # ── Secrets Manager: Cognito M2M client_id/client_secret container ─────────
     # Populated out-of-band by `auth/create_m2m_secret.py` after the Cognito


### PR DESCRIPTION
Prep step (**deploy no. 1**) for migrating runzi's 6 IAM access-tier resources (`ToshiRunzi{Base,Batch,Admin}ManagedPolicy` / `ToshiRunzi{Local,Batch,Admin}Role`) out of this repo and into `nzshm-runzi`'s `terraform/access/`. See #353 for the full per-stage hand-off checklist and `nzshm-runzi`'s [ADR-0005](https://github.com/GNS-Science/nzshm-runzi/blob/d8517ca66f59ad71eaf13412b4367bc77ea470e6/docs/architecture/adr/0005-runzi-iam-tiers-terraform-migration.md) for the decision record.

Closes #357 

## What this changes in `serverless.yml`

- Adds `DeletionPolicy: Retain` + `UpdateReplacePolicy: Retain` to the 6 `ToshiRunzi*` managed-policy/role resources, so the **later** removal of these resources from the template (deploy no. 2) won't delete the live IAM resources out from under Terraform.
- Re-points `ToshiIdentityPoolRoleAttachment` at the role ARNs via `Fn::Sub` instead of `!GetAtt` (value-identical), so the attachment — which **stays** in this repo — no longer depends on the 6 departing resources.

Both changes are **behaviour-preserving**: nothing about the live policies, roles, or the group→role mapping changes when this deploys. It only makes the resources safe to hand off.