### PR TITLE
fix(schema): restore `relations` on FileInterface for legacy parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+ - **`relations` restored on the `FileInterface` GraphQL interface.** The legacy Graphene schema declared `relations` on `FileInterface` itself; the Strawberry port declared it only on some concrete types. Clients spreading `... on FileInterface { relations { total_count } }` (e.g. toshi-ui's `InversionSolutionDiagnosticContainerQuery`) failed GraphQL *validation*, which nulls the whole document — every node came back null, not just `relations`. Same class of parity gap as the `OpenquakeHazardSolution` `config`/`modified_config` hotfix.
+ - **`RuptureSet` and `InversionSolutionNrml` now expose `relations` at all.** Both implemented the legacy `FileInterface` and their DynamoDB records carry the relation data, but the Strawberry types dropped it in `from_dict`. A `RuptureSet`'s link back to the `RuptureGenerationTask` that produced it was unreachable through the API.
+
+### Changed
+ - `InversionSolutionInterface.relations` now returns `FileRelationConnection` instead of the bespoke `InversionSolutionRelations` type (which is removed from the SDL). This restores the legacy Relay shape — `relations { edges { node { … } } }` previously failed on all four InversionSolution types. Any client written against the post-port shape must change `edges { role }` to `edges { node { role } }`.
+
 ## [0.7.1] - 2026-07-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.7.2] - 2026-07-29
 
 ### Fixed
  - **`relations` restored on the `FileInterface` GraphQL interface.** The legacy Graphene schema declared `relations` on `FileInterface` itself; the Strawberry port declared it only on some concrete types. Clients spreading `... on FileInterface { relations { total_count } }` (e.g. toshi-ui's `InversionSolutionDiagnosticContainerQuery`) failed GraphQL *validation*, which nulls the whole document — every node came back null, not just `relations`. Same class of parity gap as the `OpenquakeHazardSolution` `config`/`modified_config` hotfix.

--- a/graphql_api/models/_base/file.py
+++ b/graphql_api/models/_base/file.py
@@ -26,7 +26,6 @@ from graphql_api.models._infra.common import (
 from graphql_api.models._interfaces.file_interface import FileInterface
 from graphql_api.models._interfaces.predecessor import PredecessorInput
 from graphql_api.models._interfaces.predecessors_interface import PredecessorsInterface
-from graphql_api.models.relations import FileRelation, FileRelationsConnection, build_file_relations_for_file
 
 
 @strawberry.type(name="File")
@@ -35,12 +34,8 @@ class ToshiFile(relay.Node, FileInterface, PredecessorsInterface):
 
     pk: relay.NodeID[str]
 
-    relations_raw: strawberry.Private[list | None] = None
+    # `relations` (and its relations_raw backing field) is inherited from FileInterface.
     predecessors_raw: strawberry.Private[list | None] = None
-
-    @relay.connection(FileRelationsConnection)
-    def relations(self, info: Info) -> list[FileRelation | None]:
-        return build_file_relations_for_file(self.pk, self.relations_raw or [])
 
     @classmethod
     def resolve_node(

--- a/graphql_api/models/_interfaces/file_interface.py
+++ b/graphql_api/models/_interfaces/file_interface.py
@@ -3,10 +3,12 @@
 import json
 
 import strawberry
+from strawberry import relay
 from strawberry.types import Info
 
 from graphql_api.data.s3 import presigned_download_url
 from graphql_api.models._infra.common import BigInt, DateTime, JSONString, KeyValuePair
+from graphql_api.models.relations import FileRelation, FileRelationsConnection, build_file_relations_for_file
 
 
 @strawberry.interface
@@ -18,6 +20,21 @@ class FileInterface:
     file_size: BigInt | None = None
     created: DateTime | None = None
     meta: list[KeyValuePair | None] | None = None
+
+    # Embedded [{"id": thing_id, "role": ...}] array off the ToshiFileObject row.
+    # Decompressed upstream in data/dynamo.py, so always a plain list here.
+    relations_raw: strawberry.Private[list | None] = None
+
+    @relay.connection(FileRelationsConnection)
+    def relations(self, info: Info) -> list[FileRelation | None]:
+        """Things related to this data file.
+
+        Legacy parity: this field belongs on FileInterface (see the pre-ADR-004
+        Graphene `graphql_api/schema/file.py`), not on the concrete types. Clients
+        spread `... on FileInterface { relations { total_count } }`; declaring it
+        only on the concrete types fails validation and nulls the whole document.
+        """
+        return build_file_relations_for_file(self.pk, self.relations_raw or [])  # type: ignore[attr-defined]
 
     # Populated at create-time by mutate_create_<file_type> when S3 is configured.
     # Legacy semantics: presigned-POST is generated once and surfaced on the

--- a/graphql_api/models/_interfaces/inversion_solution_interface.py
+++ b/graphql_api/models/_interfaces/inversion_solution_interface.py
@@ -16,12 +16,13 @@ the Strawberry schema simple; concrete types implement both interfaces.
 from typing import Annotated
 
 import strawberry
+from strawberry import relay
 from strawberry.relay import GlobalID
 from strawberry.types import Info
 
 from graphql_api.data.dynamo import get_table, get_thing
 from graphql_api.models._infra.common import BigInt, DateTime, KeyValuePair, TableType
-from graphql_api.models.relations import InversionSolutionRelations, build_file_relations_for_file
+from graphql_api.models.relations import FileRelation, FileRelationsConnection, build_file_relations_for_file
 
 # ── Lazy forward refs ─────────────────────────────────────────────────────────
 # These types are defined in modules that import *this* module (circular),
@@ -83,13 +84,13 @@ class InversionSolutionInterface:
 
     tables: list[_LabelledTableRelation | None] | None = None
 
-    @strawberry.field
-    def relations(self, info: Info) -> InversionSolutionRelations | None:
-        pk = self.pk  # type: ignore[attr-defined]
-        relations_raw = self.relations_raw  # type: ignore[attr-defined]
-        if not relations_raw:
-            return InversionSolutionRelations()
-        return InversionSolutionRelations(edges=build_file_relations_for_file(pk, relations_raw))
+    # Must stay type-identical to FileInterface.relations: the concrete IS types
+    # implement both interfaces, and GraphQL allows only one `relations` field per
+    # type. FileRelationConnection is also the legacy shape (`edges { node }`);
+    # the bespoke InversionSolutionRelations this replaced was port drift.
+    @relay.connection(FileRelationsConnection)
+    def relations(self, info: Info) -> list[FileRelation | None]:
+        return build_file_relations_for_file(self.pk, self.relations_raw or [])  # type: ignore[attr-defined]
 
     @strawberry.field
     def produced_by(self, info: Info) -> AutomationTaskUnion | None:

--- a/graphql_api/models/_interfaces/inversion_solution_interface.py
+++ b/graphql_api/models/_interfaces/inversion_solution_interface.py
@@ -88,6 +88,15 @@ class InversionSolutionInterface:
     # implement both interfaces, and GraphQL allows only one `relations` field per
     # type. FileRelationConnection is also the legacy shape (`edges { node }`);
     # the bespoke InversionSolutionRelations this replaced was port drift.
+    #
+    # This body is currently unreachable. Every concrete IS type lists FileInterface
+    # ahead of InversionSolutionInterface in its bases, so the MRO binds
+    # FileInterface.relations (`InversionSolution.relations is FileInterface.relations`).
+    # The declaration is still required — without it the SDL interface would not carry
+    # the field and `... on InversionSolutionInterface { relations }` would fail
+    # validation. Kept as a working implementation rather than the `return None` stub
+    # used by file_url above, so it stays correct if a type ever implements this
+    # interface without FileInterface; edit it and FileInterface.relations together.
     @relay.connection(FileRelationsConnection)
     def relations(self, info: Info) -> list[FileRelation | None]:
         return build_file_relations_for_file(self.pk, self.relations_raw or [])  # type: ignore[attr-defined]

--- a/graphql_api/models/aggregate_inversion_solution.py
+++ b/graphql_api/models/aggregate_inversion_solution.py
@@ -36,13 +36,13 @@ class AggregateInversionSolution(relay.Node, FileInterface, InversionSolutionInt
     pk: relay.NodeID[str]
     metrics: list[KeyValuePair | None] | None = None
     aggregation_fn: AggregationFn | None = None
-    # tables, produced_by, mfd_table, mfd_table_id, hazard_table_id, relations
-    # are all inherited from InversionSolutionInterface.
+    # tables, produced_by, mfd_table, mfd_table_id, hazard_table_id are inherited
+    # from InversionSolutionInterface; `relations` (and its relations_raw backing
+    # field) from FileInterface.
 
     produced_by_raw_id: strawberry.Private[str | None] = None
     common_rupture_set_raw_id: strawberry.Private[str | None] = None
     source_solutions_raw_ids: strawberry.Private[list[str | None] | None] = None
-    relations_raw: strawberry.Private[list | None] = None
     predecessors_raw: strawberry.Private[list | None] = None
 
     @strawberry.field

--- a/graphql_api/models/inversion_solution.py
+++ b/graphql_api/models/inversion_solution.py
@@ -122,11 +122,11 @@ class InversionSolution(relay.Node, FileInterface, InversionSolutionInterface, P
 
     pk: relay.NodeID[str]
     metrics: list[KeyValuePair | None] | None = None
-    # tables, produced_by, mfd_table, mfd_table_id, hazard_table_id, relations
-    # are all inherited from InversionSolutionInterface.
+    # tables, produced_by, mfd_table, mfd_table_id, hazard_table_id are inherited
+    # from InversionSolutionInterface; `relations` (and its relations_raw backing
+    # field) from FileInterface.
 
     produced_by_raw_id: strawberry.Private[str | None] = None
-    relations_raw: strawberry.Private[list | None] = None
     predecessors_raw: strawberry.Private[list | None] = None
 
     @classmethod

--- a/graphql_api/models/inversion_solution_nrml.py
+++ b/graphql_api/models/inversion_solution_nrml.py
@@ -59,6 +59,7 @@ class InversionSolutionNrml(relay.Node, FileInterface, PredecessorsInterface):
             created=d.created,
             source_solution_raw_id=d.source_solution,
             predecessors_raw=[p.model_dump() for p in d.predecessors] if d.predecessors else None,
+            relations_raw=d.relations,
         )
 
 

--- a/graphql_api/models/relations.py
+++ b/graphql_api/models/relations.py
@@ -87,20 +87,6 @@ ChildTaskUnion = Annotated[
 ]
 
 
-# ── InversionSolutionRelations ────────────────────────────────────────────────
-
-
-@strawberry.type
-class InversionSolutionRelations:
-    """Return type for InversionSolutionInterface.relations; provides total_count."""
-
-    edges: list["FileRelation"] = strawberry.field(default_factory=list)
-
-    @strawberry.field
-    def total_count(self) -> int:
-        return len(self.edges)
-
-
 # ── FileRelation ──────────────────────────────────────────────────────────────
 
 

--- a/graphql_api/models/rupture_set.py
+++ b/graphql_api/models/rupture_set.py
@@ -71,6 +71,7 @@ class RuptureSet(relay.Node, FileInterface):
             fault_models=d.fault_models,
             metrics=[KeyValuePair(k=i.k, v=i.v) for i in d.metrics] if d.metrics else None,
             produced_by_raw_id=d.produced_by,
+            relations_raw=d.relations,
         )
 
 

--- a/graphql_api/models/scaled_inversion_solution.py
+++ b/graphql_api/models/scaled_inversion_solution.py
@@ -65,12 +65,12 @@ def dispatch_source_solution(data: dict):
 class ScaledInversionSolution(relay.Node, FileInterface, InversionSolutionInterface, PredecessorsInterface):
     pk: relay.NodeID[str]
     metrics: list[KeyValuePair | None] | None = None
-    # tables, produced_by, mfd_table, mfd_table_id, hazard_table_id, relations
-    # are all inherited from InversionSolutionInterface.
+    # tables, produced_by, mfd_table, mfd_table_id, hazard_table_id are inherited
+    # from InversionSolutionInterface; `relations` (and its relations_raw backing
+    # field) from FileInterface.
 
     produced_by_raw_id: strawberry.Private[str | None] = None
     source_solution_raw_id: strawberry.Private[str | None] = None
-    relations_raw: strawberry.Private[list | None] = None
     predecessors_raw: strawberry.Private[list | None] = None
 
     @strawberry.field

--- a/graphql_api/models/sms_file.py
+++ b/graphql_api/models/sms_file.py
@@ -20,7 +20,6 @@ from graphql_api.models._infra.common import (
     client_mutation_id_input_field,
 )
 from graphql_api.models._interfaces.file_interface import FileInterface
-from graphql_api.models.relations import FileRelation, FileRelationsConnection, build_file_relations_for_file
 
 
 @strawberry.type
@@ -30,11 +29,7 @@ class SmsFile(relay.Node, FileInterface):
     pk: relay.NodeID[str]
     file_type: SmsFileType | None = None
 
-    relations_raw: strawberry.Private[list | None] = None
-
-    @relay.connection(FileRelationsConnection)
-    def relations(self, info: Info) -> list[FileRelation | None]:
-        return build_file_relations_for_file(self.pk, self.relations_raw or [])
+    # `relations` (and its relations_raw backing field) is inherited from FileInterface.
 
     @classmethod
     def resolve_node(cls, node_id: str, *, info: Info, **kwargs) -> Optional["SmsFile"]:

--- a/graphql_api/models/time_dependent_inversion_solution.py
+++ b/graphql_api/models/time_dependent_inversion_solution.py
@@ -31,12 +31,12 @@ _InversionSolution = Annotated["InversionSolution", strawberry.lazy("graphql_api
 class TimeDependentInversionSolution(relay.Node, FileInterface, InversionSolutionInterface, PredecessorsInterface):
     pk: relay.NodeID[str]
     metrics: list[KeyValuePair | None] | None = None
-    # tables, produced_by, mfd_table, mfd_table_id, hazard_table_id, relations
-    # are all inherited from InversionSolutionInterface.
+    # tables, produced_by, mfd_table, mfd_table_id, hazard_table_id are inherited
+    # from InversionSolutionInterface; `relations` (and its relations_raw backing
+    # field) from FileInterface.
 
     produced_by_raw_id: strawberry.Private[str | None] = None
     source_solution_raw_id: strawberry.Private[str | None] = None
-    relations_raw: strawberry.Private[list | None] = None
     predecessors_raw: strawberry.Private[list | None] = None
 
     @strawberry.field

--- a/graphql_api/tests/test_file_interface_relations.py
+++ b/graphql_api/tests/test_file_interface_relations.py
@@ -1,0 +1,288 @@
+"""Regression: `relations` must be queryable via a `... on FileInterface` fragment.
+
+The legacy Graphene schema declared `relations` on FileInterface itself
+(pre-ADR-004 `graphql_api/schema/file.py`); the Strawberry port declared it only
+on some concrete types. A client selecting
+
+    ... on FileInterface { relations { total_count } }
+
+therefore failed GraphQL *validation*, which nulls the entire document — every
+sibling node came back null, not just `relations`.
+
+Two silent halves of the same bug are covered here too:
+  - RuptureSet and InversionSolutionNrml had no `relations` field at all, even
+    though their DynamoDB records carry the data.
+  - The four InversionSolution types returned a bespoke non-Relay type, so the
+    legacy `relations { edges { node { ... } } }` shape failed on them.
+"""
+
+import pytest
+
+from graphql_api.schema import schema
+
+# ── Mutations ─────────────────────────────────────────────────────────────────
+
+CREATE_TASK = """
+mutation ($input: CreateAutomationTaskInput!) {
+    create_rupture_generation_task(input: $input) { task_result { id } }
+}
+"""
+
+CREATE_FILE = """
+mutation ($file_name: String!, $md5_digest: String!, $file_size: BigInt!) {
+    create_file(file_name: $file_name, md5_digest: $md5_digest, file_size: $file_size) {
+        file_result { id }
+    }
+}
+"""
+
+CREATE_SMS_FILE = """
+mutation ($input: CreateSmsFileInput!) {
+    create_sms_file(input: $input) { file_result { id } }
+}
+"""
+
+CREATE_RUPTURE_SET = """
+mutation ($input: CreateRuptureSetInput!) {
+    create_rupture_set(input: $input) { rupture_set { id } }
+}
+"""
+
+CREATE_INVERSION_SOLUTION = """
+mutation ($input: CreateInversionSolutionInput!) {
+    create_inversion_solution(input: $input) { inversion_solution { id } }
+}
+"""
+
+CREATE_SCALED = """
+mutation ($input: CreateScaledInversionSolutionInput!) {
+    create_scaled_inversion_solution(input: $input) { solution { id } }
+}
+"""
+
+CREATE_AGGREGATE = """
+mutation ($input: CreateAggregateInversionSolutionInput!) {
+    create_aggregate_inversion_solution(input: $input) { solution { id } }
+}
+"""
+
+CREATE_TIME_DEPENDENT = """
+mutation ($input: CreateTimeDependentInversionSolutionInput!) {
+    create_time_dependent_inversion_solution(input: $input) { solution { id } }
+}
+"""
+
+CREATE_NRML = """
+mutation ($input: CreateInversionSolutionNrmlInput!) {
+    create_inversion_solution_nrml(input: $input) { inversion_solution_nrml { id } }
+}
+"""
+
+CREATE_FILE_RELATION = """
+mutation ($file_id: ID!, $role: FileRole!, $thing_id: ID!) {
+    create_file_relation(file_id: $file_id, role: $role, thing_id: $thing_id) { ok }
+}
+"""
+
+# ── Queries ───────────────────────────────────────────────────────────────────
+
+# The exact shape that was failing in the field.
+FILE_INTERFACE_FRAGMENT_QUERY = """
+query ($id: ID!) {
+    node(id: $id) {
+        __typename
+        ... on FileInterface {
+            file_name
+            relations { total_count }
+        }
+    }
+}
+"""
+
+# Legacy Relay edge shape — broken on the InversionSolution family pre-fix.
+RELATIONS_EDGES_QUERY = """
+query ($id: ID!) {
+    node(id: $id) {
+        ... on FileInterface {
+            relations {
+                total_count
+                edges { node { role thing_id } }
+            }
+        }
+    }
+}
+"""
+
+RUPTURE_SET_ROUNDTRIP_QUERY = """
+query ($id: ID!) {
+    node(id: $id) {
+        ... on RuptureSet {
+            relations {
+                total_count
+                edges {
+                    node {
+                        role
+                        thing { ... on RuptureGenerationTask { id } }
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+
+def _run(query, gql_context, **variables):
+    result = schema.execute_sync(query, variable_values=variables, context_value=gql_context)
+    assert result.errors is None, result.errors
+    return result.data
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def task_id(gql_context):
+    """A RuptureGenerationTask to hang every file relation off."""
+    data = _run(
+        CREATE_TASK,
+        gql_context,
+        input={
+            "state": "UNDEFINED",
+            "result": "UNDEFINED",
+            "task_type": "RUPTURE_SET",
+            "created": "2026-07-29T00:00:00Z",
+        },
+    )
+    return data["create_rupture_generation_task"]["task_result"]["id"]
+
+
+@pytest.fixture(scope="module")
+def file_ids(gql_context, task_id):
+    """Create one of every FileInterface implementor, each linked to `task_id`.
+
+    Returns {SDL type name: global id}. Creation order matters: the scaled,
+    aggregate and time-dependent solutions reference earlier ones.
+    """
+    ids: dict[str, str] = {}
+
+    ids["File"] = _run(CREATE_FILE, gql_context, file_name="plain.zip", md5_digest="aaa==", file_size=100)[
+        "create_file"
+    ]["file_result"]["id"]
+
+    ids["SmsFile"] = _run(CREATE_SMS_FILE, gql_context, input={"file_name": "sms.csv", "file_type": "CPT"})[
+        "create_sms_file"
+    ]["file_result"]["id"]
+
+    ids["RuptureSet"] = _run(
+        CREATE_RUPTURE_SET,
+        gql_context,
+        input={
+            "file_name": "rupture_set.zip",
+            "md5_digest": "bbb==",
+            "file_size": 200,
+            "produced_by": task_id,
+        },
+    )["create_rupture_set"]["rupture_set"]["id"]
+
+    ids["InversionSolution"] = _run(CREATE_INVERSION_SOLUTION, gql_context, input={"file_name": "solution.zip"})[
+        "create_inversion_solution"
+    ]["inversion_solution"]["id"]
+
+    ids["ScaledInversionSolution"] = _run(
+        CREATE_SCALED,
+        gql_context,
+        input={"file_name": "scaled.zip", "source_solution": ids["InversionSolution"]},
+    )["create_scaled_inversion_solution"]["solution"]["id"]
+
+    ids["AggregateInversionSolution"] = _run(
+        CREATE_AGGREGATE,
+        gql_context,
+        input={
+            "file_name": "aggregate.zip",
+            "common_rupture_set": ids["RuptureSet"],
+            "source_solutions": [ids["InversionSolution"]],
+            "aggregation_fn": "MEAN",
+        },
+    )["create_aggregate_inversion_solution"]["solution"]["id"]
+
+    ids["TimeDependentInversionSolution"] = _run(
+        CREATE_TIME_DEPENDENT,
+        gql_context,
+        input={"file_name": "time_dep.zip", "source_solution": ids["InversionSolution"]},
+    )["create_time_dependent_inversion_solution"]["solution"]["id"]
+
+    ids["InversionSolutionNrml"] = _run(CREATE_NRML, gql_context, input={"file_name": "solution.xml"})[
+        "create_inversion_solution_nrml"
+    ]["inversion_solution_nrml"]["id"]
+
+    for file_id in ids.values():
+        _run(CREATE_FILE_RELATION, gql_context, file_id=file_id, role="WRITE", thing_id=task_id)
+
+    return ids
+
+
+ALL_FILE_TYPES = [
+    "File",
+    "SmsFile",
+    "RuptureSet",
+    "InversionSolution",
+    "ScaledInversionSolution",
+    "AggregateInversionSolution",
+    "TimeDependentInversionSolution",
+    "InversionSolutionNrml",
+]
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("type_name", ALL_FILE_TYPES)
+def test_relations_via_file_interface_fragment(gql_context, file_ids, type_name):
+    """`... on FileInterface { relations { total_count } }` resolves on every file type.
+
+    Pre-fix this raised "Cannot query field 'relations' on type 'FileInterface'",
+    which failed validation and nulled the whole `node` payload.
+    """
+    data = _run(FILE_INTERFACE_FRAGMENT_QUERY, gql_context, id=file_ids[type_name])
+
+    node = data["node"]
+    assert node is not None, f"{type_name}: node came back null"
+    assert node["__typename"] == type_name
+    # Non-zero: an empty list would pass even if relations_raw were never wired up.
+    assert node["relations"]["total_count"] == 1
+
+
+@pytest.mark.parametrize("type_name", ALL_FILE_TYPES)
+def test_relations_uses_legacy_relay_edge_shape(gql_context, file_ids, type_name):
+    """`relations { edges { node { ... } } }` is the legacy FileRelationConnection shape.
+
+    The InversionSolution family previously returned a bespoke type whose `edges`
+    were bare FileRelation objects with no `node` wrapper, so this selection failed.
+    """
+    data = _run(RELATIONS_EDGES_QUERY, gql_context, id=file_ids[type_name])
+
+    relations = data["node"]["relations"]
+    assert relations["total_count"] == 1
+    assert len(relations["edges"]) == 1
+    assert relations["edges"][0]["node"]["role"] == "WRITE"
+
+
+def test_rupture_set_relations_resolve_back_to_task(gql_context, file_ids, task_id):
+    """A RuptureSet can report the task it is linked to.
+
+    RuptureSet had no `relations` field at all before this fix, so this link was
+    unreachable through the API despite being present in DynamoDB.
+    """
+    data = _run(RUPTURE_SET_ROUNDTRIP_QUERY, gql_context, id=file_ids["RuptureSet"])
+
+    edges = data["node"]["relations"]["edges"]
+    assert len(edges) == 1
+    assert edges[0]["node"]["thing"]["id"] == task_id
+
+
+def test_file_interface_declares_relations_in_sdl():
+    """Lock the field onto the interface itself, not just the concrete types."""
+    sdl = schema.as_str()
+    interface_block = sdl.split("interface FileInterface {")[1].split("\n}")[0]
+    assert "): FileRelationConnection!" in interface_block


### PR DESCRIPTION
## Problem

Clients spreading `relations` inside a `... on FileInterface` fragment (toshi-ui's `InversionSolutionDiagnosticContainerQuery`) get:

```
Cannot query field 'relations' on type 'FileInterface'.
Did you mean to use an inline fragment on 'InversionSolutionInterface',
'AggregateInversionSolution', 'File', 'InversionSolution', or 'ScaledInversionSolution'?
```

This fails GraphQL **validation**, so the entire document nulls out — every `nodes` entry comes back null, not just `relations`. The client-side workaround (dropping the selection) works, but the defect is ours.

## Root cause

The legacy Graphene `FileInterface` declared it (`git show 6e9b8d9^:graphql_api/schema/file.py`):

```python
class FileInterface(graphene.Interface):
    relations = relay.ConnectionField(
        'graphql_api.schema.thing.FileRelationConnection',
        description="things related to this data file")
```

and the legacy `InversionSolutionInterface` declared **no** `relations` — IS types got it purely by also implementing `FileInterface`. The Strawberry port inverted that arrangement.

It wasn't a deliberate refactor: `git log -S"relations" -- graphql_api/models/_interfaces/file_interface.py` returns nothing. `relations` was never ported onto the Strawberry interface; the POC hand-wrote per-type resolvers instead, and the Graphene original was deleted wholesale in `6e9b8d9`.

Same class of parity gap as bcbe85e (`OpenquakeHazardSolution` `config`/`modified_config`), fixed the same way — at the API.

### State before this PR

| Type | `relations`? | SDL return type |
|---|---|---|
| `FileInterface` | **no** | — ← the reported break |
| `File`, `SmsFile` | yes | `FileRelationConnection` ✅ |
| `InversionSolution` / `Scaled` / `Aggregate` / `TimeDependent` | yes, via `InversionSolutionInterface` | `InversionSolutionRelations` ❌ bespoke, non-Relay |
| `RuptureSet`, `InversionSolutionNrml` | **no** | — ❌ silent regression |

The last row is the part nobody reported. Both implemented the legacy `FileInterface`, and `create_file_relation` writes `relations` onto every file record with no type discrimination — so the data is sitting in DynamoDB, just unreachable. A `RuptureSet`'s link back to the `RuptureGenerationTask` that produced it has been invisible through the API since the port.

## Changes

- **`_interfaces/file_interface.py`** — adds `relations_raw` (Private) + `@relay.connection(FileRelationsConnection) relations`, mirroring the proven `Thing` interface pattern at `_base/thing.py:66`.
- **`_interfaces/inversion_solution_interface.py`** — `relations` retyped `InversionSolutionRelations` → `FileRelationConnection`. **Forced, not optional**: the IS types implement both interfaces, and GraphQL allows one `relations` field per type, so the two declarations must agree. Also restores the legacy Relay shape — `relations { edges { node { … } } }` previously failed on all four IS types.
- **`relations.py`** — removes `InversionSolutionRelations` (port drift, never a legacy type).
- **`rupture_set.py`, `inversion_solution_nrml.py`** — `relations_raw=d.relations` in `from_dict`.
- **`_base/file.py`, `sms_file.py`** — drop the now-redundant per-type resolvers.

## ⚠️ Wire change

`... on InversionSolutionInterface { relations { edges { role } } }` becomes `edges { node { role } }`.

This *restores* the legacy shape, so only a client written against the post-port drift is affected. Worth a heads-up to whoever owns weka.

## Verification

- **`394 passed, 1 skipped`** on the full suite. `test_smoketest_ab.py` (`edges { node }` on File/SmsFile) and `test_inversion_solution_interface.py` (`relations { total_count }` via the IS interface) both stayed green.
- **The new test is a real guard, not a no-op** — stashing the source changes fails all 18 cases; restoring them passes all 18.
- SDL dump confirms `relations(...): FileRelationConnection!` on `FileInterface`, present on all eight file types and both interfaces, and `InversionSolutionRelations` gone.
- `ruff check` + `ruff format --check` clean.

## Follow-up (not in this PR)

The reason this shipped undetected: there's no committed legacy SDL baseline, so `tools/schema_parity.py` has nothing to diff against and isn't wired into CI. The runzi corpus never selects `relations`, and every `... on FileInterface` spread in the suite picked only `file_name`/`file_size`/`meta`/`file_url`. Worth an issue if you want that class of drift caught structurally.

https://claude.ai/code/session_01GVCuYyZFPrCejzD7BLXkyw
