### PR TITLE
Fix serverless resource reference typo

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -119,7 +119,7 @@ custom:
   serverlessIfElse:
       - If: '"${self:custom.stage}" == "test"'
         Exclude:
-          - resourcee.Resources.ElasticSearchInstance
+          - resources.Resources.ElasticSearchInstance
           - provider.iamrolestatements.1
 
 provider:


### PR DESCRIPTION
﻿## Summary
- fix the `serverless.yml` reference from `resourcee.Resources.ElasticSearchInstance` to `resources.Resources.ElasticSearchInstance`

Closes #364.

## Validation
- `rg -n "resourcee" -S serverless.yml`
- `rg -n "resources\.Resources\.ElasticSearchInstance" -S serverless.yml`
- `git diff --check`

Generated with DevLoop-style issue diagnosis and manually reviewed before opening.
