### PR TITLE
Fix serverless resource typo

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -119,7 +119,7 @@ custom:
   serverlessIfElse:
       - If: '"${self:custom.stage}" == "test"'
         Exclude:
-          - resourcee.Resources.ElasticSearchInstance
+          - resources.Resources.ElasticSearchInstance
           - provider.iamrolestatements.1
 
 provider:


### PR DESCRIPTION
Fixes #364.

This updates the `serverlessIfElse` exclude path from `resourcee.Resources.ElasticSearchInstance` to `resources.Resources.ElasticSearchInstance`, matching the existing top-level `resources` section.

Validation:
- Confirmed the target line in `serverless.yml`.
- Confirmed `resourcee` no longer appears in `serverless.yml`.
- Ran `git diff --check`.